### PR TITLE
Fabricación productos

### DIFF
--- a/project-addons/pmp_landed_costs/stock.py
+++ b/project-addons/pmp_landed_costs/stock.py
@@ -28,10 +28,10 @@ class stock_move(models.Model):
         #res = super(stock_move, self).product_price_update_after_done(cr, uid, ids, context)
         product_obj = self.pool.get('product.product')
         for move in self.browse(cr, uid, ids, context=context):
-            if (move.location_id.usage == 'supplier') and (move.product_id.cost_method == 'real'):
+            if (move.location_id.usage in ('supplier', 'production')) and (move.product_id.cost_method == 'real'):
                 product_obj.update_real_cost(cr, uid, move.product_id.id, context)
         #return res
 
     def _store_average_cost_price(self, cr, uid, move, context=None):
-        if (move.location_id.usage == 'supplier') and (move.product_id.cost_method == 'real'):
+        if (move.location_id.usage in ('supplier', 'production')) and (move.product_id.cost_method == 'real'):
             return super(stock_move, self)._store_average_cost_price(cr, uid, move, context=context)

--- a/project-addons/sale_product_customize/i18n/es.po
+++ b/project-addons/sale_product_customize/i18n/es.po
@@ -308,3 +308,13 @@ msgstr "Linea de venta"
 #: selection:product.template,state:0
 msgid "Make to order"
 msgstr "Bajo Pedido"
+
+#. module: sale_product_customize
+#: field:mrp.production,picking_out:0
+msgid "Out picking"
+msgstr "Albarán de salida"
+
+#. module: sale_product_customize
+#: field:mrp.production,picking_in:0
+msgid "In picking"
+msgstr "Albarán de entrada"

--- a/project-addons/sale_product_customize/model/mrp_production.py
+++ b/project-addons/sale_product_customize/model/mrp_production.py
@@ -34,6 +34,8 @@ class MrpProduction(models.Model):
                               relation="sale.order", string="Sale",
                               readonly=True)
     production_name = fields.Char("Production ref", readonly=True)
+    picking_out = fields.Many2one('stock.picking', "Out picking", readonly=True)
+    picking_in = fields.Many2one('stock.picking', "In picking", readonly=True)
 
     @api.one
     def action_assign(self):
@@ -51,34 +53,35 @@ class MrpProduction(models.Model):
 
     @api.multi
     def action_production_end(self):
-        produce_wzd = self.env["mrp.product.produce"]
-        pline_wzd = self.env["mrp.product.produce.line"]
-        for prod in self:
-            for fmove in prod.move_created_ids:
-                wzd = produce_wzd.create({"product_id": fmove.product_id.id,
-                                          "product_qty": fmove.product_uom_qty,
-                                          "mode": "consume_produce",
-                                          "lot_id": fmove.restrict_lot_id and
-                                          fmove.restrict_lot_id.id or False})
-                for line in prod.move_lines:
-                    pline_wzd.create({"product_id": line.product_id.id,
-                                      "product_qty": line.product_uom_qty,
-                                      "lot_id": line.restrict_lot_id and
-                                      line.restrict_lot_id.id or False,
-                                      "produce_id": wzd.id})
-                wzd.with_context(active_id=prod.id).do_produce()
-            if prod.test_production_done():
-                prod.state = "done"
+        t_quant = self.env['stock.quant']
+        for production in self:
+            for move in production.move_created_ids2:
+                quant_ids = t_quant.browse(move.quant_ids.ids)
+                quant_ids.write({'cost': move.price_unit})
+                # move.update_product_price()
+        return super(MrpProduction, self).action_production_end()
 
-        return True
+    @api.multi
+    def action_confirm(self):
+        res = super(MrpProduction, self).action_confirm()
+        picking_obj = self.env['stock.picking']
+        # Create out picking
+        pick_out = picking_obj.create({'partner_id': self.company_id.partner_id.id,
+                                       'picking_type_id': self.env.ref('stock.picking_type_out').id,
+                                       'origin': self.name})
+        # Update reference out picking
+        self.picking_out = pick_out.id
+        for move in self.move_lines:
+            move.picking_id = pick_out.id
+
+        return res
 
     def create(self, cr, uid, vals, context=None):
         if context is None:
             context = {}
         context2 = dict(context)
         context2.pop('default_state', False)
-        return super(MrpProduction, self).create(cr, uid, vals,
-                                                  context=context2)
+        return super(MrpProduction, self).create(cr, uid, vals, context=context2)
 
 
 class MrpBomLine(models.Model):

--- a/project-addons/sale_product_customize/model/stock_reservation.py
+++ b/project-addons/sale_product_customize/model/stock_reservation.py
@@ -46,3 +46,27 @@ class StockPicking(models.Model):
     with_productions = fields.Boolean("With productions", readonly=True,
                                       compute='_get_if_productions')
 
+    @api.multi
+    def write(self, vals):
+        res = super(StockPicking, self).write(vals)
+        production_obj = self.env['mrp.production']
+        if 'MO' in self.origin and vals.get('date_done', False) and self.state == 'done':
+            mrp_production = production_obj.search([('name', '=', self.origin)])
+            if mrp_production.picking_out.id == self.id:
+                # Create in picking
+                pick_in = self.create({'partner_id': self.partner_id.id,
+                                       'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                                       'origin': self.origin})
+                # Update reference in_picking and the state
+                mrp_production.write({'state': 'in_production',
+                                      'picking_in': pick_in.id})
+                cost_moves = sum(self.move_lines.mapped('price_unit'))
+                for move in production_obj.search([('name', '=', self.origin)]).move_created_ids:
+                    move.write({'price_unit': cost_moves,
+                                'picking_id': pick_in.id})
+                pick_in.action_assign()
+            elif mrp_production.picking_in.id == self.id:
+                mrp_production.action_production_end()
+        return res
+
+

--- a/project-addons/sale_product_customize/view/mrp_production_view.xml
+++ b/project-addons/sale_product_customize/view/mrp_production_view.xml
@@ -44,14 +44,27 @@
             <field name="model">mrp.production</field>
             <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
             <field name="arch" type="xml">
+                <button name="%(mrp.act_mrp_product_produce)d" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </button>
+                <button name="button_produce" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </button>
+                <button name="button_cancel" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </button>
                 <field name="origin" position="after">
                     <field name="sale_id"/>
                     <field name="production_name"/>
                     <field name="type_ids" widget="many2many_tags" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
                 </field>
-                <form position="attributes">
+                <field name="priority" position="after">
+                    <field name="picking_out"/>
+                    <field name="picking_in"/>
+                </field>
+                <!--form position="attributes">
                     <attribute name="create">0</attribute>
-                </form>
+                </form-->
             </field>
         </record>
 
@@ -63,9 +76,9 @@
                 <field name="origin" position="after">
                     <field name="type_ids" widget="many2many_tags"/>
                 </field>
-                <tree position="attributes">
+                <!--tree position="attributes">
                     <attribute name="create">0</attribute>
-                </tree>
+                </tree-->
             </field>
         </record>
 


### PR DESCRIPTION
- [IMP] 'sale_product_customize': Modificado comportamiento fabricación de productos. Se crean albaranes de entrada y salida para que se refleje el stock en Vstock

- [IMP] 'pmp_landed_costs': Recalcular también coste producto (cuando el método es Precio real) si la ubicación de origen es Producción