### PR TITLE
Análisis factura por sede/contacto

### DIFF
--- a/project-addons/custom_account/__openerp__.py
+++ b/project-addons/custom_account/__openerp__.py
@@ -52,6 +52,7 @@
              'product_view.xml',
              'report/sale_report_view.xml',
              'voucher_view.xml',
-             'account_treasury_forecast_view.xml'],
+             'account_treasury_forecast_view.xml',
+             'report/account_invoice_contact_report_view.xml'],
     "installable": True
 }

--- a/project-addons/custom_account/i18n/es.po
+++ b/project-addons/custom_account/i18n/es.po
@@ -802,3 +802,116 @@ msgstr "\nEl mandato de adeudo directo SEPA con referencia '%s' para la empresa 
 #, python-format
 msgid "\nThe mandate with reference '%s' for partner '%s' has type set to 'One-Off' and it has a last debit date set to '%s', so we can't use it."
 msgstr "\nEl mandato con referencia '%s' para la empresa '%s' tipo como 'Único', ya tiene como fecha de último cobro '%s', por lo que no se puede usar."
+
+#. module: custom_account
+#: model:ir.actions.act_window,name:custom_account.action_account_invoice_contact_report
+#: model:ir.ui.menu,name:custom_account.menu_action_account_invoice_contact_report
+msgid "Invoices Contact Analysis"
+msgstr "Análisis de facturas (contactos)"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,number:0
+msgid "Number"
+msgstr "Número"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,date:0
+msgid "Date"
+msgstr "Fecha"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,period_id:0
+msgid "Period"
+msgstr "Período"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,partner_id:0
+msgid "Partner Company"
+msgstr "Empresa matriz"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,contact_id:0
+msgid "Partner contact"
+msgstr "Contacto"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,currency_id:0
+msgid "Currency"
+msgstr "Divisa"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,type:0
+msgid "Type"
+msgstr "Tipo"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,state:0
+msgid "State"
+msgstr "Estado"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,price_total:0
+msgid "Total Without Tax"
+msgstr "Total base"
+
+#. module: custom_account
+#: field:account.invoice.contact.report,benefit:0
+msgid "Benefit"
+msgstr "Beneficio"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "This Year"
+msgstr "Este año"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Supplier"
+msgstr "Proveedor"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Refund"
+msgstr "Factura rectificativa"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Sales Team"
+msgstr "Equipo de ventas"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Without ef"
+msgstr "Sin ef"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Status"
+msgstr "Estado"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Company"
+msgstr "Compañía"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Period"
+msgstr "Período"
+
+#. module: custom_account
+#: view:account.invoice.contact.report:custom_account.view_account_invoice_contact_report_search
+msgid "Due Month"
+msgstr "Mes de vencimiento"
+
+

--- a/project-addons/custom_account/report/__init__.py
+++ b/project-addons/custom_account/report/__init__.py
@@ -22,3 +22,4 @@ from . import account_invoice_report
 from . import sale_report
 from . import purchase_report
 from . import account_followup_print
+from . import account_invoice_contact_report

