### PR TITLE
Cambios en promociones, añadidas promos especiales

### DIFF
--- a/project-addons/sale_promotions_extend/__openerp__.py
+++ b/project-addons/sale_promotions_extend/__openerp__.py
@@ -40,6 +40,7 @@ Features:
                 "sale_product_customize"],
     "data": [
         "sale_view.xml",
+        "rule.xml",
         "product_view.xml"
 
     ],

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -589,3 +589,7 @@ msgstr "Promo especial"
 msgid "Not apply promotions"
 msgstr "No aplicar promociones"
 
+#. module: sale_promotions_extend
+#: help:sale.order,no_promos:0
+msgid "Reload the prices after marking this check"
+msgstr "Recalcular precio final después de marcar el check"

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -584,3 +584,8 @@ msgstr "no es igual a"
 msgid "Special Promo"
 msgstr "Promo especial"
 
+#. module: sale_promotions_extend
+#: field:sale.order,no_promos:0
+msgid "Not apply promotions"
+msgstr "No aplicar promociones"
+

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -579,3 +579,8 @@ msgstr "menor o igual a"
 msgid "not equal to"
 msgstr "no es igual a"
 
+#. module: sale_promotions_extend
+#: field:promos.rules,special_promo:0
+msgid "Special Promo"
+msgstr "Promo especial"
+

--- a/project-addons/sale_promotions_extend/rule.py
+++ b/project-addons/sale_promotions_extend/rule.py
@@ -442,8 +442,7 @@ class PromotionsRulesActions(orm.Model):
                             context=None):
         vals = {
             'discount': eval(action.arguments),
-            'old_discount': order_line.discount,
-            'fixed_promo': True,
+            'old_discount': order_line.discount
         }
         return order_line.write(vals)
 

--- a/project-addons/sale_promotions_extend/rule.py
+++ b/project-addons/sale_promotions_extend/rule.py
@@ -443,6 +443,7 @@ class PromotionsRulesActions(orm.Model):
         vals = {
             'discount': eval(action.arguments),
             'old_discount': order_line.discount,
+            'fixed_promo': True,
         }
         return order_line.write(vals)
 

--- a/project-addons/sale_promotions_extend/rule.py
+++ b/project-addons/sale_promotions_extend/rule.py
@@ -29,6 +29,7 @@ from openerp.osv import osv, orm, fields
 from openerp.tools.misc import ustr
 from openerp import netsvc
 from openerp.tools.translate import _
+from openerp import models, fields as fields2
 
 # LOGGER = netsvc.Logger()
 DEBUG = False
@@ -522,3 +523,9 @@ class PromotionsRulesActions(orm.Model):
         self.create_line(cr, uid, vals, context)
         return True
 
+
+class PromotionsRules(models.Model):
+
+    _inherit = "promos.rules"
+
+    special_promo = fields2.Boolean("Special Promo")

--- a/project-addons/sale_promotions_extend/rule.xml
+++ b/project-addons/sale_promotions_extend/rule.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_promotion_rules_form_special">
+            <field name="name">promos.rules.form.special</field>
+            <field name="model">promos.rules</field>
+            <field name="inherit_id" ref="openerp_sale_promotions.view_promotion_rules_form"/>
+            <field name="arch" type="xml">
+                <field name="stop_further" position="after">
+                    <field name="special_promo"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -93,7 +93,6 @@ class SaleOrder(osv.osv):
             res = super(SaleOrder, self).apply_promotions(cursor, user, ids,
                                                           context=context2)
         else:
-            # forzar volver a poner la terifa del cliente a las líneas
             self.clear_existing_promotion_lines(cursor, user, ids[0], context)
             promotions_obj.apply_special_promotions(cursor, user, ids[0], context=None)
             res = False
@@ -145,16 +144,5 @@ class SaleOrder(osv.osv):
                                      [line.id],
                                      {'accumulated_promo': False},
                                      context=context)
