### PR TITLE
[Hotfix] Pedidos xmlrpc

### DIFF
--- a/project-addons/custom_partner/security/ir.model.access.csv
+++ b/project-addons/custom_partner/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_res_partner_invoice_type,access_res_partner_invoice_type,model_res_partner_invoice_type,base.group_user,1,1,1,1
+access_partner_rappel_info,partner.rappel.info,model_partner_rappel_info,base.group_user,1,1,1,1


### PR DESCRIPTION
- [FIX] 'custom_partner': Permisos para ver la información del rappel en la ficha del cliente
- [FIX] 'custom_account': Evitar que calcule bloqueo de pedidos por impagos al crearse pedido desde la web
-------------------------------------
Hemos detectado que tardaba mucho en la función _pending_orders_amount, por lo que filtramos por el usuario que lo está creando para evitar que se calcule todo eso desde la web.