### PR TITLE
Promo 4x3 (AxB) y etiquetas de producto en flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/product_events.py
+++ b/project-addons/flask_middleware_connector/events/product_events.py
@@ -161,6 +161,11 @@ def delay_export_product_write(session, model_name, record_id, vals):
         if min_stock:
             update_product.delay(session, model_name, pack.parent_product_id.id, priority=2, eta=30)
 
+    if 'tag_ids' in vals.keys():
+        unlink_product_tag_rel.delay(session, 'product.tag.rel', record_id, priority=5, eta=60)
+        for tag_id in vals.get('tag_ids', False)[0][2]:
+            export_product_tag_rel.delay(session, 'product.tag.rel', record_id, tag_id, priority=2, eta=120)
+
 
 @on_record_unlink(model_names='product.product')
 def delay_unlink_product(session, model_name, record_id):
@@ -406,3 +411,117 @@ def unlink_product_brand_rel(session, model_name, record_id):
     brand_exporter = _get_exporter(session, model_name, record_id,
                                       ProductbrandRelExporter)
     return brand_exporter.delete(record_id)
+
+
+@middleware
+class ProductTagExporter(Exporter):
+
+    _model_name = ['product.tag']
+
+    def update(self, binding_id, mode):
+        tag = self.model.browse(binding_id)
+        vals = {"odoo_id": tag.id,
+                "name": tag.name,
+                }
+        if mode == "insert":
+            return self.backend_adapter.insert(vals)
+        else:
+            return self.backend_adapter.update(binding_id, vals)
+
+    def delete(self, binding_id):
+        return self.backend_adapter.remove(binding_id)
+
+
+@middleware
+class ProductTagAdapter(GenericAdapter):
+    _model_name = 'product.tag'
+    _middleware_model = 'producttag'
+
+
+@on_record_create(model_names='product.tag')
+def delay_export_product_tag_create(session, model_name, record_id, vals):
+    export_product_tag.delay(session, model_name, record_id, priority=1, eta=60)
+
+
+@on_record_write(model_names='product.tag')
+def delay_export_product_tag_write(session, model_name, record_id, vals):
+    update_product_tag.delay(session, model_name, record_id, priority=2, eta=120)
+
+
+@on_record_unlink(model_names='product.tag')
+def delay_export_product_tag_unlink(session, model_name, record_id):
+    unlink_product_tag.delay(session, model_name, record_id, priority=3, eta=120)
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def export_product_tag(session, model_name, record_id):
+    product_tag_exporter = _get_exporter(session, model_name, record_id,
+                                         ProductTagExporter)
+    return product_tag_exporter.update(record_id, "insert")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def update_product_tag(session, model_name, record_id):
+    product_tag_exporter = _get_exporter(session, model_name, record_id,
+                                         ProductTagExporter)
+    return product_tag_exporter.update(record_id, "update")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def unlink_product_tag(session, model_name, record_id):
+    product_tag_exporter = _get_exporter(session, model_name, record_id,
+                                         ProductTagExporter)
+    return product_tag_exporter.delete(record_id)
+
+
+@middleware
+class ProductTagRelExporter(Exporter):
+
+    _model_name = ['product.tag.rel']
+
+    def update(self, product_record_id, tag_record_id, mode):
+        vals = {"odoo_id": product_record_id,
+                "producttag_id": tag_record_id,
+                }
+        if mode == "insert":
+            return self.backend_adapter.insert(vals)
+        else:
+            return self.backend_adapter.update(product_record_id, tag_record_id, vals)
+
+    def delete(self, product_record_id):
+        return self.backend_adapter.remove(product_record_id)
+
+
+@middleware
+class ProductTagRelAdapter(GenericAdapter):
+    _model_name = 'product.tag.rel'
+    _middleware_model = 'producttagproductrel'
+
+
+
+def delay_export_product_tag_rel_create(session, model_name, product_record_id, tag_record_id, vals):
+    export_product_tag_rel.delay(session, 'product.tag.rel', product_record_id, tag_record_id, priority=2, eta=120)
+
+
+
+def delay_export_product_tag_rel_unlink(session, model_name, product_record_id):
+    unlink_product_tag_rel.delay(session, 'product.tag.rel', product_record_id, priority=5, eta=120)
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def export_product_tag_rel(session, model_name, product_record_id, tag_record_id):
+    product_tag_rel_exporter = _get_exporter(session, model_name, product_record_id,
+                                             ProductTagRelExporter)
+    return product_tag_rel_exporter.update(product_record_id, tag_record_id, "insert")
+
+
+@job(retry_pattern={1: 10 * 60, 2: 20 * 60, 3: 30 * 60, 4: 40 * 60,
+                    5: 50 * 60})
+def unlink_product_tag_rel(session, model_name, product_record_id):
+    product_tag_rel_exporter = _get_exporter(session, model_name, product_record_id,
+                                             ProductTagRelExporter)
+    return product_tag_rel_exporter.delete(product_record_id)

