### PR TITLE
Ocultar opciones botón "Más"

### DIFF
--- a/project-addons/web_disable_export_group/README.rst
+++ b/project-addons/web_disable_export_group/README.rst
@@ -1,0 +1,35 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Web Disable Export Group
+========================
+
+In the standard Odoo the UI option 'Export' that is present in the 'Action' menu
+of any list view is always enabled (for every user).
+
+This module makes the option 'Export' enabled only for the users that belong
+to the Export Data group.
+
+Admin user can always use the export option.
+
+
+Usage
+=====
+
+Enable the group "Export Data group" to the users who are allowed to
+make use of the option 'Export'.
+
+
+Credits
+=======
+
+Original code from module web_disable_export by Noviat,
+reviewed and modified by Onestein.
+
+Contributors
+------------
+
+* Dennis Sluijk <d.sluijk@onestein.nl>
+* Andrea Stirpe <a.stirpe@onestein.nl>

--- a/project-addons/web_disable_export_group/__init__.py
+++ b/project-addons/web_disable_export_group/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/project-addons/web_disable_export_group/__openerp__.py
+++ b/project-addons/web_disable_export_group/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Downgrade (version 9.0 to 8.0) by Nadia Ferreyra (Visiotech)
+
+{
+    'name': 'Web Disable Export Group',
+    'version': '8.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Onestein',
+    'website': 'http://www.onestein.eu',
+    'category': 'Web',
+    'depends': ['web'],
+    'data': [
+        'security/groups.xml',
+        'templates/assets.xml',
+    ],
+    'installable': True,
+}

--- a/project-addons/web_disable_export_group/security/groups.xml
+++ b/project-addons/web_disable_export_group/security/groups.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="group_export_data" model="res.groups">
+            <field name="name">Export Data</field>
+        </record>
+    </data>
+</openerp>

--- a/project-addons/web_disable_export_group/static/src/js/disable_export_group.js
+++ b/project-addons/web_disable_export_group/static/src/js/disable_export_group.js
@@ -1,0 +1,43 @@
+openerp.web_disable_export_group = function(instance) {
+"use strict";
+
+    var _t = instance.web._t;
+    var Model = instance.web.Model;
+    var session = new instance.web.Session();
+
+    instance.web.Sidebar.include({
+        add_items: function(section_code, items) {
+            var self = this;
+            var _super = this._super;
+            if (session.is_superuser) {
+                _super.apply(this, arguments);
+            } else {
+                var model_res_users = new Model("res.users");
+                model_res_users.call("has_group", ["web_disable_export_group.group_export_data"]).done(function(can_export) {
+                    if (!can_export) {
+                        var export_label = _t("Export");
+                        var delete_label = _t("Delete");
+                        var share_label = _t("Share");
+                        var embed_label = _t("Embed");
+                        var new_items = items;
+                        if (section_code === "other") {
+                            new_items = [];
+                            for (var i = 0; i < items.length; i++) {
+                                console.log("items[i]: ", items[i]);
+                                if ((items[i]["label"] !== export_label) && (items[i]["label"] !== delete_label)
+                                    && (items[i]["label"] !== share_label) && (items[i]["label"] !== embed_label)){
+                                    new_items.push(items[i]);
+                                }
+                            }
+                        }
+                        if (new_items.length > 0) {
+                            _super.call(self, section_code, new_items);
+                        }
+                    } else {
+                        _super.call(self, section_code, items);
+                    }
+                });
+            }
+        }
+    });
+};

--- a/project-addons/web_disable_export_group/templates/assets.xml
+++ b/project-addons/web_disable_export_group/templates/assets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="web_disable_export_group assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/web_disable_export_group/static/src/js/disable_export_group.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>


### PR DESCRIPTION
- [IMP] 'web_disable_export_group': Downgrade del módulo web_disable_export_group para ocultar la opción de exportar los datos desde las vistas de odoo [exceto para grupo "Export Data"]. Ocultadas también las opciones de compartir, borrar e incrustar