### PR TITLE
Joking index

### DIFF
--- a/project-addons/product_stock_unsafety/product.py
+++ b/project-addons/product_stock_unsafety/product.py
@@ -80,8 +80,8 @@ class product_product(models.Model):
         avg = joking_tot / len(filter_ids)
         for product in product_obj.search([]):
             if product.type != 'product' or product.id not in filter_ids:
-                if product.joking_index != 0:
-                    product.joking_index = 0
+                if product.joking_index != -1:
+                    product.joking_index = -1
             else:
                 joking_index = (product.joking - avg) / avg
                 if product.joking_index != joking_index:


### PR DESCRIPTION
Van a cambiar el filtro en la web para las ofertas en productos, ahora el joking_index a partir del cual van a mostrar los productos en oferta va a ser 0 o más. Por eso hemos cambiado el valor por defecto a -1. No creo que haya mayor problema con esto a excepción de que los productos que tengan -1 pueden estar así porque tienen el valor por defecto o porque el calculo da -1 y no se sepa cual de las dos opciones es. 

Si crees que lo podemos hacer de otra forma para que la web pueda tener en cuenta estos productos para no mostrarlos sin tener que cambiar la lógica nuestra o suya demasiado, dímelo y lo hablamos.