### PR TITLE
Contactos Flask

### DIFF
--- a/project-addons/flask_middleware_connector/models/middleware.py
+++ b/project-addons/flask_middleware_connector/models/middleware.py
@@ -145,14 +145,16 @@ class MiddlewareBackend(models.Model):
             #~ users = self.env['res.users'].search([('web', '=', True)])
             #~ for user in users:
                 #~ export_commercial(session, 'res.users', user.id)
-            partners = self.env["res.partner"].search([('web', '=', True)])
-            #partner = self.env["res.partner"].browse(196823)
-            #for partner in partners:
-            #    export_partner(session, "res.partner", partner.id)
-            contacts = self.env["res.partner"].search([('active', '=', True), ('prospective','=', False),
-                                                       ('customer', '=', True), ('parent_id', 'in', partners.ids)])
-            for contact in contacts:
-                export_partner(session, "res.partner", contact.id)
+            partner_obj = self.env['res.partner']
+            partner_ids = partner_obj.search([('is_company', '=', True),
+                                              ('web', '=', True),
+                                              ('customer', '=', True)])
+            for partner in partner_ids:
+                contact_ids = partner_obj.search([('parent_id', '=', partner.id),
+                                                  ('active', '=', True),
+                                                  ('customer', '=', True)])
+                for contact in contact_ids:
+                    export_partner(session, "res.partner", contact.id)
             #~ substates = self.env['substate.substate'].search([])
             #~ for substate in substates:
                 #~ export_rma_status(session, 'substate.substate', substate.id)


### PR DESCRIPTION
He incluido la exportación de los contactos a Flask ya que hay ciertos contactos de clientes que faltan.

- [IMP] 'flask_middleware_connector': Exportación de contactos de clientes web a Flask en el botón del middleware de "Exportar Datos Actuales". Reviso que el cliente tenga campo web y sea una company y saco todos sus contactos y los exporto. Si la exportación falla no pasa nada, con que nos exporte los clientes que no están dentro de Flask es suficiente.