### PR TITLE
Cron actualizar datos efectos

### DIFF
--- a/project-addons/account_move_line_followup/__init__.py
+++ b/project-addons/account_move_line_followup/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/account_move_line_followup/__openerp__.py
+++ b/project-addons/account_move_line_followup/__openerp__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': 'Update follow-up data in account move lines',
+    'version': '1.0',
+    'license': 'AGPL-3',
+    'author': 'Nadia Ferreyra',
+    'category': 'Account',
+    'depends': ['account'],
+    'data': ['data/ir_cron.xml'],
+    'description': '''Update follow-up data in account move lines''',
+    'installable': True,
+}

--- a/project-addons/account_move_line_followup/data/ir_cron.xml
+++ b/project-addons/account_move_line_followup/data/ir_cron.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record forcecreate="True" id="ir_cron_update_date_followup" model="ir.cron">
+            <field name="name">Update follow-up data in account move lines</field>
+            <field eval="True" name="active" />
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+            <field name="numbercall">-1</field>
+            <field eval="False" name="doall" />
+            <field eval="'account.move.line'" name="model" />
+            <field eval="'cron_update_date_followup'" name="function" />
+        </record>
+    </data>
+</openerp>

--- a/project-addons/account_move_line_followup/models/__init__.py
+++ b/project-addons/account_move_line_followup/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_line

--- a/project-addons/account_move_line_followup/models/account_move_line.py
+++ b/project-addons/account_move_line_followup/models/account_move_line.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, api
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    @api.model
+    def cron_update_date_followup(self):
+        # Searching refund account move line
+        refund_aml = self.search([('reconcile_id', '=', False), ('account_id', '=', 443),
+                                  ('credit', '!=', 0), ('invoice.type', '=', 'out_refund')])
+
+        for aml in refund_aml:
+            # Searching the most unfavorable maturity date on positive payments
+            aml_partner = self.search_read([('partner_id', '=', aml.partner_id.id),
+                                            ('reconcile_id', '=', False),
+                                            ('account_id', '=', 443),
+                                            ('debit', '!=', 0)],
+                                           ['date_maturity', 'followup_line_id', 'followup_date'],
+                                           limit=1, order="date_maturity asc")
+            # Updating maturity date and follow-up data
+            if aml_partner:
+                aml_partner_data = aml_partner[0]
+                aml.write({'date_maturity': aml_partner_data['date_maturity'],
+                           'followup_line_id': aml_partner_data['followup_line_id'] and
+                                               aml_partner_data['followup_line_id'][0] or False,
+                           'followup_date': aml_partner_data['followup_date']})
+


### PR DESCRIPTION
[IMP] 'account_move_line_followup': Cron para actualizar fecha vencimiento y datos de seguimiento de efectos que se corresponden con rectificativas tomando como referencia el efecto de facturas positivas cuya f. vencimiento sea más desfavorable