--- a/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
+++ b/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
@@ -22,7 +22,7 @@
 from openerp import models, fields, api, _
 from openerp.addons.connector.session import ConnectorSession
 from ..events.partner_events import export_partner, update_partner, export_partner_tag, update_partner_tag, export_partner_tag_rel, update_partner_tag_rel
-from ..events.product_events import update_product, export_product
+from ..events.product_events import update_product, export_product, export_product_tag, update_product_tag
 from ..events.rma_events import export_rma, export_rmaproduct, update_rma, update_rmaproduct
 from ..events.invoice_events import export_invoice, update_invoice
 from ..events.picking_events import export_picking, update_picking, export_pickingproduct, update_pickingproduct
@@ -47,7 +47,8 @@ class MiddlewareBackend(models.TransientModel):
             ('customer_tags_rel', 'Customer Tags Rel'),
             ('rappel', 'Rappel'),
             ('rappelsection', 'Rappel Sections'),
-            ('countrystate', 'States')
+            ('countrystate', 'States'),
+            ('producttag', 'Product Tag')
         ],
         string='Export type',
         required=True,
@@ -230,4 +231,14 @@ class MiddlewareBackend(models.TransientModel):
             else:
                 for section in country_state_ids:
                     update_country_state.delay(session, 'res.country.state', section.id)
+
+        elif self.type_export == 'producttag':
+            product_tag_obj = self.env['product.tag']
+            product_tag_ids = product_tag_obj.search([])
+            if self.mode_export == 'export':
+                for tag in product_tag_ids:
+                    export_product_tag.delay(session, 'product.tag', tag.id)
+            else:
+                for tag in product_tag_ids:
+                    update_product_tag.delay(session, 'product.tag', tag.id)
 

--- a/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
+++ b/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
@@ -22,7 +22,7 @@
 from openerp import models, fields, api, _
 from openerp.addons.connector.session import ConnectorSession
 from ..events.partner_events import export_partner, update_partner, export_partner_tag, update_partner_tag, export_partner_tag_rel, update_partner_tag_rel
-from ..events.product_events import update_product, export_product, export_product_tag, update_product_tag
+from ..events.product_events import update_product, export_product, export_product_tag, update_product_tag, export_product_tag_rel
 from ..events.rma_events import export_rma, export_rmaproduct, update_rma, update_rmaproduct
 from ..events.invoice_events import export_invoice, update_invoice
 from ..events.picking_events import export_picking, update_picking, export_pickingproduct, update_pickingproduct
@@ -48,7 +48,8 @@ class MiddlewareBackend(models.TransientModel):
             ('rappel', 'Rappel'),
             ('rappelsection', 'Rappel Sections'),
             ('countrystate', 'States'),
-            ('producttag', 'Product Tag')
+            ('producttag', 'Product Tag'),
+            ('producttagproductrel', 'Product Tags Rel')
         ],
         string='Export type',
         required=True,
@@ -242,3 +243,11 @@ class MiddlewareBackend(models.TransientModel):
                 for tag in product_tag_ids:
                     update_product_tag.delay(session, 'product.tag', tag.id)
 
