### PR TITLE
Cambios realizados

### DIFF
--- a/project-addons/account_invoice_bank_usability/models/sale_order.py
+++ b/project-addons/account_invoice_bank_usability/models/sale_order.py
@@ -51,5 +51,7 @@ class SaleOrder(models.Model):
                 vals['partner_bank_id'] = mandate_sel.partner_bank_id.id
             elif invoice_partner.bank_ids:
                 vals['partner_bank_id'] = invoice_partner.bank_ids[0].id
+        if 'comment' in vals:
+            vals.pop('comment', None)
         return vals
 

--- a/project-addons/crm_claim_rma_custom/__openerp__.py
+++ b/project-addons/crm_claim_rma_custom/__openerp__.py
@@ -30,7 +30,7 @@
     'website': '',
     "depends": ['crm_claim_rma','account','account_refund_original',"product_virtual_stock_conservative",
                 'sale_display_stock', 'crm_rma_advance_location',
-                'custom_partner', 'block_invoices', 'product_pack'],
+                'custom_partner', 'block_invoices', 'product_pack', 'product_brand'],
     "data": ['crm_claim_view.xml', 'mrp_repair_wkf.xml',
              'data/substate_data.xml', 'security/ir.model.access.csv',
              'wizard/claim_make_picking_view.xml', 'stock_view.xml',

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -506,3 +506,73 @@ msgstr "Semana"
 #: view:crm.phonecall:crm_claim_rma_custom.view_crm_case_phonecalls_filter_group_by
 msgid "Day"
 msgstr "Día"
+
+#. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:crm_claim_rma_custom.crm_phonecall_menu_sat
+msgid "Phone calls"
+msgstr "Llamadas telefónicas"
+
+#. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:crm_claim_rma_custom.crm_phonecall_custom_wizard_action_sat
+msgid "New Call"
+msgstr "Nueva llamada"
+
+#. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:crm_claim_rma_custom.crm_case_categ_phone_incoming0_sat
+msgid "Logged Calls"
+msgstr "Llamadas registradas"
+
+#. module: crm_claim_rma_custom
+#: field:crm.phonecall,partner_country:0
+msgid "Country"
+msgstr "País"
+
+#. module: crm_claim_rma_custom
+#: field:crm.phonecall,brand_id:0
+msgid "Brand"
+msgstr "Marca"
+
+#. module: crm_claim_rma_custom
+#: field:crm.phonecall,call_type_sat:0
+msgid "Call type"
+msgstr "Tipo de llamada"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Check RMA status"
+msgstr "Consulta de estado de RMA"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Incidence with product"
+msgstr "Incidencia con producto"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Post-sale question on operation"
+msgstr "Consulta post-venta sobre funcionamiento"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Pre-sale query/advice"
+msgstr "Consulta pre-venta/asesoramiento"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "SAT Complaint/claim"
+msgstr "Queja/reclamación SAT"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "DDNS request for registration"
+msgstr "Petición de alta en DDNS"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Enquiry about courses/certificates"
+msgstr "Consulta sobre cursos/certificados"
+
+#. module: crm_claim_rma_custom
+#: selection:crm.phonecall,call_type_sat:0
+msgid "Others"
+msgstr "Otros"

--- a/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
+++ b/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
@@ -112,6 +112,6 @@ class CrmPhonecall(models.Model):
             'state': 'done',
             'call_type': self.call_type,
             'call_type_sat': self.call_type_sat,
-            'brand_id': self.brand_id
+            'brand_id': self.brand_id.id
         }
         super(CrmPhonecall, self).write(datas)

--- a/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
+++ b/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
@@ -35,6 +35,18 @@ CALL_TYPE = [('check_stock', 'Check Stock'),
              ('shipment_complain', 'Shipment Complain/Claim'),
              ('accounting_complain', 'Accounting Complain/Claim')]
 
+CALL_TYPE_SAT = [('check_status_rma', 'Check RMA status'),
+                 ('incidence_product', 'Incidence with product'),
+                 ('check_working', 'Post-sale question on operation'),
+                 ('counsel', 'Pre-sale query/advice'),
+                 ('sat_complain', 'SAT Complaint/claim'),
+                 ('ddns_registration', 'DDNS request for registration'),
+                 ('check_courses', 'Enquiry about courses/certificates'),
+                 ('others', 'Others')]
+
+SCOPE = [('sales', 'Sales'),
+         ('sat', 'SAT')]
+
 
 class CrmPhonecall(models.Model):
     """ Wizard for CRM phonecalls"""
