### PR TITLE
Cambios realizados

### DIFF
--- a/project-addons/sale_custom/__openerp__.py
+++ b/project-addons/sale_custom/__openerp__.py
@@ -15,7 +15,8 @@
         "base",
         "sale",
         "sale_display_stock",
-        "sale_margin_percentage"
+        "sale_margin_percentage",
+        "stock_reserve_sale"
     ],
     "data": [
         'views/sale_view.xml'

--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -27,3 +27,9 @@ msgstr "Error"
 msgid "Product quantity cannot be negative or zero"
 msgstr "La cantidad de un producto no puede ser negativo o cero"
 
+#. module: sale_custom
+#: view:sale.order:sale_custom.view_order_form_sales_partner
+msgid "Partner Orders"
+msgstr "Pedidos Cliente"
+
+

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -45,7 +45,7 @@ class SaleOrder(models.Model):
         partner_id = self.partner_id.commercial_partner_id.id
         order_view_id = self.env.ref('sale.act_res_partner_2_sale_order').id
         last_order = self.env['sale.order'].search([('id', '!=', self.id),
-                                                    ('partner_id', '=', partner_id),
+                                                    ('partner_id', 'child_of', [partner_id]),
                                                     ('state', 'not in', ['cancel', 'draft', 'sent'])],
                                                    limit=1, order='date_order DESC').id
         base_url = self.env['ir.config_parameter'].get_param('web.base.url')

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -34,3 +34,29 @@ class SaleOrderLine(models.Model):
             date_order=date_order, packaging=packaging,
             fiscal_position=fiscal_position, flag=flag)
 
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    @api.multi
+    def open_historical_orders(self):
+        self.ensure_one()
+        partner_id = self.partner_id.commercial_partner_id.id
+        order_view_id = self.env.ref('sale.act_res_partner_2_sale_order').id
+        last_order = self.env['sale.order'].search([('id', '!=', self.id),
+                                                    ('partner_id', '=', partner_id),
+                                                    ('state', 'not in', ['cancel', 'draft', 'sent'])],
+                                                   limit=1, order='date_order DESC').id
+        base_url = self.env['ir.config_parameter'].get_param('web.base.url')
+        record_url = base_url + '/web/?#id=' + str(last_order) + '&view_type=form&model=sale.order&action=' + \
+                                str(order_view_id) + '&active_id=' + str(partner_id)
+        return {
+            'name': 'Historical Partner Orders',
+            'type': 'ir.actions.act_url',
+            'view_type': 'form',
+            'url': record_url,
+            'target': 'new'
+        }
+
+

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -21,5 +21,28 @@
             </field>
         </record>
 
+         <record id="action_view_historical_orders" model="ir.actions.server">
+            <field name="name">Historical Partner Orders View</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="model_sale_order"/>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree</field>
+            <field name="code">
+                action = self.open_historical_orders(cr, uid, context.get('active_ids', []), context=context)
+            </field>
+        </record>
+
+        <record id="view_order_form_sales_partner" model="ir.ui.view">
+            <field name="name">partner.sale.order.history</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="stock_reserve_sale.view_order_form_reserve"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='open_stock_reservation']" position="after">
+                    <button name="%(action_view_historical_orders)d" string="Partner Orders" class="oe_stat_button"
+                        type="action" icon="fa-strikethrough" attrs="{'invisible': ['|', ('partner_id', '=', False), ('state', 'not in', ['draft', 'reserve'])]}"/>
+                </xpath>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
- [IMP] 'sale_custom': Botón en formulario de pedido para abrir histórico de pedidos del cliente en otra pestaña