### PR TITLE
Promociones en pedidos

### DIFF
--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -85,7 +85,7 @@ class SaleOrder(osv.osv):
         if order.state == 'reserve':
             order.order_reserve()
 
-        taxes = order.order_line.mapped('tax_id')
+        taxes = order.order_line[0].tax_id
         for line in order.order_line:
             if line.promotion_line:
                 line.tax_id = taxes

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -85,4 +85,10 @@ class SaleOrder(osv.osv):
         if order.state == 'reserve':
             order.order_reserve()
 
+        taxes = order.order_line.mapped('tax_id')
+        for line in order.order_line:
+            if line.promotion_line:
+                line.tax_id = taxes
+                line.sequence = 999
+
         return res


### PR DESCRIPTION
- [IMP] 'sale_promotions_extend': Incluido impuestos al añadir línea de promoción en pedidos y modificada secuencia para que aparezca al final