@@ -52,6 +64,10 @@ class CrmPhonecall(models.Model):
     call_type = fields.Selection(CALL_TYPE, 'Call type', required=True)
     description = fields.Text('Call Description')
     partner_ref = fields.Char('Ref. Contact', readonly=True, compute='get_partner_ref')
+    scope = fields.Selection(SCOPE, 'Scope call')
+    call_type_sat = fields.Selection(CALL_TYPE_SAT, 'Call type', required=True)
+    partner_country = fields.Many2one(related='partner_id.country_id', string='Country', readonly=True)
+    brand_id = fields.Many2one('product.brand', 'Brand')
 
     def utc_to_local(self, utc_dt):
         local_dt = utc_dt.replace(tzinfo=pytz.utc).astimezone(self.local_tz)
@@ -94,6 +110,8 @@ class CrmPhonecall(models.Model):
             'opportunity_id': False,
             'duration': (duration.seconds / float(60)),
             'state': 'done',
-            'call_type': self.call_type
+            'call_type': self.call_type,
+            'call_type_sat': self.call_type_sat,
+            'brand_id': self.brand_id
         }
         super(CrmPhonecall, self).write(datas)

--- a/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
+++ b/project-addons/crm_claim_rma_custom/wizard/crm_phonecall.py
@@ -33,7 +33,8 @@ CALL_TYPE = [('check_stock', 'Check Stock'),
              ('tech_complain', 'Tech Complain/Claim'),
              ('web_complain', 'Web Complain/Claim'),
              ('shipment_complain', 'Shipment Complain/Claim'),
-             ('accounting_complain', 'Accounting Complain/Claim')]
+             ('accounting_complain', 'Accounting Complain/Claim'),
+             ('none', 'N/A')]
 
 CALL_TYPE_SAT = [('check_status_rma', 'Check RMA status'),
                  ('incidence_product', 'Incidence with product'),
@@ -42,7 +43,8 @@ CALL_TYPE_SAT = [('check_status_rma', 'Check RMA status'),
                  ('sat_complain', 'SAT Complaint/claim'),
                  ('ddns_registration', 'DDNS request for registration'),
                  ('check_courses', 'Enquiry about courses/certificates'),
-                 ('others', 'Others')]
+                 ('others', 'Others'),
+                 ('none', 'N/A')]
 
 SCOPE = [('sales', 'Sales'),
          ('sat', 'SAT')]
@@ -78,6 +80,22 @@ class CrmPhonecall(models.Model):
         if self.partner_id:
             self.partner_ref = self.partner_id.ref
 
+    @api.model
+    def create(self, datas):
+        if 'call_type' not in datas:
+            datas['call_type'] = 'none'
+        if 'call_type_sat' not in datas:
+            datas['call_type_sat'] = 'none'
+        return super(CrmPhonecall, self).create(datas)
+
+    @api.multi
+    def write(self, datas):
+        if not self.call_type and 'call_type' not in datas:
+            datas['call_type'] = 'none'
+        if not self.call_type_sat and 'call_type_sat' not in datas:
+            datas['call_type_sat'] = 'none'
+        return super(CrmPhonecall, self).write(datas)
+
     @api.multi
     def end_call(self):
         self.ensure_one()
@@ -110,8 +128,6 @@ class CrmPhonecall(models.Model):
             'opportunity_id': False,
             'duration': (duration.seconds / float(60)),
             'state': 'done',
-            'call_type': self.call_type,
-            'call_type_sat': self.call_type_sat,
             'brand_id': self.brand_id.id
         }
-        super(CrmPhonecall, self).write(datas)
+        self.write(datas)

--- a/project-addons/crm_claim_rma_custom/wizard/crm_phonecall_view.xml
+++ b/project-addons/crm_claim_rma_custom/wizard/crm_phonecall_view.xml
@@ -2,6 +2,8 @@
 <openerp>
     <data>
 
