### PR TITLE
Custom labels edit

### DIFF
--- a/project-addons/customer_mood/res_partner_view.xml
+++ b/project-addons/customer_mood/res_partner_view.xml
@@ -22,7 +22,7 @@
             <field eval="1" name="priority"/>
             <field name="arch" type="xml">
                <field name="category_id" position="attributes">
-                   <attribute name ="options">{'no_create_edit':True}</attribute>
+                   <attribute name ="options">{'no_quick_create':True,'no_create_edit':True}</attribute>
                </field>
                <field name="category_id" position="before">
                      <field name="selected_image" widget='image' class="oe_left oe_avatar"/>

--- a/project-addons/customer_mood/res_partner_view.xml
+++ b/project-addons/customer_mood/res_partner_view.xml
@@ -21,6 +21,9 @@
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field eval="1" name="priority"/>
             <field name="arch" type="xml">
+               <field name="category_id" position="attributes">
+                   <attribute name ="options">{'no_create_edit':True}</attribute>
+               </field>
                <field name="category_id" position="before">
                      <field name="selected_image" widget='image' class="oe_left oe_avatar"/>
                     <field name="mood_image" colspan="2" placeholder="Mood..." nolabel="1" class="oe_inline"/>


### PR DESCRIPTION
Hola. Se han desactivado algunas opciones en las etiquetas:

[IMG] 'customer_mood':Oculta el quick_create en las etiquetas
[IMP] 'customer_mood':Oculta opcion crear/editar etiquetas cliente