+        elif self.type_export == 'producttagproductrel':
+            product_obj = self.env['product.product']
+            product_ids = product_obj.search([])
+
+            if self.mode_export == 'export':
+                for product in product_ids:
+                    for tag in product.tag_ids:
+                        export_product_tag_rel.delay(session, 'product.tag.rel', product.id, tag.id)

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -75,6 +75,14 @@ msgstr "Atributo"
 msgid "Buy X get Y free"
 msgstr "Compre X y llévate Y"
 
+#. modules: openerp_sale_promotions, sale_promotions_extend
+#: code:addons/openerp_sale_promotions/models/rules.py:76
+#: selection:promos.rules.actions,action_type:0
+#: code:addons/sale_promotions_extend/rule.py:65
+#, python-format
+msgid "AxB on product tag"
+msgstr "AxB en tag de producto"
+
 #. module: openerp_sale_promotions
 #: field:promos.rules.conditions.exps,comparator:0
 msgid "Comparator"

--- a/project-addons/sale_promotions_extend/rule.py
+++ b/project-addons/sale_promotions_extend/rule.py
@@ -500,18 +500,18 @@ class PromotionsRulesActions(orm.Model):
                                 qty += order_line_2.product_uom_qty
                         num_lines = int(qty / qty_a) * (qty_a - qty_b)
                         if qty - qty_a >= 0:
-                            self.create_y_line_axb(cursor, user, action, order, order_line.price_unit, order_line.discount, num_lines, order_line.product_id, context)
+                            self.create_y_line_axb(cursor, user, action, order, order_line.price_unit, order_line.discount, order_line.sequence, num_lines, order_line.product_id, context)
                             promo_products.append(order_line.product_id.id)
 
         return {}
 
-    def create_y_line_axb(self, cr, uid, action, order, price_unit, discount, quantity, product_id, context=None):
+    def create_y_line_axb(self, cr, uid, action, order, price_unit, discount, sequence, quantity, product_id, context=None):
         vals = {
-            'order_id':order.id,
+            'order_id': order.id,
+            'sequence': sequence,
             #'product_id':product_id.id,
-            'name':'[%s]%s (%s)' % (
+            'name':'%s (%s)' % (
                      product_id.default_code,
-                     product_id.name,
                      action.promotion.name),
             'price_unit': -price_unit,
             'discount': discount,

--- a/project-addons/sale_promotions_extend/rule.py
+++ b/project-addons/sale_promotions_extend/rule.py
@@ -64,7 +64,8 @@ ACTION_TYPES = [
     ('cart_disc_perc', _('Discount % on Sub Total')),
     ('cart_disc_fix', _('Fixed amount on Sub Total')),
     ('prod_x_get_y', _('Buy X get Y free')),
-    ('web_disc_accumulated', _('Web Discount % on Product accumulated'))
+    ('web_disc_accumulated', _('Web Discount % on Product accumulated')),
+    ('a_get_b_product_tag', _('AxB on product tag'))
 ]
 
 
@@ -369,6 +370,8 @@ class PromotionsRulesActions(orm.Model):
                              'arguments': "0.00"}}
         if action_type in ['web_disc_accumulated']:
             res = {'value': {'arguments': "10.00"}}