+        <menuitem id="crm_phonecall_menu_sat" name="Phone Calls" parent="crm_claim_rma.menu_sat" sequence="10"/>
+
         <record id="crm_phonecall_custom_call_type" model="ir.ui.view">
             <field name="name">crm.phonecall.custom.call.type</field>
             <field name="model">crm.phonecall</field>
@@ -51,7 +53,7 @@
         <record id="crm_phonecall_custom_wizard_action" model="ir.actions.act_window">
             <field name="name">New Call</field>
             <field name="res_model">crm.phonecall</field>
-            <field name="context">{'readonly_by_pass': ['start_date', 'name']}</field>
+            <field name="context">{'readonly_by_pass': ['start_date', 'name'], 'default_scope': 'sales'}</field>
             <field name="view_mode">form</field>
             <field name="view_type">form</field>
             <field name="target">new</field>
@@ -89,5 +91,85 @@
             </field>
         </record>
 
+        <!--New Phonecalls Wizard SAT-->
+        <record id="crm_phonecall_custom_wizard_form_view_sat" model="ir.ui.view">
+            <field name="name">crm.phonecall.custom.wizard.sat</field>
+            <field name="model">crm.phonecall</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="New Call">
+                    <group>
+                        <field name="start_date"/>
+                        <field name="partner_id" string="Partner"/>
+                        <field name="partner_country"/>
+                        <field name="user_id"/>
+                        <field name="call_type_sat"/>
+                        <field name="brand_id"/>
+                        <field name="description"/>
+                    </group>
+                    <footer>
+                        <button name="end_call" type="object"
+                            string="End Call" class="oe_highlight"/>
+                        or
+                        <button string="Cancel Call" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="crm_phonecall_custom_wizard_action_sat" model="ir.actions.act_window">
+            <field name="name">New Call</field>
+            <field name="res_model">crm.phonecall</field>
+            <field name="context">{'readonly_by_pass': ['start_date', 'name'], 'default_scope': 'sat'}</field>
+            <field name="view_mode">form</field>
+            <field name="view_type">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="crm_phonecall_custom_wizard_form_view_sat"/>
+        </record>
+
+        <menuitem id="crm_phonecall_custom_wizard_menu_sat" action="crm_phonecall_custom_wizard_action_sat"
+                  parent="crm_phonecall_menu_sat" sequence="1"/>
+
+        <!--Logged Phonecalls Tree View SAT-->
+        <record model="ir.ui.view" id="crm_case_inbound_phone_tree_view_sat">
+            <field name="name">CRM - Logged Phone Calls Tree SAT</field>
+            <field name="model">crm.phonecall</field>
+            <field name="arch" type="xml">
+                <tree string="Phone Calls" editable="top">
+                    <field name="date"/>
+                    <field name="partner_id" string="Partner"/>
+                    <field name="partner_country"/>
+                    <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'base.group_sale_salesman_all_leads']}"/>
+                    <field name="call_type_sat"/>
+                    <field name="brand_id"/>
+                    <field name="description"/>
+                    <field name="duration" string="Duration (min)" widget="float_time" class="oe_inline" style="vertical-align:baseline"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="crm_case_categ_phone_incoming0_sat">
+            <field name="name">Logged Calls</field>
+            <field name="res_model">crm.phonecall</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,calendar</field>
+            <field name="view_id" ref="crm_case_inbound_phone_tree_view_sat"/>
+            <field name="domain">[('scope', '=', 'sat')]</field>
+            <field name="context">{'search_default_state': 'done', 'default_state': 'done', 'search_default_user_id': uid,
+                                   'default_scope': 'sat'}</field>
+            <field name="search_view_id" ref="crm.view_crm_case_phonecalls_filter"/>
+            <field name="help" type="html">
+              <p class="oe_view_nocontent_create">
+                Click to log the summary of a phone call.
+              </p><p>
+                Odoo allows you to log inbound calls on the fly to track the
+                history of the communication with a customer or to inform another
+                team member.
+              </p>
+            </field>
+        </record>
+
+        <menuitem id="crm_phonecall_custom_logged_call_menu_sat" action="crm_case_categ_phone_incoming0_sat"
+                  parent="crm_phonecall_menu_sat" sequence="2"/>
     </data>
 </openerp>

