### PR TITLE
Cambios en funcion calculo de margen

### DIFF
--- a/project-addons/purchase_proposal/product.py
+++ b/project-addons/purchase_proposal/product.py
@@ -117,7 +117,7 @@ class ProductProduct(models.Model):
             product_ids = ids
         for product_id in self.browse(product_ids):
             sale_order_line_obj = self.env['sale.order.line']
-            domain = [('product_id', '=', product_id.id)]
+            domain = [('product_id', '=', product_id.id), ('state', 'not in', ('draft', 'cancel', 'exception'))]
             sales_obj = sale_order_line_obj.search(domain, limit=100,
                                                    order='date_order desc')
             margin_perc_sum = 0


### PR DESCRIPTION
Acabamos de darnos cuenta de un error en el calculo del margen de las ultimas ventas de los productos. En el dominio en el que buscaba las lineas de productos de los pedidos, no se filtraba por el estado del pedido y sacaba información de pedidos cancelados, en estado borrador y en estado excepcion. Se ha corregido eso.