### PR TITLE
Hotfix

### DIFF
--- a/project-addons/product_stock_unsafety/product.py
+++ b/project-addons/product_stock_unsafety/product.py
@@ -91,8 +91,11 @@ class product_product(models.Model):
                     max_joking = joking_index
                 if product.joking_index != joking_index:
                     product.joking_index = joking_index
-        for product in product_obj.browse(product_ids):
-            if product.joking_index == -1:
+        for product in product_obj.browse(filter_ids):
+            if product.joking_index == -1 \
+                    and product.last_sixty_days_sales == 0\
+                    and product.type == 'product'\
+                    and product.categ_id.parent_id.name != 'Outlet':
                 product.joking_index = max_joking
 
     @api.one


### PR DESCRIPTION
[FIX] 'product_stock_unsafety': Realizados ajustes en el calculo del joking index en cuanto al calculo del mismo en productos con ventas en 60 días a 0 que no son outlet y que tienen un joking index de -1. Ahora se calcula el indice para todos los productos y se vuelven a revisar cambiando los que el indice es -1 y cumplen las condiciones anteriores, poniéndoles como indice el máximo calculado anteriormente.