### PR TITLE
Hotfix Flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -131,7 +131,7 @@ def delay_export_partner_create(session, model_name, record_id, vals):
                 for line in picking.move_lines:
                         export_pickingproduct.delay(session, 'stock.move', line.id,
                                                     priority=10, eta=240)
-        elif vals.get("active", False) or vals.get("prospective", False) and partner.web:
+        elif (vals.get("active", False) or vals.get("prospective", False)) and partner.web:
             export_partner.delay(session, model_name, record_id, priority=1,
                                  eta=60)
 


### PR DESCRIPTION
Se están exportando clientes a Flask cuando se creaban y no tenían el campo web activo, esto era debido a que la comprobación del "and" tenia prioridad sobre la del "or" y se me olvido poner un paréntesis para evitar esto.