-            elif line.fixed_promo:
-                order_line_obj.write(cursor, user,
-                                     [line.id],
-                                     {'discount': line_dict[line.id],
-                                      'old_discount': False,
-                                      'accumulated_promo': False,
-                                      'fixed_promo': False},
-                                     context=context)
-            else:
-                order_line_obj.write(cursor, user,
-                                     [line.id],
-                                     {'fixed_promo': False},
-                                     context=context)
+            elif order.no_promos:
+                continue

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -76,7 +76,7 @@ class SaleOrder(osv.osv):
     _inherit = "sale.order"
 
     _columns = {
-        'no_promos': fields.boolean("Not apply promotions")
+        'no_promos': fields.boolean("Not apply promotions", help="Reload the prices after marking this check")
     }
 
     def apply_promotions(self, cursor, user, ids, context=None):

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -131,10 +131,6 @@ class SaleOrder(osv.osv):
                                                ], context=context
                                                )
 
-        import ipdb
-        ipdb.set_trace()
-
-
         for line in order_line_obj.browse(cursor, user, order_line_ids, context):
             # if the line has an accumulated promo and the discount of the partner is 0
             if line.accumulated_promo and line_dict[line.id] == 0.0:

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -74,6 +74,10 @@ class SaleOrder(osv.osv):
 
     _inherit = "sale.order"
 
+    _columns = {
+        'no_promos': fields.boolean("Not apply promotions")
+    }
+
     def apply_promotions(self, cursor, user, ids, context=None):
         if context is None:
             context = {}

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -85,9 +85,17 @@ class SaleOrder(osv.osv):
         context2.pop('default_state', False)
         self._prepare_custom_line(cursor, user, ids, moves=False,
                                   context=context2)
-        res = super(SaleOrder, self).apply_promotions(cursor, user, ids,
-                                                      context=context2)
         order = self.browse(cursor, user, ids[0], context=context2)
+        promotions_obj = self.pool.get('promos.rules')
+
+        if not order.no_promos:
+            res = super(SaleOrder, self).apply_promotions(cursor, user, ids,
+                                                          context=context2)
+        else:
+            self.clear_existing_promotion_lines(cursor, user, ids[0], context)
+            promotions_obj.apply_special_promotions(cursor, user, ids[0], context=None)
+            res = False
+
         if order.state == 'reserve':
             order.order_reserve()
 

--- a/project-addons/sale_promotions_extend/sale.py
+++ b/project-addons/sale_promotions_extend/sale.py
@@ -66,8 +66,7 @@ class sale_order_line(osv.osv):
         'product_tags': fields.function(_get_tags_product, string='Tags',
                                         type='char', size=255),
         'web_discount': fields.boolean('Web Discount'),
-        'accumulated_promo': fields.boolean(default=False),
-        'fixed_promo': fields.boolean(default=False)
+        'accumulated_promo': fields.boolean(default=False)
     }
 
 
@@ -144,5 +143,3 @@ class SaleOrder(osv.osv):
                                      [line.id],
                                      {'accumulated_promo': False},
                                      context=context)
-            elif order.no_promos:
-                continue

--- a/project-addons/sale_promotions_extend/sale_view.xml
+++ b/project-addons/sale_promotions_extend/sale_view.xml
@@ -39,8 +39,16 @@
             </field>
         </record>
 
-
-
+        <record id="sale_order_no_promos" model="ir.ui.view">
+            <field name="name">sale.order.no.promos</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="model">sale.order</field>
+            <field name="arch" type="xml">
+                <field name="origin" position="after">
+                    <field name="no_promos"/>
+                </field>
+            </field>
+        </record>
 
     </data>
 </openerp>


### PR DESCRIPTION
- [IMP]'sale_promotions_extend': Añadido check de promo especial
- [IMP]'sale_promotions_extend': añadido check de no aplicar promociones en pedido
- [IMP]'sale_promotions_extend': añadida funcionalidad de calculo de promos especiales y pasado nuevo campo a api antigua
- [FIX]'sale_promotions_extend': Arreglo de promociones
- [FIX]'sale_promotions_extend': eliminado ipdb
- [FIX]'sale_promotions_extend': arreglo de promociones
- [IMP]'sale_promotions_extend': añadido tooltip al nuevo campo
- [FIX]'sale_promotions_extend': Arreglo de promociones, simplificación 