+        if action_type in ['a_get_b_product_tag']:
+            res = {'value': {'product_code': "'product_tag'", 'arguments': "A,B"}}
         return res
 
     def apply_perc_discount_accumulated(self, cursor, user, action, order_line,
@@ -482,3 +485,37 @@ class PromotionsRulesActions(orm.Model):
                 self.apply_perc_discount_accumulated(cursor, user, action,
                                                      order_line, context)
         return {}
+
+    def action_a_get_b_product_tag(self, cursor, user, action, order,
+                               context=None):
+        qty_a, qty_b = [eval(arg) for arg in action.arguments.split(",")]
+        for order_line in order.order_line:
+            if not order_line.pack_parent_line_id:
+                if eval(action.product_code) in order_line.product_id.tag_ids.mapped('name'):
+                    qty = order_line.product_uom_qty
+
+                    for order_line_2 in order.order_line:
+                        if order_line_2.product_id.id == order_line.product_id.id:
+                            qty = order_line_2.product_uom_qty
+
+                    num_lines = int(qty / qty_a) * (qty_a - qty_b)
+
+                    return self.create_y_line_axb(cursor, user, action, order, order_line.price_unit, order_line.discount, num_lines, order_line.product_id, context)
+
+    def create_y_line_axb(self, cr, uid, action, order, price_unit, discount, quantity, product_id, context=None):
+        vals = {
+            'order_id':order.id,
+            #'product_id':product_id.id,
+            'name':'[%s]%s (%s)' % (
+                     product_id.default_code,
+                     product_id.name,
+                     action.promotion.name),
+            'price_unit': -price_unit,
+            'discount': discount,
+            'promotion_line':True,
+            'product_uom_qty':quantity,
+            'product_uom':product_id.uom_id.id
+        }
+        self.create_line(cr, uid, vals, context)
+        return True
+

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -91,7 +91,8 @@ class SaleOrder(osv.osv):
         for line in order.order_line:
             if line.promotion_line:
                 line.tax_id = taxes
-                line.sequence = 999
+                if '3 por ciento' in line.name:
+                    line.sequence = 999
 
         return res
 

--- a/project-addons/shipping_balance/sale_order.py
+++ b/project-addons/shipping_balance/sale_order.py
@@ -75,10 +75,10 @@ class sale_order_line(models.Model):
     @api.multi
     def unlink(self):
 
-        res_id= self.order_id.id
+        res_id = self.mapped('order_id.id')
 
         res = super(sale_order_line, self).unlink()
-        line2 = self.env['shipping.balance'].search([('sale_id', '=', res_id)])
+        line2 = self.env['shipping.balance'].search([('sale_id', 'in', res_id)])
         if line2:
             line2.unlink()
         return True

--- a/project-addons/vt_flask_middleware/implemented_models.py
+++ b/project-addons/vt_flask_middleware/implemented_models.py
@@ -1,6 +1,6 @@
 from country import Country, CountryState
 from product import Product, ProductCategory, ProductBrand, \
-    ProductBrandCountryRel
+    ProductBrandCountryRel, ProductTag, ProductTagProductRel
 from customer import Customer, CustomerTag, CustomerTagCustomerRel
 from invoice import Invoice
 from order import Order, OrderProduct
@@ -16,14 +16,14 @@ MODELS_CLASS = {
     'rmaproduct': RmaProduct, 'country': Country, 'commercial': Commercial,
     'productbrand': ProductBrand, 'productbrandcountryrel': ProductBrandCountryRel, 
     'order': Order, 'orderproduct': OrderProduct, 'rappel': Rappel, 'rappelcustomerinfo': RappelCustomerInfo,
-    'rappelsection':RappelSection, 'countrystate': CountryState}#, 'post': Post}
+    'rappelsection':RappelSection, 'countrystate': CountryState, 'producttag': ProductTag, 'producttagproductrel': ProductTagProductRel}#, 'post': Post}
 
 MASTER_CLASSES = {'commercial': Commercial,'productcategory': ProductCategory,
                   'rmastatus': RmaStatus, 'rmastage': RmaStage,
-                  'country': Country, 'productbrand': ProductBrand, 'rappel': Rappel}
+                  'country': Country, 'productbrand': ProductBrand, 'rappel': Rappel, 'producttag': ProductTag}
 
 DEPENDENT_CLASSES = {'invoice': Invoice, 'customer': Customer, 'customertag': CustomerTag, 'customertagcustomerrel': CustomerTagCustomerRel,
                      'product': Product, 'picking': Picking, 'pickingproduct': PickingProduct,
                      'rma': Rma, 'rmaproduct': RmaProduct,
-                     'productbrandcountryrel': ProductBrandCountryRel, 'order': Order,
+                     'productbrandcountryrel': ProductBrandCountryRel, 'order': Order, 'producttagproductrel': ProductTagProductRel,
                      'orderproduct': OrderProduct, 'rappelcustomerinfo': RappelCustomerInfo, 'countrystate': CountryState}

