### PR TITLE
Hotfix Flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -245,7 +245,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
             unlink_partner.delay(session, model_name, record_id, priority=1, eta=60)
 
         elif "active" in vals and not vals["active"] and partner.web or \
-                "prospective" in vals and not vals["prospective"]:
+                "prospective" in vals and vals["prospective"]:
             for contact in contacts:
                 unlink_partner.delay(session, model_name, contact.id, priority=1,
                                      eta=60)

--- a/project-addons/flask_middleware_connector/models/queue_job.py
+++ b/project-addons/flask_middleware_connector/models/queue_job.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright (C) 2016 Comunitea All Rights Reserved
-#    $Jesús Ventosinos Mayor <jesus@comunitea.com>$
+#    Copyright (C) 2015 Comunitea All Rights Reserved
+#    $Omar Castiñeira Saavedra <omar@comunitea.com>$
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -18,11 +18,16 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import claim
-from . import product
-from . import res_partner
-from . import res_users
-from . import stock
-from . import middleware
-from . import product_brand
-from . import queue_job
+
+from openerp import models, fields, api
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.multi
+    def create(self, vals):
+        res = super(QueueJob, self).create(vals)
+        if not res.active:
+            res.active = True
+        return res

--- a/project-addons/flask_middleware_connector/models/queue_job.py
+++ b/project-addons/flask_middleware_connector/models/queue_job.py
@@ -25,7 +25,7 @@ from openerp import models, fields, api
 class QueueJob(models.Model):
     _inherit = 'queue.job'
 
-    @api.multi
+    @api.model
     def create(self, vals):
         res = super(QueueJob, self).create(vals)
         if not res.active:


### PR DESCRIPTION
Se ha arreglado el problema existente al exportar un cliente potencial marcando directamente el campo activo y el campo web y desmarcando el campo potencial. Esto creaba un trabajo inactivo que no se ejecutaba, se ha modificado la lógica para forzar a que cualquier trabajo sea activo. Esto se ha hecho después de comprobar en producción los trabajos inactivos y ver que solo correspondían con clientes. 