### PR TITLE
Flask: Implementacion de Pedidos y Etiquetas de clientes

### DIFF
--- a/project-addons/flask_middleware_connector/events/__init__.py
+++ b/project-addons/flask_middleware_connector/events/__init__.py
@@ -25,3 +25,4 @@ from . import rma_events
 from . import country_events
 from . import commercial_events
 from . import picking_events
+from . import order_events

--- a/project-addons/flask_middleware_connector/events/order_events.py
+++ b/project-addons/flask_middleware_connector/events/order_events.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 Visiotech All Rights Reserved
+#    $Jesus Garcia Manzanas <jgmanzanas@visiotechsecurity.com>$
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models
+from openerp.addons.connector.event import on_record_create, on_record_write, \
+    on_record_unlink
+from openerp.addons.connector.queue.job import job
+from .utils import _get_exporter
+from ..backend import middleware
+from openerp.addons.connector.unit.synchronizer import Exporter
+from ..unit.backend_adapter import GenericAdapter
+
+
+@middleware
+class OrderExporter(Exporter):
+
+    _model_name = ['sale.order']
+
+    def update(self, binding_id, mode):
+        order = self.model.browse(binding_id)
+        vals = {"odoo_id": order.id,
+                "name": order.name,
+                "state": order.state,
+                "partner_id": order.partner_id.id,
+                "total_amount": order.amount_total,
+                "date_order": order.date_order,
+                "client_order_ref": order.client_order_ref,
+        }
+        if mode == "insert":
+            return self.backend_adapter.insert(vals)
+        else:
+            return self.backend_adapter.update(binding_id, vals)
+
+    def delete(self, binding_id):
+        return self.backend_adapter.remove(binding_id)
+
+@middleware
+class OrderAdapter(GenericAdapter):
+    _model_name = 'sale.order'
+    _middleware_model = 'order'
+
+
+@on_record_create(model_names='sale.order')
+def delay_export_order_create(session, model_name, record_id, vals):
+    order = session.env[model_name].browse(record_id)
+    if order.partner_id.web or order.partner_id.commercial_partner_id.web:
+        export_order.delay(session, model_name, record_id, priority=2, eta=80)
+
+
+@on_record_write(model_names='sale.order')
+def delay_export_order_write(session, model_name, record_id, vals):
+    order = session.env[model_name].browse(record_id)
+    up_fields = ["name", "state", "partner_id", "total_amount", "date_order", "client_order_ref"]
+    if order.partner_id.web or order.partner_id.commercial_partner_id.web:
+        for field in up_fields:
+            if field in vals:
+                update_order.delay(session, model_name, record_id, priority=7, eta=120)
+                break
+
+
+@on_record_unlink(model_names='sale.order')
+def delay_export_order_unlink(session, model_name, record_id, vals):
+    order = session.env[model_name].browse(record_id)
+    if order.partner_id.web or order.partner_id.commercial_partner_id.web:
+        unlink_order.delay(session, model_name, record_id, priority=7, eta=120)
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def export_order(session, model_name, record_id):
+    order_exporter = _get_exporter(session, model_name, record_id,
+                                   OrderExporter)
+    return order_exporter.update(record_id, "insert")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def update_order(session, model_name, record_id):
+    order_exporter = _get_exporter(session, model_name, record_id,
+                                   OrderExporter)
+    return order_exporter.update(record_id, "update")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def unlink_order(session, model_name, record_id):
+    order_exporter = _get_exporter(session, model_name, record_id,
+                                   OrderExporter)
+    return order_exporter.delete(record_id)
+
+@middleware
+class OrderProductExporter(Exporter):
+
+    _model_name = ['sale.order.line']
+
+    def update(self, binding_id, mode):
+        orderproduct = self.model.browse(binding_id)
+        vals = {"odoo_id": orderproduct.id,
+                "product_id": orderproduct.product_id.id,
+                "product_qty": orderproduct.product_uom_qty,
+                "total_price": orderproduct.price_subtotal,
+                "order_id": orderproduct.order_id.id,
+        }
+        if mode == "insert":
+            return self.backend_adapter.insert(vals)
+        else:
+            return self.backend_adapter.update(binding_id, vals)
+
+    def delete(self, binding_id):
+        return self.backend_adapter.remove(binding_id)
+
+@middleware
+class OrderProductAdapter(GenericAdapter):
+    _model_name = 'sale.order.line'
+    _middleware_model = 'orderproduct'
+
+
+@on_record_create(model_names='sale.order.line')
+def delay_export_orderproduct_create(session, model_name, record_id, vals):
+    orderproduct = session.env[model_name].browse(record_id)
+    if orderproduct.order_id.partner_id.web or orderproduct.order_id.partner_id.commercial_partner_id.web:
+        export_orderproduct.delay(session, model_name, record_id, priority=2, eta=180)
+
+
+@on_record_write(model_names='sale.order.line')
+def delay_export_orderproduct_write(session, model_name, record_id, vals):
+    orderproduct = session.env[model_name].browse(record_id)
+    up_fields = ["product_id", "product_qty", "total_price", "order_id"]
+    if orderproduct.order_id.partner_id.web or orderproduct.order_id.partner_id.commercial_partner_id.web:
+        for field in up_fields:
+            if field in vals:
+                update_orderproduct.delay(session, model_name, record_id, priority=7, eta=180)
+                break
+
+
+@on_record_unlink(model_names='sale.order.line')
+def delay_export_orderproduct_unlink(session, model_name, record_id, vals):
+    orderproduct = session.env[model_name].browse(record_id)
+    if orderproduct.order_id.partner_id.web or orderproduct.order_id.partner_id.commercial_partner_id.web:
+        unlink_orderproduct.delay(session, model_name, record_id, priority=7, eta=180)
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def export_orderproduct(session, model_name, record_id):
+    orderproduct_exporter = _get_exporter(session, model_name, record_id,
+                                          OrderProductExporter)
+    return orderproduct_exporter.update(record_id, "insert")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def update_orderproduct(session, model_name, record_id):
+    orderproduct_exporter = _get_exporter(session, model_name, record_id,
+                                          OrderProductExporter)
+    return orderproduct_exporter.update(record_id, "update")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def unlink_orderproduct(session, model_name, record_id):
+    orderproduct_exporter = _get_exporter(session, model_name, record_id,
+                                          OrderProductExporter)
+    return orderproduct_exporter.delete(record_id)
+

