### PR TITLE
Cambios realizados

### DIFF
--- a/project-addons/crm_claim_rma_custom/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/crm_claim.py
@@ -54,7 +54,8 @@ class CrmClaimRma(models.Model):
     name = fields.Selection([('return', 'Return'),
                              ('rma', 'RMA')], 'Claim Subject',
                             required=True, default='rma')
-    priority = fields.Selection(default=0, selection=[('1', 'High'),
+    priority = fields.Selection(default=0, selection=[('-1', 'No priority'),
+                                                      ('1', 'High'),
                                                       ('2', 'Critical')])
     comercial = fields.Many2one("res.users", string="Comercial")
     country = fields.Many2one("res.country", string="Country", related='partner_id.country_id')
@@ -91,6 +92,8 @@ class CrmClaimRma(models.Model):
                 if line_state.name in self.check_states:
                     raise except_orm(_('Warning!'),
                                      _("One or more products aren't review yet!"))
+        if 'priority' in vals and vals['priority'] is False:
+            vals['priority'] = '-1'
 
         return super(CrmClaimRma, self).write(vals)
 

--- a/project-addons/crm_claim_rma_custom/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/crm_claim_view.xml
@@ -32,13 +32,37 @@
                     <attribute name="operator">child_of</attribute>
                     <attribute name="filter_domain"/>
                 </field>
+                <field name="user_id" position="after">
+                    <field name="stage_id"/>
+                </field>
                 <filter string="Closure" position="after">
                     <filter string="Comercial" domain="[]" context="{'group_by':'comercial'}"/>
+                    <filter string="Recibidos" name="received" domain="[('stage_id', '=', 'Recibido'), ('date_received', '!=', None)]"/>
                 </filter>
             </field>
         </record>
 
-
+        <record model="ir.ui.view" id="crm_case_claims_tree_view_received">
+            <field name="name">CRM - Claims Tree</field>
+            <field name="model">crm.claim</field>
+            <field name="arch" type="xml">
+                <tree default_order="priority desc, date_received asc">
+                    <field name="number"/>
+                    <field name="name"/>
+                    <field name="partner_id"/>
+                    <field name="country"/>
+                    <field name="comercial"/>
+                    <field name="user_id"/>
+                    <field name="date"/>
+                    <field name="date_received"/>
+                    <field name="stage_id"/>
+                    <field name="rma_cost"/>
+                    <field name="priority"/>
+                    <field name="bool_category_id"/>
+                    <field name="date_deadline"/>
+                </tree>
+            </field>
+        </record>
 
         <record model="ir.ui.view" id="crm_claim_rma_form_view3">
             <field name="name">CRM - Claim product return Form</field>
@@ -235,6 +259,25 @@
                 </p>
             </field>
         </record>
+
+        <record model="ir.actions.act_window" id="crm_case_categ_claim_sort">
+            <field name="name">Received Claims</field>
+            <field name="res_model">crm.claim</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,calendar,form</field>
+            <field name="view_id" ref="crm_case_claims_tree_view_received"/>
+            <field name="domain">[('claim_type', '=', 'customer')]</field>
+            <field name="context">{"stage_type":'claim', "claim_type": 'customer', 'search_default_received': 1}</field>
+            <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
+            <field name="help" type="html">
+                <p class="oe_view_nocontent_create">
+                    Record and track your customers' claims. Claims may be linked to a sales order or a lot.You can send emails with attachments and keep the full history for a claim (emails sent, intervention type and so on).Claims may automatically be linked to an email address using the mail gateway module.
+                </p>
+            </field>
+        </record>
+
+        <menuitem name="Received Claims" id="menu_crm_case_claims"
+            parent="base.menu_aftersale" action="crm_case_categ_claim_sort" sequence="1"/>
 
         <!--<record model="ir.actions.act_window" id="crm_claim.crm_case_categ_claim0">
             <field name="domain">[('claim_type', '=', 'customer')]</field>

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -16,6 +16,21 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:0
+msgid "Received Claims"
+msgstr "RMAs Recividos"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.menu,name:0
+msgid "Received Claims"
+msgstr "RMAs Recividos"
+
+#. module: crm_claim_rma_custom
+#: field:crm.claim,bool_category_id:0
+msgid "Category"
+msgstr "Certificado"
+
+#. module: crm_claim_rma_custom
 #: field:crm.phonecall,start_date:0
 msgid "Start Date"
 msgstr "Fecha de Inicio"

--- a/project-addons/external_salesperson_visit/__openerp__.py
+++ b/project-addons/external_salesperson_visit/__openerp__.py
@@ -28,7 +28,7 @@
     """,
     'author': 'Nadia Ferreyra',
     'website': '',
-    "depends": ['base', 'email_template'],
+    "depends": ['base', 'email_template', 'custom_partner'],
     "data": ['partner_visit_view.xml',
              'email_template.xml',
              'security/ir.model.access.csv',

--- a/project-addons/external_salesperson_visit/i18n/es.po
+++ b/project-addons/external_salesperson_visit/i18n/es.po
@@ -16,6 +16,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: external_salesperson_visit
+#: field:partner.visit,partner_pricelist:0
+msgid "Sale Pricelist"
+msgstr "Tarifa de venta"
+
+#. module: external_salesperson_visit
+#: field:partner.visit,partner_annual_invoiced:0
+msgid "Annual invoiced"
+msgstr "Facturación anual"
+
+#. module: external_salesperson_visit
+#: field:partner.visit,partner_monthly_invoiced:0
+msgid "Monthly invoiced"
+msgstr "Facturación mensual"
+
+#. module: external_salesperson_visit
+#: field:partner.visit,partner_past_year_invoiced:0
+msgid "Past year invoiced"
+msgstr "Facturación año anterior"
+
+#. module: external_salesperson_visit
+#: field:partner.visit,partner_past_month_invoiced:0
+msgid "Past Month invoiced"
+msgstr "Facturación mes anterior"
+
+#. module: external_salesperson_visit
 #: model:ir.ui.menu,name:external_salesperson_visit.menu_partner_case_visit
 msgid "Visits"
 msgstr "Visitas"

--- a/project-addons/external_salesperson_visit/partner_visit.py
+++ b/project-addons/external_salesperson_visit/partner_visit.py
@@ -45,6 +45,12 @@ class partner_visit(models.Model):
                                          compute='get_internal_salesperson', store=True)
     add_user_email = fields.Many2one('res.users', 'CC to')
     confirm_done = fields.Boolean('Done', default=False)
+    partner_pricelist = fields.Many2one(related='partner_id.property_product_pricelist')
+    partner_annual_invoiced = fields.Float(related='partner_id.annual_invoiced')
+    partner_past_year_invoiced = fields.Float(related='partner_id.past_year_invoiced')
+    partner_monthly_invoiced = fields.Float(related='partner_id.monthly_invoiced')
+    partner_past_month_invoiced = fields.Float(related='partner_id.past_month_invoiced')
+
 
     @api.one
     @api.constrains('confirm_done')

--- a/project-addons/external_salesperson_visit/partner_visit_view.xml
+++ b/project-addons/external_salesperson_visit/partner_visit_view.xml
@@ -16,6 +16,11 @@
                     <field name="create_date" invisible="1"/>
                     <field name="partner_ref"/>
                     <field name="partner_id"/>
+                    <field name="partner_pricelist"/>
+                    <field name="partner_annual_invoiced"/>
+                    <field name="partner_monthly_invoiced"/>
+                    <field name="partner_past_year_invoiced"/>
+                    <field name="partner_past_month_invoiced"/>
                     <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'base.group_sale_salesman_all_leads']}"/>
                     <field name="description"/>
                     <field name="salesperson_select"/>


### PR DESCRIPTION
- [IMP] 'external_salesperson_visit': Incluidos campos de facturación de cliente en la vista de arbol de visitas. Los campos son related
- [IMP] 'external_salesperson_visit': Incluida la dependencia del modulo custom_partner necesaria para los campos related.
- [IMP] 'custom_partner': Creado método _unblock_invoices que se utilizara para crear un cron que desmarque el campo sin seguimiento de las facturas de clientes que tengan como plazo de pago "Pago inmediato" o "Prepago" y que hayan vencido hace mas de siete dias
- [IMP] 'crm_claim_rma_custom': Se ha incluido una nueva entrada en el menú de SAT para mostrar los RMAs recibidos, ordenados por prioridad y fecha. Se ha tenido que incluir una prioridad 'No priority', que se pone por defecto al dejar el campo vacío, para que la ordenación por prioridad sea efectiva. La vista de árbol es nueva para evitar que se solape con la vista de "Reclamaciones de clientes".