--- a/project-addons/custom_account/crm_view.xml
+++ b/project-addons/custom_account/crm_view.xml
@@ -8,8 +8,9 @@
         <field name="view_type">form</field>
         <field name="view_mode">tree,calendar</field>
         <field name="view_id" ref="crm.crm_case_inbound_phone_tree_view"/>
-        <field name="domain">[]</field>
-        <field name="context">{'search_default_state': 'done', 'default_state': 'done', 'search_default_user_id': uid}</field>
+        <field name="domain"> [('scope', '=', 'sales')]</field>
+        <field name="context">{'search_default_state': 'done', 'default_state': 'done', 'search_default_user_id': uid,
+                               'default_scope': 'sales'}</field>
         <field name="search_view_id" ref="crm.view_crm_case_phonecalls_filter"/>
         <field name="help" type="html">
           <p class="oe_view_nocontent_create">

--- a/project-addons/custom_partner/__openerp__.py
+++ b/project-addons/custom_partner/__openerp__.py
@@ -29,7 +29,7 @@
     "depends": ['base', 'sale', 'l10n_es_partner', 'warning', 'account',
                 'base_partner_sequence', 'stock', 'account_followup',
                 'purchase', 'purchase_advance_payment',
-                'account_due_list', 'rappel'],
+                'account_due_list', 'rappel', 'product_brand'],
     "data": ["partner_view.xml", "stock_view.xml",
              "security/ir.model.access.csv", "sale_view.xml"],
     "installable": True

--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -338,3 +338,14 @@ msgstr "Referencia Cliente"
 #: field:rappel.calculated,goal_percentage:0
 msgid "Goal Percentage"
 msgstr "Porcentaje de cumplimiento"
+
+#. module: custom_partner
+#: field:rappel,brand_ids:0
+msgid "Brand"
+msgstr "Marca"
+
+#. module: custom_partner
+#: code:addons/custom_partner/partner.py:76
+#, python-format
+msgid "Product, brand and category are empty"
+msgstr "El producto, la marca y la categoría están vacíos"

--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -349,3 +349,8 @@ msgstr "Marca"
 #, python-format
 msgid "Product, brand and category are empty"
 msgstr "El producto, la marca y la categoría están vacíos"
+
+#. module: custom_partner
+#: view:rappel:custom_partner.rappel_form_add_brand
+msgid "You must fill in only one of the following fields to define the validity area of rappel:"
+msgstr "Debe rellenar solamente uno de los siguientes datos para definir el ámbito de validez del rappel:"

--- a/project-addons/custom_partner/partner.py
+++ b/project-addons/custom_partner/partner.py
@@ -764,6 +764,38 @@ class ResPartnerRappelRel(models.Model):
         return True
 
 
+class rappel(models.Model):
+
+    _inherit = 'rappel'
+    brand_ids = fields.Many2many('product.brand', 'rappel_product_brand_rel',
+                                 'rappel_id', 'product_brand_id', 'Brand')
+
+    @api.multi
+    def get_products(self):
+        product_obj = self.env['product.product']
+        product_ids = self.env['product.product']
+        for rappel in self:
+            if not rappel.global_application:
+                if rappel.product_id:
+                    product_ids += rappel.product_id
+                elif rappel.brand_ids:
+                    product_ids += product_obj.search(
+                        [('product_brand_id', 'in', rappel.brand_ids.ids)])
+                elif rappel.product_categ_id:
+                    product_ids += product_obj.search(
+                        [('categ_id', '=', rappel.product_categ_id.id)])
+            else:
+                product_ids += product_obj.search([])
+        return [x.id for x in product_ids]
+
+    @api.constrains('global_application', 'product_id', 'brand_ids', 'product_categ_id')
+    def _check_application(self):
+        if not self.global_application and not self.product_id \
+                and not self.product_categ_id and not self.brand_ids:
+            raise exceptions. \
+                ValidationError(_('Product, brand and category are empty'))
+
+
 class RappelInvoice(models.TransientModel):
 
     _inherit = "rappel.invoice.wzd"

--- a/project-addons/custom_partner/partner.py
+++ b/project-addons/custom_partner/partner.py
@@ -786,7 +786,7 @@ class rappel(models.Model):
                         [('categ_id', '=', rappel.product_categ_id.id)])
             else:
                 product_ids += product_obj.search([])
