### PR TITLE
Hotfix: cantidad mínima sugerida

### DIFF
--- a/project-addons/crm_claim_rma_custom/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/crm_claim_view.xml
@@ -2,18 +2,18 @@
 <openerp>
     <data>
 
-      <!--<record id="equivalent_products_wizard_inherit" model="ir.ui.view">
-          <field name="name">equivalent.products.wizard</field>
-          <field name="model">equivalent.products.wizard</field>
-          <field name="type">form</field>
-          <field name="inherit_id" ref="crm_claim_rma.equivalent_products_wizard"/>
-          <field name="arch" type="xml">
-              <xpath expr="//form[@string='Equivalent products']/group/field[@name='tag_ids']" position="replace">
-                <field name="tag_ids" on_change="onchange_tags(tag_ids)" >
+        <record id="equivalent_products_wizard_no_create" model="ir.ui.view">
+            <field name="name">equivalent.products.wizard.no.create</field>
+            <field name="model">equivalent.products.wizard</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="crm_claim_rma.equivalent_products_wizard"/>
+            <field name="arch" type="xml">
+                <field name="product_id" position="attributes">
+                    <attribute name="options">{'no_create': True, 'no_open': True}</attribute>
                 </field>
-              </xpath>
-          </field>
-      </record>-->
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="crm_claim_rma_form_view_inherit_new_refund">
             <field name="name">CRM - Claim product return Form</field>
             <field name="model">crm.claim</field>

--- a/project-addons/custom_account/i18n/es.po
+++ b/project-addons/custom_account/i18n/es.po
@@ -589,3 +589,7 @@ msgstr "Recuerde cambiar la fecha de vencimiento en el(los) efecto(s) asociado(s
 msgid "Don't show on supplier payment follow-ups"
 msgstr "No mostrar en el seguimiento de pagos a proveedores"
 
+#. module: custom_account
+#: field:sale.report,main_supplier:0
+msgid "Main supplier"
+msgstr "Proveedor principal"

--- a/project-addons/custom_account/report/sale_report.py
+++ b/project-addons/custom_account/report/sale_report.py
@@ -29,10 +29,12 @@ class SaleReport(models.Model):
     parent_category_id = fields.Many2one("product.category", 'Parent categ.')
     partner_ref = fields.Char("Partner ref")
     state_name = fields.Char("State Name")
+    main_supplier = fields.Many2one('res.partner', 'Main supplier')
 
     def _select(self):
         select_str = (", t.product_brand_id as brand_id, pc.parent_id as "
-                      "parent_category_id, rp.ref as partner_ref, cs.name as state_name")
+                      "parent_category_id, rp.ref as partner_ref, cs.name as state_name, "
+                      "t.manufacturer as main_supplier")
         return super(SaleReport, self)._select() + select_str
 
     def _from(self):
@@ -44,5 +46,5 @@ class SaleReport(models.Model):
 
 
     def _group_by(self):
-        group_by_str = """, t.product_brand_id, rp.ref, pc.parent_id, cs.name"""
+        group_by_str = """, t.product_brand_id, rp.ref, pc.parent_id, cs.name, t.manufacturer"""
         return super(SaleReport, self)._group_by() + group_by_str

--- a/project-addons/flask_middleware_connector/models/middleware.py
+++ b/project-addons/flask_middleware_connector/models/middleware.py
@@ -146,10 +146,10 @@ class MiddlewareBackend(models.Model):
             #~ users = self.env['res.users'].search([('web', '=', True)])
             #~ for user in users:
                 #~ export_commercial(session, 'res.users', user.id)
-            partner_obj = self.env['res.partner']
-            partner_ids = partner_obj.search([('is_company', '=', True),
-                                              ('web', '=', True),
-                                              ('customer', '=', True)])
+            #~ partner_obj = self.env['res.partner']
+            #~ partner_ids = partner_obj.search([('is_company', '=', True),
+                                              #~ ('web', '=', True),
+                                              #~ ('customer', '=', True)])
             #~ picking_obj = self.env['stock.picking']
             #~ picking_ids = picking_obj.search([('partner_id', 'child_of', partner_ids.ids),
                                               #~ ('state', '!=', 'cancel'),
@@ -170,20 +170,19 @@ class MiddlewareBackend(models.Model):
             #~ for substate in substates:
                 #~ export_rma_status(session, 'substate.substate', substate.id)
 