--- a/project-addons/custom_account/report/account_invoice_contact_report.py
+++ b/project-addons/custom_account/report/account_invoice_contact_report.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Pexego All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields, tools
+
+
+class AccountInvoiceContactReport(models.Model):
+
+    _name = 'account.invoice.contact.report'
+    _description = "Contact Invoices Statistics"
+    _auto = False
+    _rec_name = 'date'
+    _order = 'date desc'
+
+    number = fields.Char('Number', readonly=True)
+    date = fields.Date('Date', readonly=True)
+    date_due = fields.Date('Due Date', readonly=True)
+    period_id = fields.Many2one('account.period', 'Period', domain=[('state', '<>', 'done')], readonly=True)
+    partner_id = fields.Many2one('res.partner', 'Partner Company', readonly=True)
+    contact_id = fields.Many2one('res.partner', 'Partner Contact', readonly=True)
+    section_id = fields.Many2one('crm.case.section', 'Sales Team')
+    currency_id = fields.Many2one('res.currency', 'Currency', readonly=True)
+    type = fields.Selection([
+        ('out_invoice', 'Customer Invoice'),
+        ('in_invoice', 'Supplier Invoice'),
+        ('out_refund', 'Customer Refund'),
+        ('in_refund', 'Supplier Refund'),
+    ], 'Type', readonly=True)
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('proforma', 'Pro-forma'),
+        ('proforma2', 'Pro-forma'),
+        ('open', 'Open'),
+        ('paid', 'Done'),
+        ('cancel', 'Cancelled')
+    ], 'Invoice Status', readonly=True)
+    price_total = fields.Float('Total Without Tax', readonly=True)
+    benefit = fields.Float('Benefit', readonly=True)
+
+    def _select(self):
+        select_str = """
+            SELECT  sub.id, sub.number, sub.partner_id, sub.contact_id, 
+                    sub.date, sub.date_due, sub.section_id, sub.period_id, sub.type, sub.state, sub.currency_id,
+                    sub.price_total / cr.rate as price_total, 
+                    CASE WHEN sub.type IN ('out_refund') THEN -sub.benefit
+                         WHEN sub.type IN ('out_invoice') THEN sub.benefit
+                         ELSE 0 END as benefit
+        """
+        return select_str
+
+    def _sub_select(self):
+        select_str = """
+                SELECT  ai.id, ai.number AS number, ai.partner_id, coalesce(rp_contact.id, ai.partner_id) AS contact_id,
+                        ai.date_invoice AS date, ai.date_due, ai.section_id, ai.period_id, ai.type, ai.state, ai.currency_id, 
+                        SUM(CASE
+                                WHEN ai.type::text = ANY (ARRAY['out_refund'::character varying::text, 'in_invoice'::character varying::text])
+                                THEN - ail.price_subtotal
+                                ELSE ail.price_subtotal
+                            END) AS price_total,
+                        SUM(ail.quantity * ail.price_unit * (100.0-ail.discount) / 100.0) - sum(coalesce(ail.cost_unit, 0)*ail.quantity) as benefit
+        """
+        return select_str
+
+    def _from(self):
+        from_str = """
+                FROM account_invoice_line ail
+                JOIN account_invoice ai ON ai.id = ail.invoice_id
+                LEFT JOIN sale_order_line_invoice_rel solir ON solir.invoice_id = ail.id
+                LEFT JOIN sale_order_line sol ON  sol.id = solir.order_line_id
+                LEFT JOIN sale_order so ON so.id = sol.order_id
+                LEFT JOIN res_partner rp_contact ON rp_contact.id = so.partner_shipping_id 
+        """
+        return from_str
+
+    def _group_by(self):
+        group_by_str = """
+                GROUP BY ai.id, ai.partner_id, coalesce(rp_contact.id, ai.partner_id), ai.number, ai.date_invoice, 
+                ai.section_id, ai.period_id, ai.currency_id, ai.type, ai.state
+        """
+        return group_by_str
+
+    def init(self, cr):
+        # self._table = account_invoice_contact_report
+        tools.drop_view_if_exists(cr, self._table)
+        cr.execute("""CREATE or REPLACE VIEW %s as (
+            WITH currency_rate (currency_id, rate, date_start, date_end) AS (
+                SELECT r.currency_id, r.rate, r.name AS date_start,
+                    (SELECT name FROM res_currency_rate r2
+                     WHERE r2.name > r.name AND
+                           r2.currency_id = r.currency_id
+                     ORDER BY r2.name ASC
+                     LIMIT 1) AS date_end
+                FROM res_currency_rate r
+            )
+            %s
+            FROM (
+                %s %s %s
+            ) AS sub
+            JOIN currency_rate cr ON
+                (cr.currency_id = sub.currency_id AND
+                 cr.date_start <= COALESCE(sub.date, NOW()) AND
+                 (cr.date_end IS NULL OR cr.date_end > COALESCE(sub.date, NOW())))
+        )""" % (
+                    self._table,
+                    self._select(), self._sub_select(), self._from(), self._group_by()))
+

