### PR TITLE
Hotfix Flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -131,7 +131,8 @@ def delay_export_partner_create(session, model_name, record_id, vals):
                 for line in picking.move_lines:
                         export_pickingproduct.delay(session, 'stock.move', line.id,
                                                     priority=10, eta=240)
-        elif (vals.get("active", False) or vals.get("prospective", False)) and partner.web:
+        elif (vals.get("active", False) or vals.get('prospective', False)) and vals.get('web', False) and \
+                partner.web:
             export_partner.delay(session, model_name, record_id, priority=1,
                                  eta=60)
 
@@ -264,8 +265,9 @@ def delay_export_partner_write(session, model_name, record_id, vals):
                     export_pickingproduct.delay(session, 'stock.move', line.id,
                                                 priority=10, eta=240)
 
-        elif ((vals.get("active", False) or vals.get('prospective', False)) and partner.web and \
-                vals.get('is_company', partner.is_company)):
+        elif (vals.get("active", False) or vals.get('prospective', False)) and vals.get('web', False) and \
+                partner.web and \
+                vals.get('is_company', partner.is_company):
             export_partner.delay(session, model_name, record_id, priority=1, eta=60)
             for contact in contacts:
                 export_partner.delay(session, model_name, contact.id, priority=1,
@@ -396,6 +398,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
                             for sale in sales:
                                 update_order.delay(session, 'sale.order', sale.id, priority=5, eta=180)
                         break
+
 
 @on_record_unlink(model_names='res.partner')
 def delay_unlink_partner(session, model_name, record_id):

--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -275,7 +275,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
                 export_partner_tag_rel.delay(session, 'res.partner.res.partner.category.rel',
                                              record_id, tag.id, priority=10, eta=60)
 
-            sales = session.env['sale.order'].search([('commercial_partner_id', '=', partner.id),
+            sales = session.env['sale.order'].search([('partner_id', 'child_of', [record_id]),
                                                       ('company_id', '=', 1),
                                                       ('state', 'in', ('done', 'progress', 'draft', 'reserve'))])
             for sale in sales:

--- a/project-addons/flask_middleware_connector/events/partner_events.py
+++ b/project-addons/flask_middleware_connector/events/partner_events.py
@@ -91,7 +91,7 @@ def delay_export_partner_create(session, model_name, record_id, vals):
             tags = partner.category_id
             for tag in tags:
                 export_partner_tag_rel.delay(session, 'res.partner.res.partner.category.rel',
-                                             record_id, tag.id, priority=10, eta=60)
+                                             record_id, tag.id, priority=10, eta=120)
 
             sales = session.env['sale.order'].search([('partner_id', 'child_of', [record_id]),
                                                       ('company_id', '=', 1),
@@ -138,7 +138,7 @@ def delay_export_partner_create(session, model_name, record_id, vals):
             tags = partner.category_id
             for tag in tags:
                 export_partner_tag_rel.delay(session, 'res.partner.res.partner.category.rel',
-                                             record_id, tag.id, priority=10, eta=60)
+                                             record_id, tag.id, priority=10, eta=120)
 
             sales = session.env['sale.order'].search([('partner_id', 'child_of', [record_id]),
                                                       ('company_id', '=', 1),
@@ -225,7 +225,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
             tags = partner.category_id
             for tag in tags:
                 export_partner_tag_rel.delay(session, 'res.partner.res.partner.category.rel',
-                                             record_id, tag.id, priority=10, eta=60)
+                                             record_id, tag.id, priority=10, eta=120)
 
             sales = session.env['sale.order'].search([('partner_id', 'child_of', [record_id]),
                                                       ('company_id', '=', 1),
@@ -273,7 +273,7 @@ def delay_export_partner_write(session, model_name, record_id, vals):
             tags = partner.category_id
             for tag in tags:
                 export_partner_tag_rel.delay(session, 'res.partner.res.partner.category.rel',
-                                             record_id, tag.id, priority=10, eta=60)
+                                             record_id, tag.id, priority=10, eta=120)
 
             sales = session.env['sale.order'].search([('partner_id', 'child_of', [record_id]),
                                                       ('company_id', '=', 1),

--- a/project-addons/vt_flask_middleware/order.py
+++ b/project-addons/vt_flask_middleware/order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from peewee import CharField, IntegerField, DateTimeField, ForeignKeyField, DecimalField
+from peewee import CharField, IntegerField, DateTimeField, ForeignKeyField, DecimalField, BooleanField
 from app import app
 from customer import Customer
 from product import Product
@@ -18,7 +18,7 @@ class Order(SyncModel):
     shipping_street = CharField(max_length=100, null=True)
     shipping_zip = CharField(max_length=10, null=True)
     shipping_city = CharField(max_length=50, null=True)
-    shipping_state = CharField(max_length=30, null=True)
+    shipping_state = CharField(max_length=100, null=True)
     shipping_country = CharField(max_length=50, null=True)
 
     MOD_NAME = 'order'


### PR DESCRIPTION
He realizado un par de cambios en eventos de clientes y en pedidos. Lo de clientes es bastante urgente ya que no se pueden pasar clientes potenciales con campo web a activos. Si pudieras mergearlo y meterlo en producción con un reinicio a las 14:30 seria estupendo.