### PR TITLE
Números de Serie

### DIFF
--- a/project-addons/custom_account/stock_view.xml
+++ b/project-addons/custom_account/stock_view.xml
@@ -35,7 +35,7 @@
             <field name="inherit_id" ref="sale_quick_payment.sale_order_view_form" />
             <field name="arch" type="xml">
                 <button name="%(sale_quick_payment.open_pay_sale_order)d" position="attributes">
-                  <attribute name="states">draft,sent,reserve</attribute>
+                  <attribute name="states">draft,sent,reserve,progress,done</attribute>
                 </button>
             </field>
         </record>

--- a/project-addons/stock_custom/__openerp__.py
+++ b/project-addons/stock_custom/__openerp__.py
@@ -30,7 +30,7 @@
                  "custom_account", "picking_incidences",
                  "reserve_without_save_sale", "sale_display_stock",
                  "stock_reserve_sale", "product_brand", "product_pack",
-                 "product_stock_unsafety"],
+                 "product_stock_unsafety","stock"],
     "data" : ["ir_attachment_view.xml",
               "stock_custom_report.xml",
               "report/stock_report.xml",

--- a/project-addons/stock_custom/i18n/es.po
+++ b/project-addons/stock_custom/i18n/es.po
@@ -333,3 +333,19 @@ msgstr "Equipo de ventas"
 #: field:product.product,ref_visiotech:0
 msgid "Visiotech reference"
 msgstr "Referencia Visiotech"
+
+#. module: stock_custom
+#: field:stock.production.lot,partner_id:0
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: stock_custom
+#: field:stock.production.lot,lot_notes:0
+#: view:stock.production.lot:view_production_lot_form_customers
+msgid "Notes"
+msgstr "Notas"
+
+#. module: stock_custom
+#: help:stock.production.lot,partner_id:0
+msgid "The last customer in possession of the product"
+msgstr "El último cliente en posesión del producto"

--- a/project-addons/stock_custom/stock.py
+++ b/project-addons/stock_custom/stock.py
@@ -213,7 +213,7 @@ class stock_production_lot(models.Model):
         for lot in self:
             quant = self.env['stock.quant'].search([('lot_id', '=', lot.id)], order="id desc", limit=1)
             if quant and quant.history_ids:
-                lot.partner_id = quant.history_ids[0].partner_id
+                lot.partner_id = quant.history_ids[0].partner_id.commercial_partner_id
             else:
                 lot.partner_id = False
 

--- a/project-addons/stock_custom/stock.py
+++ b/project-addons/stock_custom/stock.py
@@ -211,7 +211,7 @@ class stock_production_lot(models.Model):
     @api.depends('quant_ids')
     def _get_partner_id(self):
         for lot in self:
-            quant = self.env['stock.quant'].search([('lot_id', '=', lot.id)], order="id", limit=1)
+            quant = self.env['stock.quant'].search([('lot_id', '=', lot.id)], order="id desc", limit=1)
             if quant and quant.history_ids:
                 lot.partner_id = quant.history_ids[0].partner_id
             else:

--- a/project-addons/stock_custom/stock.py
+++ b/project-addons/stock_custom/stock.py
@@ -199,3 +199,21 @@ class StockReservation(models.Model):
             if moves:
                 date_expected = moves[0].date_expected
             res.next_reception_date = date_expected
+
+
+class stock_production_lot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    partner_id = fields.Many2one('res.partner', string='Customer', compute='_get_partner_id', help='The last customer in possession of the product')
+    lot_notes = fields.Text('Notes')
+
+    @api.multi
+    @api.depends('quant_ids')
+    def _get_partner_id(self):
+        for lot in self:
+            quant = self.env['stock.quant'].search([('lot_id', '=', lot.id)], order="id", limit=1)
+            if quant and quant.history_ids:
+                lot.partner_id = quant.history_ids[0].partner_id
+            else:
+                lot.partner_id = False
+

--- a/project-addons/stock_custom/stock_view.xml
+++ b/project-addons/stock_custom/stock_view.xml
@@ -280,5 +280,35 @@
 
         <menuitem action="action_move_review_form" id="menu_move_review" parent="stock.menu_traceability" sequence="4" groups="stock.group_locations"/>
 
+        <record id="view_production_lot_form_customers" model="ir.ui.view">
+            <field name="name">stock.production.lot.form.customers</field>
+            <field name="model">stock.production.lot</field>
+            <field name="inherit_id" ref="stock.view_production_lot_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form//notebook" position="inside">
+                     <page string="Notes">
+                         <field name="lot_notes"/>
+                     </page>
+                </xpath>
+                <xpath expr="//form//group[@name='main_group']" position="inside">
+                    <group>
+                        <field name="partner_id"/>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_production_lot_tree_partner" model="ir.ui.view">
+            <field name="name">stock.production.lot.tree.partner</field>
+            <field name="model">stock.production.lot</field>
+            <field name="inherit_id" ref="stock.view_production_lot_tree"/>
+            <field name="arch" type="xml">
+                <field name="create_date" position="after">
+                    <field name="partner_id"/>
+                    <field name="lot_notes"/>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION

- [IMP]'custom_account': Añadido botón registrar pagos en pedidos en proceso
Este pequeño cambio no tiene nada que ver con los números de serie, pero se ha colado en esta rama.
- [IMP]'stock_custom': Añadido campos a las vistas de los números de serie 
- [FIX]'stock_custom': Arreglado orden descendente para coger el último cliente
- [FIX]'stock_custom': Recogemos el commercial_partner_id