--- a/project-addons/flask_middleware_connector/events/order_events.py
+++ b/project-addons/flask_middleware_connector/events/order_events.py
@@ -72,7 +72,7 @@ def delay_export_order_write(session, model_name, record_id, vals):
     #He cogido order_line porque no entra amount_total ni amount_untaxed en el write
     up_fields = ["name", "state", "partner_id", "date_order", "client_order_ref", "order_line"] 
     if order.partner_id.web or order.partner_id.commercial_partner_id.web:
-        if 'state' in vals.keys() and vals['state'] not in ('done', 'progress', 'reserve'):
+        if 'state' in vals.keys() and vals['state'] == 'cancel':
             unlink_order.delay(session, model_name, record_id, priority=7, eta=180)
         elif 'state' in vals.keys() and vals['state'] in  ('draft', 'reserve'):
             export_order.delay(session, model_name, record_id, priority=2, eta=80)

--- a/project-addons/flask_middleware_connector/events/order_events.py
+++ b/project-addons/flask_middleware_connector/events/order_events.py
@@ -76,10 +76,11 @@ def delay_export_order_write(session, model_name, record_id, vals):
             unlink_order.delay(session, model_name, record_id, priority=7, eta=180)
         elif 'state' in vals.keys() and vals['state'] in  ('draft', 'reserve'):
             export_order.delay(session, model_name, record_id, priority=2, eta=80)
