### PR TITLE
Peor fecha notificación cyc

### DIFF
--- a/project-addons/account_move_line_followup/__openerp__.py
+++ b/project-addons/account_move_line_followup/__openerp__.py
@@ -7,7 +7,9 @@
     'author': 'Nadia Ferreyra',
     'category': 'Account',
     'depends': ['account', 'cyc_view'],
-    'data': ['data/ir_cron.xml', 'data/ir_config_parameter.xml'],
+    'data': ['data/ir_cron.xml',
+             'data/ir_config_parameter.xml',
+             'views/partner_view.xml'],
     'description': '''Update follow-up data in account move lines''',
     'installable': True,
 }

--- a/project-addons/account_move_line_followup/i18n/es.po
+++ b/project-addons/account_move_line_followup/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_move_line_followup
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-21 11:30+0000\n"
+"PO-Revision-Date: 2019-03-21 11:30+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_line_followup
+#: field:res.partner,worst_cyc_notify_date:0
+msgid "Worst C&C notify date"
+msgstr "Peor fecha notificación C&C"
+

--- a/project-addons/account_move_line_followup/models/account_move_line.py
+++ b/project-addons/account_move_line_followup/models/account_move_line.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, api
+from openerp import models, api, fields
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+
+
+class ResPartner(models.Model):
+
+    _inherit = 'res.partner'
+
+    worst_cyc_notify_date = fields.Date("Worst C&C notify date")
 
 
 class AccountMoveLine(models.Model):
@@ -38,7 +45,7 @@ class AccountMoveLine(models.Model):
 
     @api.model
     def cron_update_date_followup(self):
-        # Searching negative account move line
+        # Searching negative account move line to update follow-up data
         refund_aml = self.search([('reconcile_id', '=', False), ('account_id', '=', 443), ('credit', '!=', 0)])
 
         for aml in refund_aml:
@@ -56,4 +63,30 @@ class AccountMoveLine(models.Model):
                            'followup_line_id': aml_partner_data['followup_line_id'] and
                                                aml_partner_data['followup_line_id'][0] or False,
                            'followup_date': aml_partner_data['followup_date']})
+
+        # Search all partner to update new field 'worst cyc notify date'
+        all_partner = self.env['res.partner'].search([('customer', '=', True), ('active', '=', True),
+                                                      ('prospective', '=', False), ('is_company', '=', True),
+                                                      ('parent_id', '=', False), ('child_ids', '!=', False)])
+
+        # Searching all positive account move line with cyc notify date
+        aml_notify_date = self.search_read([('reconcile_id', '=', False),
+                                            ('account_id', '=', 443),
+                                            ('debit', '!=', 0),
+                                            ('cyc_notify_date', '!=', False)],
+                                           ['partner_id', 'cyc_notify_date'],
+                                           order="cyc_notify_date asc")
+
+        aml_partner = {}
+        for aml in aml_notify_date:
+            if aml['partner_id'][0] not in aml_partner:
+                aml_partner.update({aml['partner_id'][0]: aml['cyc_notify_date']})
+
+        for partner in all_partner:
+            # Updating field worst cyc notify date
+            if aml_partner.get(partner.id):
+                partner.worst_cyc_notify_date = aml_partner.get(partner.id)
+            else:
+                partner.worst_cyc_notify_date = False
+
 

--- a/project-addons/account_move_line_followup/views/partner_view.xml
+++ b/project-addons/account_move_line_followup/views/partner_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_partner_inherit_followup_form_2" model="ir.ui.view">
+            <field name="name">res.partner.followup.form.inherit.2</field>
+            <field name="inherit_id" ref="custom_partner.view_partner_inherit_followup_form_add_send_email"/>
+            <field name="model">res.partner</field>
+            <field name="arch" type="xml" >
+                <field name="notified_creditoycaucion" position="after">
+                    <field name="worst_cyc_notify_date" readonly="True"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
[IMP] 'account_move_line_followup': Actualizar nuevo campo de cliente para reflejar la peor fecha de notificación cyc según los efectos positivos que tengan fecha de notificacón a cyc y que no estén conciliados