### PR TITLE
Hotfix sincronizacion contactos

### DIFF
--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -155,7 +155,7 @@ def delay_export_partner_create(session, model_name, record_id, vals):
                     update_partner.delay(session, model_name, record_id, priority=5, eta=120)
                     break
     else:
-        if partner.commercial_partner_id.web and 'active' in vals and vals.get('active', False):
+        if partner.parent_id.web and 'active' in vals and vals.get('active', False):
             export_partner.delay(session, model_name, record_id, priority=1,
                                  eta=120)
 
@@ -282,7 +282,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
                 for field in up_fields:
                     if field in vals:
                         update_partner.delay(session, model_name, record_id, priority=3,
-                                             eta=120)
+                                             eta=180)
                         break
 
 


### PR DESCRIPTION
He encontrado este error en la exportación de clientes y contactos, pero solo afecta a estos últimos. Cuando se crea el contacto y se hace el create en flask, todavía el contacto no tiene commercial_partner_id por lo que al hacer la comprobación de si este tiene el campo web activo o no siempre sale false. Lo he modificado por un parent_id ya que he comprobado que cuando se crea un contacto, el objeto contacto tiene ese campo y no debería de dar problemas. 

Por ahora vamos a ver como se comporta esto, voy a revisar los demás objetos que se exportan para dejarlos bien. Si vemos que esta solución no funciona, hacemos lo que me dijiste en el correo y concateno un export si el update falla. 