-        for field in up_fields:
-            if field in vals:
-                update_order.delay(session, model_name, record_id, priority=5, eta=120)
-                break
+        elif order.state in ('draft', 'reserve', 'progress', 'done'):
+            for field in up_fields:
+                if field in vals:
+                    update_order.delay(session, model_name, record_id, priority=5, eta=120)
+                    break
 
 
 @on_record_unlink(model_names='sale.order')

--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -473,10 +473,8 @@ class PartnerTagRelExporter(Exporter):
     _model_name = ['res.partner.res.partner.category.rel']
 
     def update(self, partner_record_id, category_record_id, mode):
-        partner = self.env['res.partner'].browse(partner_record_id)
-        category = self.env['res.partner.category'].browse(category_record_id)
-        vals = {"odoo_id": partner.id,
-                "customertag_id": category.id,
+        vals = {"odoo_id": partner_record_id,
+                "customertag_id": category_record_id,
                 }
         if mode == "insert":
             return self.backend_adapter.insert(vals)

--- a/project-addons/flask_middleware_connector/events/picking_events.py
+++ b/project-addons/flask_middleware_connector/events/picking_events.py
@@ -101,6 +101,7 @@ def delay_export_picking_write(session, model_name, record_id, vals):
             for field in up_fields:
                 if field in vals:
                     update_picking.delay(session, model_name, record_id, priority=2, eta=120)
+                    break
 
 
 @on_record_unlink(model_names='stock.picking')

--- a/project-addons/vt_flask_middleware/customer.py
+++ b/project-addons/vt_flask_middleware/customer.py
@@ -12,6 +12,23 @@ from app import app
 from database import SyncModel
 
 
+class CustomerTag(SyncModel):
+    """
+    User tag model.
+
+    Note: follows the 'user model' protocol specified by flask_peewee.auth.Auth
+    """
+
+    odoo_id = IntegerField(unique=True)
+    name = CharField(max_length=70)
+    parent_id = IntegerField(null=True)
+
+    MOD_NAME = 'customertag'
+
+    def __unicode__(self):
+        return self.name
+
+
 class Customer(SyncModel):
     """
     User model.
@@ -30,14 +47,26 @@ class Customer(SyncModel):
     country = CharField(max_length=100, null=True)
     state = CharField(max_length=100, null=True)
     email = CharField(max_length=70, null=True)
-    commercial_id = ForeignKeyField(Commercial, on_delete='CASCADE', null=True)
     odoo_id = IntegerField(unique=True)
     lang = CharField(max_length=5, null=True)
     type = CharField(max_length=30, null=True)
     parent_id = IntegerField(null=True)
+    commercial_id = ForeignKeyField(Commercial, on_delete='CASCADE', null=True)
     is_company = BooleanField(default=True)
 
     MOD_NAME = 'customer'
 
     def __unicode__(self):
         return self.fiscal_name
+
+
+class CustomerTagCustomerRel(SyncModel):
+
+    odoo_id = IntegerField()
+    customertag_id = ForeignKeyField(CustomerTag, on_delete='CASCADE')
+
+    MOD_NAME = 'customertagcustomerrel'
+
+    def __unicode__(self):
+        return u"Customer id: %s - Tag id: %s" % (self.odoo_id, self.customertag_id)
+

--- a/project-addons/vt_flask_middleware/implemented_models.py
+++ b/project-addons/vt_flask_middleware/implemented_models.py
@@ -1,24 +1,28 @@
 from country import Country
 from product import Product, ProductCategory, ProductBrand, \
     ProductBrandCountryRel
-from customer import Customer
+from customer import Customer, CustomerTag, CustomerTagCustomerRel
 from invoice import Invoice
+from order import Order, OrderProduct
 from commercial import Commercial
 from rma import RmaStatus, RmaStage, Rma, RmaProduct
 from picking import Picking, PickingProduct
 #from post import Post
 MODELS_CLASS = {
-    'invoice': Invoice, 'customer': Customer, 'product': Product,
-    'productcategory': ProductCategory, 'rmastatus': RmaStatus,
+    'invoice': Invoice, 'customer': Customer, 'customertag': CustomerTag, 'customertagcustomerrel': CustomerTagCustomerRel,
+    'product': Product, 'productcategory': ProductCategory, 'rmastatus': RmaStatus,
     'rmastage': RmaStage, 'rma': Rma, 'picking': Picking, 'pickingproduct': PickingProduct,
     'rmaproduct': RmaProduct, 'country': Country, 'commercial': Commercial,
-    'productbrand': ProductBrand, 'productbrandcountryrel': ProductBrandCountryRel}#, 'post': Post}
+    'productbrand': ProductBrand, 'productbrandcountryrel': ProductBrandCountryRel, 
+    'order': Order, 'orderproduct': OrderProduct}#, 'post': Post}
 
 MASTER_CLASSES = {'commercial': Commercial,'productcategory': ProductCategory,
                   'rmastatus': RmaStatus, 'rmastage': RmaStage,
                   'country': Country, 'productbrand': ProductBrand}
 
-DEPENDENT_CLASSES = {'invoice': Invoice, 'customer': Customer, 'product': Product,
-                     'picking': Picking, 'pickingproduct': PickingProduct,
+DEPENDENT_CLASSES = {'invoice': Invoice, 'customer': Customer, 'customertag': CustomerTag, 'customertagcustomerrel': CustomerTagCustomerRel,
+                     'product': Product, 'picking': Picking, 'pickingproduct': PickingProduct,
                      'rma': Rma, 'rmaproduct': RmaProduct,
-                     'productbrandcountryrel': ProductBrandCountryRel}
+                     'productbrandcountryrel': ProductBrandCountryRel, 'order':Order,
+                     'orderproduct': OrderProduct}
+    

--- a/project-addons/vt_flask_middleware/invoice.py
+++ b/project-addons/vt_flask_middleware/invoice.py
@@ -30,4 +30,3 @@ class Invoice(SyncModel):
 
     def __unicode__(self):
         return u"%s - %s" % (self.odoo_id, self.number)
-

--- a/project-addons/vt_flask_middleware/order.py
+++ b/project-addons/vt_flask_middleware/order.py
@@ -11,7 +11,8 @@ class Order(SyncModel):
     name = CharField(max_length=30)
     state = CharField(max_length=15)
     partner_id = ForeignKeyField(Customer, on_delete="CASCADE")
-    total_amount = FloatField(default=0.0)
+    amount_total= FloatField(default=0.0)
+    amount_untaxed = FloatField(default=0.0)
     date_order = DateTimeField(formats=['%Y-%m-%d %H:%M:%S'])
     client_order_ref = CharField(max_length=50, null=True)
 
@@ -25,7 +26,7 @@ class OrderProduct(SyncModel):
     odoo_id = IntegerField(unique=True)
     product_id = ForeignKeyField(Product, on_delete='CASCADE')
     product_qty = IntegerField()
-    total_price = FloatField()
+    price_subtotal = FloatField(default=0.0)
     order_id = ForeignKeyField(Order, on_delete='CASCADE')
 
     MOD_NAME = 'orderproduct'

--- a/project-addons/vt_flask_middleware/order.py
+++ b/project-addons/vt_flask_middleware/order.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from peewee import CharField, IntegerField, DateTimeField, ForeignKeyField, FloatField
+from app import app
+from customer import Customer
+from product import Product
+from database import SyncModel
+
+
+class Order(SyncModel):
+    odoo_id = IntegerField(unique=True)
+    name = CharField(max_length=30)
+    state = CharField(max_length=15)
+    partner_id = ForeignKeyField(Customer, on_delete="CASCADE")
+    total_amount = FloatField(default=0.0)
+    date_order = DateTimeField(formats=['%Y-%m-%d %H:%M:%S'])
+    client_order_ref = CharField(max_length=50, null=True)
+
+    MOD_NAME = 'order'
+
+    def __unicode__(self):
+        return u'%s' % self.name
+
+
+class OrderProduct(SyncModel):
+    odoo_id = IntegerField(unique=True)
+    product_id = ForeignKeyField(Product, on_delete='CASCADE')
+    product_qty = IntegerField()
+    total_price = FloatField()
+    order_id = ForeignKeyField(Order, on_delete='CASCADE')
+
+    MOD_NAME = 'orderproduct'
+
+    def __unicode__(self):
+        return u'%s - %s' % (self.product_id, self.order_id)

--- a/project-addons/vt_flask_middleware/rma.py
+++ b/project-addons/vt_flask_middleware/rma.py
@@ -16,6 +16,7 @@ class RmaStatus(SyncModel):
     def __unicode__(self):
         return self.name
 
+
 class RmaStage(SyncModel):
     MOD_NAME = 'rmastage'
 

--- a/project-addons/vt_flask_middleware/xmlrpc_interface.py
+++ b/project-addons/vt_flask_middleware/xmlrpc_interface.py
@@ -3,7 +3,8 @@ from app import app
 from database import db
 from user import User
 from country import Country
-from customer import Customer
+from customer import Customer, CustomerTag, CustomerTagCustomerRel
+from order import Order, OrderProduct
 from invoice import Invoice
 from commercial import Commercial
 from product import Product, ProductCategory
@@ -12,6 +13,9 @@ from auth import auth
 from sync_log import SyncLog
 from flask import session
 from utils import parse_many2one_vals
+import xmlrpclib
+import datetime
+import logging
 from implemented_models import MODELS_CLASS
 handler = XMLRPCHandler('xmlrpc')
 handler.connect(app, '/xmlrpc')
@@ -106,5 +110,13 @@ def unlink(user_id, password, model, odoo_id):
             for rma in Rma.select().where(
                     Rma.stage_id == rec.id):
                 rma.delete_instance()
+        elif model == 'customertagcustomerrel':
+            for customertagcustomerrel in CustomerTagCustomerRel.select().where(
+                    CustomerTagCustomerRel.odoo_id == rec.odoo_id):
+                customertagcustomerrel.delete_instance()
+        elif model == 'order':
+            for order in Order.select().where(
+                Order.partner_id == rec.id):
+                order.delete_instance()
         rec.delete_instance()
     return True


### PR DESCRIPTION
Hemos incluido la exportación de etiquetas de cliente y de pedidos (con las lineas del pedido incluidas). Tambien hemos creado una tabla intermedia de etiquetas para relacionarlas con los clientes.

- [IMP] 'flask_middleware_connector': Incluido eventos de exportacion de pedidos y lineas de pedidos
- [IMP] 'vt_flask_middleware': Incluido modelo de pedido y lineas de pedido en Flask
- [IMP] 'vt_flask_middleware': Incluido modelos 'order', 'orderproduct', 'customertag' y 'customertagcustomerrel' en Flask. Implementada la eliminacion de pedidos y etiquetas relacionadas con el cliente
- [IMP] 'vt_flask_middleware': Incluidos modelos de etiquetas y tabla intermedia de etiquetas con clientes en Flask
- [IMP] 'flask_middleware_connector': Incluidos eventos de etiquetas y tabla intermedia de etiquetas.
- [IMP] 'flask_middleware_connector': Incluidas mas condiciones y modificados los 
- [IMP] 'flask_middleware_connector': Incluido pedidos, etiquetas y tabla intermedia de etiquetas y clientes en el exportador

En cuanto al PR pasado, podemos empezar a mirar si tenemos que incluir el paquete que nos limita de external dentro del repo, así vamos optimizando alguna cosilla.