### PR TITLE
Hotfix avisos rappel

### DIFF
--- a/project-addons/custom_partner/partner.py
+++ b/project-addons/custom_partner/partner.py
@@ -825,3 +825,86 @@ class RappelInvoice(models.TransientModel):
                                              'section_id': rappel.partner_id.section_id.id})
         return res
 
+
+class RappelCurrentInfo(models.Model):
+
+    _inherit = "rappel.current.info"
+
+    @api.model
+    def send_rappel_info_mail(self):
+        mail_pool = self.env['mail.mail']
+        mail_ids = self.env['mail.mail']
+        partner_pool = self.env['res.partner'].search([('rappel_ids', '!=', '')])
+        for partner in partner_pool:
+            partner_list = []
+            partner_list.append(partner.id)
+            pool_partners = self.search([('partner_id', '=', partner.id)])
+            send = False
+            if pool_partners:
+
+                values = {}
+                for rappel in pool_partners:
+
+                    date_end = datetime.strptime(str(rappel.date_end), '%Y-%m-%d')
+                    date_start = datetime.strptime(str(rappel.date_start), '%Y-%m-%d')
+                    today = datetime.strptime(str(fields.Date.today()), '%Y-%m-%d')
+
+                    for rappel_timing in rappel.rappel_id.advice_timing_ids:
+
+                        if rappel_timing.advice_timing == 'fixed':
+                            timing = (date_end - today).days
+                            if timing == rappel_timing.timing:
+                                send = True
+
+                        if rappel_timing.advice_timing == 'variable':
+
+                            timing = (date_end - date_start).days*rappel_timing.timing/100
+                            timing2= (today - date_start).days
+
+                            if timing == timing2:
+                                send = True
+
+                        if send == True and rappel.curr_qty:
+                            if values.get(partner.id):
+                                values[partner.id].append ({
+                                    'concepto': rappel.rappel_id.name,
+                                    'date_start': date_start.strftime('%d/%m/%Y'),
+                                    'date_end': date_end.strftime('%d/%m/%Y'),
+                                    'advice_timing': rappel_timing.advice_timing,
+                                    'timing': rappel_timing.timing,
+                                    'curr_qty': rappel.curr_qty,
+                                    'section_goal': rappel.section_goal,
+                                    'section_id': rappel.section_id,
+                                    'amount': rappel.amount
+                                })
+                            else:
+                                values[partner.id] = [{
+                                    'concepto': rappel.rappel_id.name,
+                                    'date_start': date_start.strftime('%d/%m/%Y'),
+                                    'date_end': date_end.strftime('%d/%m/%Y'),
+                                    'advice_timing': rappel_timing.advice_timing,
+                                    'timing': rappel_timing.timing,
+                                    'curr_qty': rappel.curr_qty,
+                                    'section_goal': rappel.section_goal,
+                                    'section_id': rappel.section_id,
+                                    'amount': rappel.amount
+                                }]
+                        send = False
+
+                if values.get(partner.id):
+                    template = self.env.ref('rappel.rappel_mail_advice')
+                    ctx = dict(self._context)
+                    ctx.update({
+                        'partner_email': partner.email,
+                        'partner_id': partner.id,
+                        'partner_lang': partner.lang,
+                        'partner_name': partner.name,
+                        'mail_from': self.env.user.company_id.email,
+                        'values': values[partner.id]
+                    })
+
+                    mail_id = template.with_context(ctx).send_mail(rappel.partner_id.id)
+                    mail_ids += mail_pool.browse(mail_id)
+        if mail_ids:
+            mail_ids.send()
+


### PR DESCRIPTION
[FIX] 'custom_partner': Sobrescribir función de avisos de rappel para evitar enviar un mismo correo múltiples veces