### PR TITLE
Dos campos nuevos para flask

### DIFF
--- a/project-addons/flask_middleware_connector/events/product_events.py
+++ b/project-addons/flask_middleware_connector/events/product_events.py
@@ -67,7 +67,9 @@ class ProductExporter(Exporter):
                     'type': product.type,
                     'is_pack': product.is_pack,
                     'discontinued': product.discontinued,
-                    'state': product.state}
+                    'state': product.state,
+                    'sale_in_groups_of': product.sale_in_groups_of,
+                    }
             if product.show_stock_outside:
                 vals['external_stock'] = product.qty_available_external
                 stock_qty = eval("product." + self.backend_record.
@@ -123,7 +125,7 @@ def delay_export_product_create(session, model_name, record_id, vals):
                  "pvd1_relation", "pvd2_relation", "pvd3_relation", "pvd4_relation",
                  "categ_id", "product_brand_id", "last_sixty_days_sales",
                  "joking_index", "sale_ok", "ean13", "description_sale",
-                 "manufacturer_pref", "standard_price", "type", "pack_line_ids", "discontinued", "state"]
+                 "manufacturer_pref", "standard_price", "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of"]
     export_product.delay(session, model_name, record_id)
     claim_lines = session.env['claim.line'].search(
         [('product_id', '=', product.id),
@@ -148,7 +150,7 @@ def delay_export_product_write(session, model_name, record_id, vals):
                  "pvd1_relation", "pvd2_relation", "pvd3_relation", "pvd4_relation",
                  "last_sixty_days_sales", "joking_index", "sale_ok",
                  "ean13", "description_sale", "manufacturer_pref", "standard_price",
-                 "type", "pack_line_ids", "discontinued", "state"]
+                 "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of"]
     for field in up_fields:
         if field in vals:
             update_product.delay(session, model_name, record_id, priority=2, eta=30)

--- a/project-addons/flask_middleware_connector/events/product_events.py
+++ b/project-addons/flask_middleware_connector/events/product_events.py
@@ -69,6 +69,7 @@ class ProductExporter(Exporter):
                     'discontinued': product.discontinued,
                     'state': product.state,
                     'sale_in_groups_of': product.sale_in_groups_of,
+                    'replacement_id': product.replacement_id.id
                     }
             if product.show_stock_outside:
                 vals['external_stock'] = product.qty_available_external
@@ -125,7 +126,8 @@ def delay_export_product_create(session, model_name, record_id, vals):
                  "pvd1_relation", "pvd2_relation", "pvd3_relation", "pvd4_relation",
                  "categ_id", "product_brand_id", "last_sixty_days_sales",
                  "joking_index", "sale_ok", "ean13", "description_sale",
-                 "manufacturer_pref", "standard_price", "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of"]
+                 "manufacturer_pref", "standard_price", "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of",
+                 "replacement_id"]
     export_product.delay(session, model_name, record_id)
     claim_lines = session.env['claim.line'].search(
         [('product_id', '=', product.id),
@@ -150,7 +152,7 @@ def delay_export_product_write(session, model_name, record_id, vals):
                  "pvd1_relation", "pvd2_relation", "pvd3_relation", "pvd4_relation",
                  "last_sixty_days_sales", "joking_index", "sale_ok",
                  "ean13", "description_sale", "manufacturer_pref", "standard_price",
-                 "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of"]
+                 "type", "pack_line_ids", "discontinued", "state", "sale_in_groups_of", "replacement_id"]
     for field in up_fields:
         if field in vals:
             update_product.delay(session, model_name, record_id, priority=2, eta=30)

--- a/project-addons/vt_flask_middleware/product.py
+++ b/project-addons/vt_flask_middleware/product.py
@@ -72,6 +72,7 @@ class Product(SyncModel):
     discontinued = BooleanField()
     state = CharField(max_length=50)
     sale_in_groups_of = FloatField(default=1.0)
+    replacement_id = IntegerField()
 
     def __unicode__(self):
         return self.name

--- a/project-addons/vt_flask_middleware/product.py
+++ b/project-addons/vt_flask_middleware/product.py
@@ -71,6 +71,7 @@ class Product(SyncModel):
     is_pack = BooleanField()
     discontinued = BooleanField()
     state = CharField(max_length=50)
+    sale_in_groups_of = FloatField(default=1.0)
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
- [IMP]'vt_flask_middleware': añadido campo grupo de productos
- [IMP]'flask_middleware_connector': añadido campo de grupo de productos
---------
- [IMP]'vt_flask_middleware': añadido campo producto de reemplazo 
- [IMP]'flask_middleware_connector': añadido campo producto de reemplazo 

Habría que añadir las siguientes columnas a middleware:
ALTER TABLE product ADD COLUMN sale_in_groups_of REAL DEFAULT 1.0
ALTER TABLE product ADD COLUMN replacement_id INT