### PR TITLE
[Hotfix] Flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/order_events.py
+++ b/project-addons/flask_middleware_connector/events/order_events.py
@@ -83,7 +83,7 @@ def delay_export_order_write(session, model_name, record_id, vals):
                  "order_line", "partner_shipping_id", "delivery_type"]
     if order.partner_id.web or order.partner_id.commercial_partner_id.web:
         job = session.env['queue.job'].search([('func_string', 'like', '%, ' + str(order.id) + ')%'),
-                                               ('model_name', '=', model_name)], order='date_created desc', limit=1)
+                                               ('model_name', '=', model_name)], order='date_created desc, id desc', limit=1)
         if 'state' in vals.keys() and vals['state'] == 'cancel':
             unlink_order.delay(session, model_name, record_id, priority=7, eta=80)
         elif 'state' in vals.keys() and vals['state'] in ('draft', 'reserve') and job.name and 'unlink' in job.name:
@@ -93,7 +93,7 @@ def delay_export_order_write(session, model_name, record_id, vals):
         elif order.state in ('draft', 'reserve', 'progress', 'done', 'shipping_except', 'invoice_except'):
             for field in up_fields:
                 if field in vals:
-                    update_order.delay(session, model_name, record_id, priority=5, eta=120)
+                    update_order.delay(session, model_name, record_id, priority=5, eta=80)
                     break
 
 

--- a/project-addons/flask_middleware_connector/events/picking_events.py
+++ b/project-addons/flask_middleware_connector/events/picking_events.py
@@ -185,7 +185,6 @@ def delay_export_picking_line_create(session, model_name, record_id, vals=None):
     move_line = session.env[model_name].browse(record_id)
     if move_line.picking_id.partner_id.commercial_partner_id.web \
             and move_line.picking_id.partner_id.commercial_partner_id.active \
-            and move_line.picking_id.partner_id.active \
             and move_line.picking_id.picking_type_id.code == 'outgoing' \
             and not move_line.picking_id.not_sync \
             and move_line.picking_id.company_id.id == 1:
@@ -198,7 +197,6 @@ def delay_export_picking_line_write(session, model_name, record_id, vals):
     move_line = session.env[model_name].browse(record_id)
     if move_line.picking_id.partner_id.commercial_partner_id.web \
             and move_line.picking_id.partner_id.commercial_partner_id.active \
-            and move_line.picking_id.partner_id.active \
             and move_line.picking_id.picking_type_id.code == 'outgoing'\
             and not move_line.picking_id.not_sync \
             and move_line.picking_id.company_id.id == 1:
@@ -212,7 +210,6 @@ def delay_export_picking_line_unlink(session, model_name, record_id):
     move_line = session.env[model_name].browse(record_id)
     if move_line.picking_id.partner_id.commercial_partner_id.web \
             and move_line.picking_id.partner_id.commercial_partner_id.active \
-            and move_line.picking_id.partner_id.active \
             and move_line.picking_id.picking_type_id.code == 'outgoing' \
             and not move_line.picking_id.not_sync \
             and move_line.picking_id.company_id.id == 1:


### PR DESCRIPTION
- [FIX]'flask_middleware_connector': ajuste de tiempo y ajuste de consulta en pedidos
- [FIX] 'flask_middleware_connector': Modificación para obtener datos de la empresa matriz en vez del partner asociado al picking (que puede ser un contacto o dropship)