### PR TITLE
sale_custom_risk_information

### DIFF
--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -54,3 +54,25 @@ msgstr "Por favor, valide la dirección de envío."
 #, python-format
 msgid "Please, introduce a shipping cost line."
 msgstr "Por favor, introduzca una línea de gastos de envío."
+
+#. module: sale_custom
+#: view:sale.order:sale_custom.view_order_form_sales_partner
+msgid "Risk Information"
+msgstr "Riesgo Cliente"
+
+#. module: sale_custom
+#: view:sale.order:sale_custom.view_order_form_sales_partner
+msgid "Warnings"
+msgstr "Avisos"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:108
+#, python-format
+msgid "Partner Risk Information"
+msgstr "Información del riesgo contable de una empresa"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:91
+#, python-format
+msgid "Warnings"
+msgstr "Avisos"

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -88,12 +88,29 @@ class SaleOrder(models.Model):
         view_id = self.env.ref('sale_custom.view_warning_form').id  # Id asociado a esa vista
 
         return {
-            'name': 'Avisos',
+            'name': _('Warnings'),
             'view_type': 'form',
             'view_mode': 'form',
             'res_model': 'res.partner',
             'view_id': view_id,
             'res_id': res_partner_id.id,
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'flags': {'form': {'options': {'mode': 'view'}}}
+        }
+
+    @api.multi
+    def button_notification_open_risk_window(self):
+        partner_id = self.partner_id
+        view_id = self.env.ref('nan_partner_risk.open_risk_window_view').id
+
+        return {
+            'name': _('Partner Risk Information'),
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'res.partner',
+            'view_id': view_id,
+            'res_id': partner_id.id,
             'type': 'ir.actions.act_window',
             'target': 'new',
             'flags': {'form': {'options': {'mode': 'view'}}}

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -81,8 +81,10 @@
                 <xpath expr="//button[@name='open_stock_reservation']" position="after">
                     <button name="%(action_view_historical_orders)d" string="Partner Orders" class="oe_stat_button"
                             type="action" icon="fa-strikethrough" attrs="{'invisible': ['|', ('partner_id', '=', False), ('state', 'not in', ['draft', 'reserve'])]}"/>
-                    <button name="button_notification" string="Avisos" class="oe_stat_button"
+                    <button name="button_notification" string="Warnings" class="oe_stat_button"
                             type="object" icon="fa-exclamation-triangle" attrs="{'invisible': ['|', ('partner_id', '=', False), ('state', 'not in', ['draft', 'reserve', 'sent'])]}"/>
+                    <button name="button_notification_open_risk_window" string="Risk Information"
+                            class="oe_stat_button" type="object" icon="fa-bar-chart-o"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION

- [IMP][I18N]'sale_custom': crear un acceso directo en pedidos, del botón 'Ver información del riego' que 
  aparece en clientes.
