### PR TITLE
Hotfix cron facturacion anual

### DIFF
--- a/project-addons/custom_partner/__openerp__.py
+++ b/project-addons/custom_partner/__openerp__.py
@@ -31,6 +31,7 @@
                 'purchase', 'purchase_advance_payment',
                 'account_due_list', 'rappel'],
     "data": ["partner_view.xml", "stock_view.xml",
-             "security/ir.model.access.csv", "sale_view.xml"],
+             "security/ir.model.access.csv", "sale_view.xml",
+             "data/custom_partner_data.xml"],
     "installable": True
 }

--- a/project-addons/custom_partner/data/custom_partner_data.xml
+++ b/project-addons/custom_partner/data/custom_partner_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record forcecreate="True" id="ir_cron_calculate_annual_invoiced" model="ir.cron">
+            <field name="name">Calculate Annual Invoiced</field>
+            <field eval="True" name="active"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field eval="False" name="doall"/>
+            <field eval="'res.partner'" name="model"/>
+            <field eval="'_calculate_annual_invoiced'" name="function"/>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
[FIX] 'custom_partner': Incluida definincion del cron de facturacion anual en codigo

Se tendrá mas en cuenta para futuros PR de crons la necesidad de este archivo con la definición del cron. Nos gustaría que, si todo esta bien, se aceptara el PR antes de las 14:30 para intentar hacer un reinicio antes de que los comerciales vuelvan a sus puestos.