### PR TITLE
Acontreras

### DIFF
--- a/project-addons/crm_claim_rma_custom/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/crm_claim.py
@@ -58,7 +58,7 @@ class CrmClaimRma(models.Model):
                                                                        ('2', 'High'),
                                                                        ('3', 'Critical')])
     comercial = fields.Many2one("res.users", string="Comercial")
-    country = fields.Many2one("res.country", string="Country", related='partner_id.country_id')
+    country = fields.Many2one("res.country", string="Country")
     date = fields.Date('Claim Date', select=True,
                        default=fields.Date.context_today)
     write_date = fields.Datetime("Update date", readonly=True)
@@ -163,15 +163,17 @@ class CrmClaimRma(models.Model):
             if vals:
                 claim_inv_line_obj.create(cr, uid, vals, context)
 
-    def onchange_partner_id(self, cr, uid, ids, partner_id, email=False,
-                            context=None):
-        res = super(CrmClaimRma, self).onchange_partner_id(cr, uid, ids,
-                                                           partner_id,
-                                                           email=email,
-                                                           context=context)
+    def onchange_partner_id(self, cr, uid, ids, partner_id, email=False, context=None):
+        res = super(CrmClaimRma, self).onchange_partner_id(cr, uid, ids, partner_id, email=email, context=context)
+
+        import ipdb
+        ipdb.set_trace()
+
         if partner_id:
             partner = self.pool["res.partner"].browse(cr, uid, partner_id)
             res['value']['delivery_address_id'] = partner_id
+            res['value']['section_id'] = partner.section_id   # Get section_id from res.partner
+            res['value']['country'] = partner.country_id      # Get country_id from res.partner
             if partner.user_id:
                 res['value']['comercial'] = partner.user_id.id
 

--- a/project-addons/crm_claim_rma_custom/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/crm_claim.py
@@ -166,9 +166,6 @@ class CrmClaimRma(models.Model):
     def onchange_partner_id(self, cr, uid, ids, partner_id, email=False, context=None):
         res = super(CrmClaimRma, self).onchange_partner_id(cr, uid, ids, partner_id, email=email, context=context)
 
-        import ipdb
-        ipdb.set_trace()
-
         if partner_id:
             partner = self.pool["res.partner"].browse(cr, uid, partner_id)
             res['value']['delivery_address_id'] = partner_id

--- a/project-addons/crm_claim_rma_custom/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/crm_claim_view.xml
@@ -38,6 +38,11 @@
                 <filter string="Closure" position="after">
                     <filter string="Comercial" domain="[]" context="{'group_by':'comercial'}"/>
                 </filter>
+
+                <group expand="0" string="Group By">
+                    <filter string="Country" domain="[]" context="{'group_by':'country'}"/>
+                </group>
+
             </field>
         </record>
 

--- a/project-addons/crm_claim_rma_custom/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/crm_claim_view.xml
@@ -221,9 +221,21 @@
             <field name="model">crm.claim</field>
             <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
             <field name="arch" type="xml">
+
               <field name="priority" position="replace">
                 <field name="priority"/>
               </field>
+
+              <separator string="Claim/Action Description" position="replace"/>
+              <field name="description" position="attributes">
+                <attribute name='invisible'>1</attribute>
+              </field>
+
+              <xpath expr="//sheet/group/notebook" position="after">
+                  <separator colspan="4" string="Claim/Action Description" groups="base.group_user"/>
+                  <field name="description" colspan="4" nolabel="1"/>
+              </xpath>
+
             </field>
         </record>
 


### PR DESCRIPTION

-  [IMP]'crm_claim_rma_custom': Modificación del campo descripción en los RMAs para que se vea en todas las pestañas y no solo en el campo.

-  [IMP]'crm_claim_rma_custom': modificación de código para agrupar por equipo de ventas y por países en los RMA. 
Para que esto funcione correctamente hay que actualizar la base de datos ya que esto arregla los datos nuevos, pero los anteriores al código no están actualizados, aquí te dejo las query´s necesarias para actualizar el campo country y el campo section_id:

      1.  UPDATE crm_claim cc SET country = rp.country_id
          FROM res_partner rp
          WHERE rp.id = cc.partner_id

     2.  UPDATE crm_claim cc SET section_id = rp.section_id
         FROM res_partner rp
         WHERE rp.id = cc.partner_id

- [IMP]'crm_claim_rma_custom': eliminado del ipdb del código