--- a/project-addons/custom_account/report/account_invoice_contact_report_view.xml
+++ b/project-addons/custom_account/report/account_invoice_contact_report_view.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record id="view_account_invoice_contact_report_search" model="ir.ui.view">
+        <field name="name">account.invoice.contact.report.search</field>
+        <field name="model">account.invoice.contact.report</field>
+        <field name="arch" type="xml">
+            <search string="Invoices Analysis">
+                <field name="date"/>
+                <filter string="This Year" name="thisyear" domain="['|', ('date', '=', False), '&amp;',('date','&lt;=', time.strftime('%%Y-12-31')),('date','&gt;=',time.strftime('%%Y-01-01'))]" help="Journal invoices with period in current year"/>
+                <separator/>
+                <filter string="Customer" name="customer" domain="['|', ('type','=','out_invoice'),('type','=','out_refund')]"/>
+                <filter string="Supplier" domain="['|', ('type','=','in_invoice'),('type','=','in_refund')]"/>
+                <separator/>
+                <filter string="Invoice" domain="['|', ('type','=','out_invoice'),('type','=','in_invoice'), ('state', '!=', 'cancel')]"/>
+                <filter string="Refund" domain="['|', ('type','=','out_refund'),('type','=','in_refund')]"/>
+                <field name="partner_id" operator="child_of"/>
+                <filter string="Sales Team" domain="[]" context="{'group_by':'section_id'}" groups="base.group_multi_salesteams"/>
+                <group expand="1" string="Group By">
+                    <filter name="without_ef" string="Without ef" domain="[('number','not like','%_ef%')]"/>
+                    <filter string="Status" context="{'group_by':'state'}"/>
+                    <filter string="Company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
+                    <separator orientation="vertical" />
+                    <filter string="Period" context="{'group_by':'period_id'}"/>
+                    <filter string="Due Month" context="{'group_by':'date_due:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="view_account_invoice_contact_report_graph" model="ir.ui.view">
+         <field name="name">account.invoice.contact.report.graph</field>
+         <field name="model">account.invoice.contact.report</field>
+         <field name="arch" type="xml">
+             <graph string="Invoices Contact Analysis" type="pivot">
+                 <field name="date" type="row"/>
+                 <field name="period_id" type="col"/>
+                 <field name="price_total" type="measure"/>
+             </graph>
+         </field>
+    </record>
+
+    <record id="action_account_invoice_contact_report" model="ir.actions.act_window">
+        <field name="name">Invoices Contact Analysis</field>
+        <field name="res_model">account.invoice.contact.report</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">graph</field>
+        <field name="search_view_id" ref="view_account_invoice_contact_report_search"/>
+        <field name="domain">[('state', 'not in', ['draft', 'cancel','proforma','proforma2'])]</field>
+        <field name="context">{'search_default_customer':1, 'search_default_without_ef':1, 'group_by':['date'], 'group_by_no_leaf':1, 'search_default_year': 1}</field>
+    </record>
+
+    <menuitem action="action_account_invoice_contact_report" id="menu_action_account_invoice_contact_report" parent="account.menu_finance_reporting" sequence="1"/>
+    
+</data>
+</openerp>

--- a/project-addons/vt_flask_middleware/rappel.py
+++ b/project-addons/vt_flask_middleware/rappel.py
@@ -19,8 +19,8 @@ class Rappel(SyncModel):
 class RappelCustomerInfo(SyncModel):
 
     odoo_id = IntegerField(unique=True)
-    rappel_id = ForeignKeyField(Rappel)
-    partner_id = ForeignKeyField(Customer)
+    rappel_id = ForeignKeyField(Rappel, on_delete='CASCADE')
+    partner_id = ForeignKeyField(Customer, on_delete='CASCADE')
     date_start = CharField(max_length=15)
     date_end = CharField(max_length=15)
     amount = FloatField(default=0.0)


### PR DESCRIPTION
- [DEV] 'custom_account': Nuevo informe de análisis para valorar la facturación por sede de empresa. Falta definir los filtros de búsqueda y afinar la consulta para cuadrar con el análisis ya existente de facturas por empresa

- [IMP] 'custom_account': Añadida vista search para poder filtrar el informe de facturas por contactos

- [IMP] 'custom_account': Modificada la secuencia del menú del informe de análisis de facturas de contactos y traducciones
-----------------------------------
- [FIX] 'vt_flask_middleware': Modificada definición de las fk en rappelcustomerinfo con borrado en cascada

Este último es simplemente para añadir esa propiedad en las foreign keys por código, pero ya lo hemos modificado en la base de datos.