--- a/project-addons/vt_flask_middleware/implemented_models.py
+++ b/project-addons/vt_flask_middleware/implemented_models.py
@@ -20,10 +20,10 @@ MODELS_CLASS = {
 
 MASTER_CLASSES = {'commercial': Commercial,'productcategory': ProductCategory,
                   'rmastatus': RmaStatus, 'rmastage': RmaStage,
-                  'country': Country, 'productbrand': ProductBrand, 'rappel': Rappel, 'producttag': ProductTag}
+                  'country': Country, 'productbrand': ProductBrand, 'rappel': Rappel}
 
 DEPENDENT_CLASSES = {'invoice': Invoice, 'customer': Customer, 'customertag': CustomerTag, 'customertagcustomerrel': CustomerTagCustomerRel,
                      'product': Product, 'picking': Picking, 'pickingproduct': PickingProduct,
                      'rma': Rma, 'rmaproduct': RmaProduct,
-                     'productbrandcountryrel': ProductBrandCountryRel, 'order': Order, 'producttagproductrel': ProductTagProductRel,
+                     'productbrandcountryrel': ProductBrandCountryRel, 'order': Order, 'producttag': ProductTag, 'producttagproductrel': ProductTagProductRel,
                      'orderproduct': OrderProduct, 'rappelcustomerinfo': RappelCustomerInfo, 'countrystate': CountryState}

--- a/project-addons/vt_flask_middleware/product.py
+++ b/project-addons/vt_flask_middleware/product.py
@@ -72,3 +72,25 @@ class Product(SyncModel):
 
     def __unicode__(self):
         return self.name
+
+class ProductTag(SyncModel):
+
+    odoo_id = IntegerField(unique=True)
+    name = CharField(max_length=70)
+
+    MOD_NAME = 'producttag'
+
+    def __unicode__(self):
+        return self.name
+
+
+class ProductTagProductRel(SyncModel):
+
+    odoo_id = IntegerField()
+    producttag_id = ForeignKeyField(ProductTag, on_delete='CASCADE')
+
+    MOD_NAME = 'producttagproductrel'
+
+    def __unicode__(self):
+        return u"Product id: %s - Tag id: %s" % (self.odoo_id, self.producttag_id)
+

--- a/project-addons/vt_flask_middleware/xmlrpc_interface.py
+++ b/project-addons/vt_flask_middleware/xmlrpc_interface.py
@@ -7,7 +7,7 @@ from customer import Customer, CustomerTag, CustomerTagCustomerRel
 from order import Order, OrderProduct
 from invoice import Invoice
 from commercial import Commercial
-from product import Product, ProductCategory
+from product import Product, ProductCategory, ProductTag, ProductTagProductRel
 from rma import RmaStatus, RmaStage, Rma, RmaProduct
 from auth import auth
 from sync_log import SyncLog
@@ -114,6 +114,10 @@ def unlink(user_id, password, model, odoo_id):
             for customertagcustomerrel in CustomerTagCustomerRel.select().where(
                     CustomerTagCustomerRel.odoo_id == rec.odoo_id):
                 customertagcustomerrel.delete_instance()
+        elif model == 'producttagproductrel':
+            for producttagproductrel in ProductTagProductRel.select().where(
+                    ProductTagProductRel.odoo_id == rec.odoo_id):
+                producttagproductrel.delete_instance()
         elif model == 'order':
             for order in Order.select().where(
                 Order.partner_id == rec.id):


### PR DESCRIPTION
- [IMP]'flask_middleware_connector': añadido modelo de etiquetas de productos
- [IMP]'vt_flask_middleware': añadido modelo de etiquetas de productos
- [IMP]'flask_middleware_conector': añadida tabla de relacion de etiquetas producto al wizard
- [IMP]'vt_flask_middleware': Añadido borrado de tags de producto 
(Este ultimo commit arregla lo que te comentamos en el correo de que no se hacía bien el unlink)
----------------------------------
- [IMP]'sale_promotions_extend': añadida promo de AxB con tag de producto
- [FIX]'sale_promotions_extend': arreglado comportamiento de calculo de promocion AxB
- [FIX]'shipping_balance': modificada forma de obtener varios ids
- [IMP]'sale_promotions_exteng': Reorganizadas líneas de promo en el pedido
