### PR TITLE
Cambios pedidos xmlrpc

### DIFF
--- a/project-addons/custom_account/stock.py
+++ b/project-addons/custom_account/stock.py
@@ -192,7 +192,7 @@ class SaleOrder(models.Model):
                                                          context=context)
         if part and res.get('value', False):
             partner = self.pool['res.partner'].browse(cr, uid, part)
-            res['value']['partner_tags'] = [x.id for x in partner.category_id]
+            res['value']['partner_tags'] = [(6, 0, [x.id for x in partner.category_id])]
             if partner.section_id:
                 res['value']['section_id'] = partner.section_id.id
 

--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -42,3 +42,15 @@ msgstr "Algunos de los productos no estan disponibles actualmente. Por favor, te
 #: view:sale.confirm.wizard:sale_custom.sale_confirm_wizard_form_wizard
 msgid "Sale Confirm"
 msgstr "Confirmar Tramitacion"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:133
+#, python-format
+msgid "Please, validate shipping address."
+msgstr "Por favor, valide la dirección de envío."
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:121
+#, python-format
+msgid "Please, introduce a shipping cost line."
+msgstr "Por favor, introduzca una línea de gastos de envío."

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -87,5 +87,21 @@
             </field>
         </record>
 
+        <record id="view_order_form_imp_ship_addr_val" model="ir.ui.view">
+            <field name="name">sale.order.form.imp_ship_addr_val</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <field name="partner_shipping_id" position="after">
+                    <field name="validated_dir" invisible="1"/>
+                    <label for="compute_variables"/>
+                    <button name="validate_address"
+                            string="Validate address" type="object"
+                            class="oe_highlight"
+                            attrs="{'invisible': [('validated_dir', '=', True)]}"/>
+                </field>
+            </field>
+        </record>
+
     </data>
 </openerp>


### PR DESCRIPTION

- [IMP]'sale_custom': nuevo botón para verificar manualmente la dirección
- [IMP]'sale_custom': comprobación de gastos de envío.
- [FIX] 'custom_account': Actualizar campo many2many con el formato necesario para que lo inserte bien al crear pedido con xmlrpc