### PR TITLE
Nuevo campo flask y cambios menores

### DIFF
--- a/project-addons/custom_account/security/ir.model.access.csv
+++ b/project-addons/custom_account/security/ir.model.access.csv
@@ -5,3 +5,4 @@
 "base.access_ir_exports_line_group_system","ir_exports_line group_system","base.model_ir_exports_line","base.group_user",1,1,1,0
 "access_ir_exports_group_system_manager","ir_exports group_system","base.model_ir_exports","base.group_system",1,1,1,1
 "access_ir_exports_line_group_system_manager","ir_exports_line group_system","base.model_ir_exports_line","base.group_system",1,1,1,1
+"access_account_invoice_contact_report","account.invoice.contact.report","model_account_invoice_contact_report","account.group_account_invoice",1,0,0,0

--- a/project-addons/flask_middleware_connector/events/order_events.py
+++ b/project-addons/flask_middleware_connector/events/order_events.py
@@ -143,6 +143,7 @@ class OrderProductExporter(Exporter):
                 "deposit": orderproduct.deposit,
                 "pack_parent_line_id": orderproduct.pack_parent_line_id.id,
                 "discount": orderproduct.discount,
+                "price_unit": orderproduct.price_unit,
         }
         if mode == "insert":
             return self.backend_adapter.insert(vals)
@@ -169,7 +170,7 @@ def delay_export_orderproduct_create(session, model_name, record_id, vals):
 def delay_export_orderproduct_write(session, model_name, record_id, vals):
     orderproduct = session.env[model_name].browse(record_id)
     up_fields = ["product_id", "product_uom_qty", "price_unit", "discount", "order_id",
-                 "no_rappel", "deposit", "pack_parent_line_id"]
+                 "no_rappel", "deposit", "pack_parent_line_id", "price_unit"]
     if orderproduct.order_id.partner_id.web or orderproduct.order_id.partner_id.commercial_partner_id.web:
         for field in up_fields:
             if field in vals:

--- a/project-addons/product_pack/purchase.py
+++ b/project-addons/product_pack/purchase.py
@@ -41,7 +41,7 @@ class purchase_order_line(orm.Model):
             'purchase.order.line', 'pack_parent_line_id', 'Lines in pack'
         ),
     }
-    _order = 'order_id desc, sequence, id'
+    _order = 'order_id desc, id, sequence'
     _defaults = {
         'pack_depth': 0,
     }

--- a/project-addons/product_pack/purchase.py
+++ b/project-addons/product_pack/purchase.py
@@ -41,7 +41,7 @@ class purchase_order_line(orm.Model):
             'purchase.order.line', 'pack_parent_line_id', 'Lines in pack'
         ),
     }
-    _order = 'order_id desc, id, sequence'
+    _order = 'order_id desc, id'
     _defaults = {
         'pack_depth': 0,
     }

--- a/project-addons/vt_flask_middleware/order.py
+++ b/project-addons/vt_flask_middleware/order.py
@@ -38,6 +38,7 @@ class OrderProduct(SyncModel):
     deposit = BooleanField(default=False)
     pack_parent_line_id = IntegerField(null=True)
     discount = DecimalField(max_digits=2, decimal_places=2, rounding='ROUND_HALF_EVEN')
+    price_unit = DecimalField(max_digits=2, decimal_places=2, rounding='ROUND_HALF_EVEN')
 
     MOD_NAME = 'orderproduct'
 


### PR DESCRIPTION
- [IMP] 'custom_account': Añadido permisos para ver el análisis de facturas de contactos
- [IMP] 'vt_flask_middleware': Definición del campo price_unit de la línea de pedido en flask
- [IMP] 'flask_middleware_connector': Lógica sincronización campo price_unit de las líneas de pedido en flask
- [FIX] 'product_pack': Reordenación de las líneas de un pedido de compra para que no se coloque en la última posición la primera línea insertada

--------------------------------
Creación del campo en la base de datos de flask:
`ALTER TABLE public.orderproduct ADD COLUMN price_unit NUMERIC NOT NULL DEFAULT 0.0;`