-            rmas = self.env['crm.claim'].search(['|', ('partner_id.web', '=', True),
-                                                 ('partner_id.commercial_partner_id.web', '=', True)])
-            for rma in rmas:
-                export_rma.delay(session, 'crm.claim', rma.id)
-                for line in rma.claim_line_ids:
+            #~ rmas = self.env['crm.claim'].search(['|', ('partner_id.web', '=', True),
+                                                 #~ ('partner_id.commercial_partner_id.web', '=', True)])
+            #~ for rma in rmas:
+                #~ export_rma.delay(session, 'crm.claim', rma.id)
+                #~ for line in rma.claim_line_ids:
                     #~if line.product_id.web == 'published':
-                    export_rmaproduct.delay(session, 'claim.line', line.id)
-            #~ invoices = self.env['account.invoice'].\
-                #~ search([('commercial_partner_id.web',
-                # '=', True),
-                        #~ ('state', 'in', ['open', 'paid']),
-                        #~ ('number', 'not like', '%ef%')])
-            #~ for invoice in invoices:
-                #~ export_invoice.delay(session, 'account.invoice', invoice.id)
+                    #~ export_rmaproduct.delay(session, 'claim.line', line.id)
+            invoices = self.env['account.invoice'].\
+                search([('commercial_partner_id.web', '=', True),
+                        ('state', 'in', ['open', 'paid']),
+                        ('number', 'not like', '%ef%')])
+            for invoice in invoices:
+                export_invoice.delay(session, 'account.invoice', invoice.id)
             #~ products = self.env["product.product"]. \
             #~     search(['manufacturer_ref', '!=', False])
             #~ for product in products:

--- a/project-addons/product_stock_unsafety/product.py
+++ b/project-addons/product_stock_unsafety/product.py
@@ -98,7 +98,7 @@ class product_product(models.Model):
                     and product.categ_id.parent_id.name != 'Outlet':
                 product.joking_index = max_joking
 
-    @api.one
+    @api.model
     def _get_next_move(self, product, limit=1):
         next_move = self.env['stock.move'].search(
             [('product_id', '=', product.id),
@@ -115,14 +115,14 @@ class product_product(models.Model):
         """ Get next incoming date """
         for product in self:
             next_move = self._get_next_move(product, limit=1)
-            if next_move[0]:
-                product.next_incoming_date = next_move[0].date_expected
+            if next_move:
+                product.next_incoming_date = next_move.date_expected
 
     @api.one
     def _get_min_suggested_qty(self):
         """ Get the min suggested qty to buy of a product """
         for product in self:
-            next_moves = self._get_next_move(product, limit=3)[0]
+            next_moves = self._get_next_move(product, limit=3)
             sixty_days_sales = - product.last_sixty_days_sales
             order_cycle = product.order_cycle
             res = (sixty_days_sales / 60.0) * order_cycle \

--- a/project-addons/product_stock_unsafety/product.py
+++ b/project-addons/product_stock_unsafety/product.py
@@ -122,7 +122,7 @@ class product_product(models.Model):
     def _get_min_suggested_qty(self):
         """ Get the min suggested qty to buy of a product """
         for product in self:
-            next_moves = self._get_next_move(product, limit=3)
+            next_moves = self._get_next_move(product, limit=3)[0]
             sixty_days_sales = - product.last_sixty_days_sales
             order_cycle = product.order_cycle
             res = (sixty_days_sales / 60.0) * order_cycle \
@@ -143,6 +143,6 @@ class product_product(models.Model):
     replacement_id = fields.Many2one("product.product", "Replaced by")
     min_days_id = fields.Many2one("minimum.day", "Stock Minimum Days",
                                   related="orderpoint_ids.min_days_id",
-                                  readonly=True)
+                                   readonly=True)
     next_incoming_date = fields.Date('Next incoming date', compute='_get_next_incoming_date')
     min_suggested_qty = fields.Integer('Min qty suggested', compute='_get_min_suggested_qty')


### PR DESCRIPTION
- [IMP] 'crm_claim_rma_custom': Se ha limitado la creación a en la vista de productos equivalentes para evitar creaciones de productos vacíos.
- [FIX] 'product_stock_unsafety': Solucionado un problema con la cantidad mínima sugerida en el cual se devolvían los objetos stock.move como una lista y no se iteraba por cada uno de ellos y se producía una excepción al esperar un singleton y obtener una lista
- [IMP] 'custom_account': Añadido campo para permitir agrupar y filtrar por Proveedor Principal del producto en Análisis de ventas