### PR TITLE
Info Rappel Cliente

### DIFF
--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -439,41 +439,6 @@ msgid "Payment Reference"
 msgstr "Referencia de pago"
 
 #. module: custom_partner
-#: field:partner.rappel.info,partner_id:0
-msgid "Partner"
-msgstr "Cliente"
-
-#. module: custom_partner
-#: field:partner.rappel.info,start_rappel:0
-msgid "Start rappel"
-msgstr "Comienzo rappel"
-
-#. module: custom_partner
-#: field:partner.rappel.info,end_rappel:0
-msgid "End rappel"
-msgstr "Fin rappel"
-
-#. module: custom_partner
-#: field:partner.rappel.info,last_settlement_date:0
-msgid "Last settlement date"
-msgstr "Últ. fecha liquidación"
-
-#. module: custom_partner
-#: field:partner.rappel.info,start_current_info:0
-msgid "Start current period"
-msgstr "Comienzo período actual"
-
-#. module: custom_partner
-#: field:partner.rappel.info,end_current_info:0
-msgid "End current period"
-msgstr "Fin período actual"
-
-#. module: custom_partner
-#: field:partner.rappel.info,current_amount:0
-msgid "Current rappel amount"
-msgstr "Cantidad rappel actual"
-
-#. module: custom_partner
 #: code:addons/custom_partner/partner.py:428
 #, python-format
 msgid "Email web must be unique"

--- a/project-addons/custom_partner/partner.py
+++ b/project-addons/custom_partner/partner.py
@@ -51,7 +51,6 @@ class ResPartner(models.Model):
     past_year_global_invoiced = fields.Float('Past year invoiced (global)', default=0.0)
     current_employees = fields.Integer('Current year employees', default=0)
     past_year_employees = fields.Integer('Past year employees', default=0)
-    rappel_info_ids = fields.One2many('partner.rappel.info', 'partner_id', 'Rappels Info')
 
     @api.model
     def _calculate_annual_invoiced(self):

--- a/project-addons/custom_partner/rappel.py
+++ b/project-addons/custom_partner/rappel.py
@@ -511,37 +511,4 @@ class RappelCurrentInfo(models.Model):
             mail_ids.send()
 
 
-class PartnerRappelInfo(models.Model):
-
-    _name = "partner.rappel.info"
-    _auto = False
-    _order = 'partner_id, rappel_id desc'
-    # _table = 'partner_rappel_info'
-
-    partner_id = fields.Many2one('res.partner', 'Partner', readonly=True)
-    rappel_id = fields.Many2one('rappel', 'Rappel', readonly=True)
-    start_rappel = fields.Date('Start rappel', readonly=True)
-    end_rappel = fields.Date('End rappel', readonly=True)
-    last_settlement_date = fields.Date('Last settlement date', readonly=True)
-    start_current_info = fields.Date('Start current period', readonly=True)
-    end_current_info = fields.Date('End current period', readonly=True)
-    current_amount = fields.Float('Current rappel amount', readonly=True)
-    discount_voucher = fields.Boolean('Discount voucher', readonly=True)
-
-    def init(self, cr):
-        # self._table = partner_rappel_info
-        tools.drop_view_if_exists(cr, self._table)
-        cr.execute("""
-            CREATE OR REPLACE VIEW %s AS (
-                SELECT  rprr.id, rprr.partner_id, rprr.rappel_id, r.discount_voucher,
-                        rprr.date_start as start_rappel, rprr.date_end as end_rappel, last_settlement_date,
-                        rci.date_start as start_current_info, rci.date_end as end_current_info, 
-                        rci.amount as current_amount
-                FROM res_partner_rappel_rel rprr
-                LEFT JOIN rappel_current_info rci ON rprr.partner_id = rci.partner_id and rprr.rappel_id = rci.rappel_id
-                                 and rci.date_start BETWEEN rprr.date_start and COALESCE(rprr.date_end, rci.date_start)
-                JOIN rappel r ON r.id = rprr.rappel_id 
-                WHERE rprr.date_start <= current_date and COALESCE(rprr.date_end, current_date) >= current_date
-            )""" % self._table)
-
 

--- a/project-addons/custom_partner/rappel_view.xml
+++ b/project-addons/custom_partner/rappel_view.xml
@@ -59,7 +59,7 @@
             <field name="view_id" ref="view_rappel_current_info_tree_add_qty_picking"/>
         </record>
 
-        <record id="view_partner_rappel_info_form" model="ir.ui.view">
+        <record id="view_partner_form_add_rappel_info" model="ir.ui.view">
             <field name="name">res.partner.rappel.button</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>

--- a/project-addons/custom_partner/rappel_view.xml
+++ b/project-addons/custom_partner/rappel_view.xml
@@ -51,29 +51,28 @@
             </field>
         </record>
 
-        <record id="view_partner_form_add_rappel_info" model="ir.ui.view">
-            <field name="name">partner.rappel.info</field>
-            <field name="model">res.partner</field>
-            <field name="inherit_id" ref="rappel.view_partner_form_add_rappel"/>
-            <field name="arch" type="xml">
-                <field name="rappel_ids" position="replace">
-                     <field name="rappel_info_ids" nolabel="1" colspan="4">
-                         <tree string="Rappels info" editable="bottom" create="false" delete="false">
-                             <field name="rappel_id"/>
-                             <field name="discount_voucher" invisible="True"/>
-                             <field name="start_rappel"/>
-                             <field name="end_rappel"/>
-                             <field name="last_settlement_date"/>
-                             <field name="start_current_info"/>
-                             <field name="end_current_info"/>
-                             <field name="current_amount"/>
-                          </tree>
-                      </field>
-                </field>
-            </field>
+        <record model="ir.actions.act_window" id="action_view_rappel_info">
+            <field name="name">Rappel Info</field>
+            <field name="res_model">rappel.current.info</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_rappel_current_info_tree_add_qty_picking"/>
         </record>
 
-        <menuitem id="rappel.menu_rappel_config_sale" name="Rappel" sequence="50" parent="base.menu_sales"/>
+        <record id="view_partner_rappel_info_form" model="ir.ui.view">
+            <field name="name">res.partner.rappel.button</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="priority" eval="80"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='buttons']" position="inside">
+                    <button class="oe_inline oe_stat_button" type="action" name="%(action_view_rappel_info)d" string="Rappel"
+                        context="{'search_default_partner_id': active_id, 'default_partner_id': active_id}"
+                        icon="fa-flag-checkered">
+                    </button>
+                </xpath>
+            </field>
+        </record>
 
     </data>
 </openerp>

--- a/project-addons/custom_partner/security/ir.model.access.csv
+++ b/project-addons/custom_partner/security/ir.model.access.csv
@@ -1,3 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_res_partner_invoice_type,access_res_partner_invoice_type,model_res_partner_invoice_type,base.group_user,1,1,1,1
-access_partner_rappel_info,partner.rappel.info,model_partner_rappel_info,base.group_user,1,1,1,1


### PR DESCRIPTION
- [IMP] 'custom_partner': Permitir modificar rappels desde cliente como antes, y añadido botón para ver la información de lo que lleva conseguido de rappel
- [FIX] 'custom_partner': Cambios afectados al eliminar vista partner_rappel_info