### PR TITLE
Cambios realizados

### DIFF
--- a/project-addons/custom_account/stock.py
+++ b/project-addons/custom_account/stock.py
@@ -230,6 +230,7 @@ class PurchaseLineInvoice(models.TransientModel):
         inv_id = super(PurchaseLineInvoice, self).\
             _make_invoice_by_partner(partner, orders, lines_ids)
         invoice = self.env["account.invoice"].browse(inv_id)
+        invoice.payment_mode_id = partner.supplier_payment_mode.id
         invoice.button_reset_taxes()
         return inv_id
 

--- a/project-addons/flask_middleware_connector/unit/backend_adapter.py
+++ b/project-addons/flask_middleware_connector/unit/backend_adapter.py
@@ -66,9 +66,9 @@ class MiddlewareCRUDAdapter(CRUDAdapter):
             try:
                 result = self.server.create(self.uid, self.password, model,
                                             data)
-            except:
+            except Exception as err:
                 _logger.error("create(%s, %s) failed", model, data)
-                raise
+                raise RetryableJobError(err)
             else:
                 _logger.debug("create(%s, %s) returned %s in %s seconds",
                               model, data, result,
@@ -100,9 +100,9 @@ class MiddlewareCRUDAdapter(CRUDAdapter):
             try:
                 result = self.server.write(self.uid, self.password, model, id,
                                            data)
-            except:
+            except Exception as err:
                 _logger.error("write(%s, %s, %s) failed", model, id, data)
-                raise
+                raise RetryableJobError(err)
             else:
                 _logger.debug("write(%s, %s, %s) returned %s in %s seconds",
                               model, id, data, result,

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -87,7 +87,7 @@ class SaleOrder(osv.osv):
         if order.state == 'reserve':
             order.order_reserve()
 
-        taxes = order.order_line[0].tax_id
+        taxes = order.order_line.filtered(lambda l: l.tax_id.id is not False)[0].tax_id
         for line in order.order_line:
             if line.promotion_line:
                 line.tax_id = taxes


### PR DESCRIPTION
- [IMP]'flask_middleware_connector': Se recoge una excepción para volver a reintentar los trabajos fallidos
Hemos introducido este cambio para minimizar los errores que nos estaban dando al crear  pedidos muy grandes, se hacían antes las líneas que el pedido y faltaban en la web. También pasaba al dividir un albarán muy rápido. Lo ves bien así?, si no buscamos otra alternativa pero esta nos pareció la mejor.

-  [FIX]'sale_promotions_extend': cambiada la forma de coger las tasas para las líneas de promoción para evitar generarlas vacías.
Había casos en los que al meter la línea de promoción no rellenaba las tasas aunque si que pasaba por la función, con lo cual supusimos que al coger la tasa de la primera línea no conseguía ninguna.

-  [FIX]'custom_account': arrastrar método de pago de proveedor a la factura