-        return [x.id for x in product_ids]
+        return product_ids.ids
 
     @api.constrains('global_application', 'product_id', 'brand_ids', 'product_categ_id')
     def _check_application(self):

--- a/project-addons/custom_partner/partner_view.xml
+++ b/project-addons/custom_partner/partner_view.xml
@@ -489,5 +489,16 @@
             </field>
         </record>
 
+         <record id="rappel_form_add_brand" model="ir.ui.view">
+            <field name="name">rappel.form.add.brand</field>
+            <field name="model">rappel</field>
+            <field name="inherit_id" ref="rappel.rappel_form"/>
+            <field name="arch" type="xml">
+                <field name="product_id" position="after">
+                    <field name="brand_ids" attrs="{'invisible':[('global_application','=', True)]}"/>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>

--- a/project-addons/custom_partner/partner_view.xml
+++ b/project-addons/custom_partner/partner_view.xml
@@ -92,7 +92,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">tree,form,graph</field>
             <field name="context">{'search_default_partner_id': active_id}</field>
-            <field name="domain">[('state', 'in', ['draft','sent'])]</field>
+            <field name="domain">[('state', 'in', ['cancel','draft','sent'])]</field>
             <field name="groups_id" eval="[(4, ref('base.group_sale_salesman'))]"/>
             <field name="help" type="html">
               <p class="oe_view_nocontent_create">

--- a/project-addons/custom_partner/partner_view.xml
+++ b/project-addons/custom_partner/partner_view.xml
@@ -494,6 +494,13 @@
             <field name="model">rappel</field>
             <field name="inherit_id" ref="rappel.rappel_form"/>
             <field name="arch" type="xml">
+                <field name="global_application" position="after">
+                    <separator colspan="4" attrs="{'invisible':[('global_application','=', True)]}"/>
+                    <label colspan="4" string="You must fill in only one of the following fields to define the validity area of rappel:"
+                           attrs="{'invisible':[('global_application','=', True)]}"
+                           style="color: red;"/>
+                    <separator colspan="4" attrs="{'invisible':[('global_application','=', True)]}"/>
+                </field>
                 <field name="product_id" position="after">
                     <field name="brand_ids" attrs="{'invisible':[('global_application','=', True)]}"/>
                 </field>

--- a/project-addons/stock_deposit/stock.py
+++ b/project-addons/stock_deposit/stock.py
@@ -80,6 +80,12 @@ class stock_picking(models.Model):
                 picking.invoice_state = 'invoiced'
         return super(stock_picking, self).action_assign()
 
+    @api.model
+    def _get_invoice_vals(self, key, inv_type, journal_id, move):
+        res = super(stock_picking, self)._get_invoice_vals(key, inv_type, journal_id, move)
+        if 'comment' in res:
+            res.pop('comment', None)
+        return res
 
 '''class stock_invoice_onshipping(models.TransientModel):
 


### PR DESCRIPTION
- [IMP] 'custom_partner': Permitir filtrar por marca en los productos incluidos en el cálculo del rappel

- [IMP] 'custom_partner': En el botón Presupuestos de la ficha del cliente, añadido también aquellos que están cancelados

- [IMP] 'account_invoice_bank_usability': No arrastrar Términos y condiciones del pedido a la factura

- [IMP] 'stock_deposit': No arrastrar Términos y condiciones del pedido al crear factura desde albarán

- [IMP] 'crm_claim_rma_custom': Módulo de llamadas telefónicas para SAT. Se ha reutilizado el mismo modelo que está en Ventas, creando los nuevos campos para SAT y los necesarios para la distinción del ámbito ("sat" or "sales")

- [IMP] 'custom_account': Filtradas las llamadas registradas desde Ventas para que salgan las correspondientes a su ámbito

- [FIX] 'crm_claim_rma_custom': Pasar id en vez del objeto product.brand en el wirte del módulo de llamadas

- [IMP] 'custom_partner': Añadido texto a modo de ayuda para filtrar el ámbito de cálculo del rappel

NOTA: Como he creado un nuevo campo en el modelo de las llamadas telefónicas, habría que ejecutar la siguiente query para asignar todas las llamadas ya creadas al ámbito "ventas": 
UPDATE crm_phonecall SET scope = 'sales'