### PR TITLE
Seguimiento efectos

### DIFF
--- a/project-addons/account_move_line_followup/__openerp__.py
+++ b/project-addons/account_move_line_followup/__openerp__.py
@@ -6,8 +6,8 @@
     'license': 'AGPL-3',
     'author': 'Nadia Ferreyra',
     'category': 'Account',
-    'depends': ['account'],
-    'data': ['data/ir_cron.xml'],
+    'depends': ['account', 'cyc_view'],
+    'data': ['data/ir_cron.xml', 'data/ir_config_parameter.xml'],
     'description': '''Update follow-up data in account move lines''',
     'installable': True,
 }

--- a/project-addons/account_move_line_followup/data/ir_config_parameter.xml
+++ b/project-addons/account_move_line_followup/data/ir_config_parameter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="param_notification_period_days_cyc" model="ir.config_parameter">
+            <field name="key">notification.period.days.cyc</field>
+            <field name="value">120</field>
+        </record>
+    </data>
+</openerp>

--- a/project-addons/account_move_line_followup/models/account_move_line.py
+++ b/project-addons/account_move_line_followup/models/account_move_line.py
@@ -38,9 +38,8 @@ class AccountMoveLine(models.Model):
 
     @api.model
     def cron_update_date_followup(self):
-        # Searching refund account move line
-        refund_aml = self.search([('reconcile_id', '=', False), ('account_id', '=', 443),
-                                  ('credit', '!=', 0), ('invoice.type', '=', 'out_refund')])
+        # Searching negative account move line
+        refund_aml = self.search([('reconcile_id', '=', False), ('account_id', '=', 443), ('credit', '!=', 0)])
 
         for aml in refund_aml:
             # Searching the most unfavorable maturity date on positive payments

--- a/project-addons/account_move_line_followup/models/account_move_line.py
+++ b/project-addons/account_move_line_followup/models/account_move_line.py
@@ -1,11 +1,40 @@
 # -*- coding: utf-8 -*-
 
 from openerp import models, api
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 
 class AccountMoveLine(models.Model):
 
     _inherit = 'account.move.line'
+
+    @api.model
+    def create(self, vals):
+        # Check if it is a positive account move line with customer invoice origin
+        if vals.get('account_id', False) == 443 and vals.get('debit', False) > 0:
+            invoice = self.env.context.get('invoice', False)
+            if invoice and invoice.type == 'out_invoice' and vals.get('date_maturity', False):
+                date_maturity = vals['date_maturity']
+                cyc_days = self.env['ir.config_parameter'].get_param('notification.period.days.cyc')
+                limit_date = datetime.strptime(date_maturity, "%Y-%m-%d") + relativedelta(days=int(cyc_days))
+                limit_date_format = limit_date.strftime("%Y-%m-%d")
+                # Update cyc limit date with a predefined margin of days
+                vals.update({'cyc_limit_date_insolvency': limit_date_format})
+        res = super(AccountMoveLine, self).create(vals)
+        return res
+
+    # De momento no contemplar el caso de que se cambie la fecha de vencimiento desde el efecto
+    '''@api.multi
+    def write(self, vals, context=None, check=True, update_check=True):
+        if vals.get('date_maturity') and self.account_id.id == 443 and self.debit > 0\
+                and self.invoice and self.invoice.type == 'out_invoice':
+            cyc_days = self.env['ir.config_parameter'].get_param('notification.period.days.cyc')
+            limit_date = datetime.strptime(vals['date_maturity'], "%Y-%m-%d") + relativedelta(days=int(cyc_days))
+            limit_date_format = limit_date.strftime("%Y-%m-%d")
+            vals.update({'cyc_limit_date_insolvency': limit_date_format})
+        res = super(AccountMoveLine, self).write(vals, context=context, check=check, update_check=update_check)
+        return res'''
 
     @api.model
     def cron_update_date_followup(self):


### PR DESCRIPTION
- [IMP] 'account_move_line_followup': Actualizar en efecto positivos de cliente la fecha límite insolvencia cyc sumando un número de días configurado como parámetro sobre la fecha vencimiento
- [FIX] 'account_move_line_followup': Actualizar también seguimiento en los efectos negativos correspondientes a entregas a cuenta que no provienen directamente de una factura rectificativa
