### PR TITLE
[Hotfix] Flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/picking_events.py
+++ b/project-addons/flask_middleware_connector/events/picking_events.py
@@ -194,7 +194,7 @@ def delay_export_picking_line_create(session, model_name, record_id, vals=None):
 
 @on_record_write(model_names='stock.move')
 def delay_export_picking_line_write(session, model_name, record_id, vals):
-    up_fields = ["parent_id", "product_uom_qty", "product_id"]
+    up_fields = ["parent_id", "product_uom_qty", "product_id", "picking_id"]
     move_line = session.env[model_name].browse(record_id)
     if move_line.picking_id.partner_id.commercial_partner_id.web \
             and move_line.picking_id.partner_id.commercial_partner_id.active \


### PR DESCRIPTION
- [FIX] 'flask_middleware_connector': Tener en cuenta si se modifica el picking_id asociado a las líneas para que se haga un update_pickingproduct (en el caso de que se genere un albarán parcial)