### PR TITLE
validar direcciones y nuevos filtros en informes

### DIFF
--- a/project-addons/account_invoice_report_filter_brand/views/account_invoice_report_filter_view.xml
+++ b/project-addons/account_invoice_report_filter_brand/views/account_invoice_report_filter_view.xml
@@ -1,55 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
+        <record id="view_account_invoice_report_brand_graph" model="ir.ui.view">
+             <field name="name">account.invoice.report.brand.graph</field>
+             <field name="model">account.invoice.report.filter</field>
+             <field name="arch" type="xml">
+                 <graph string="Invoices Analysis" type="pivot">
+                     <field name="section_id" type="row"/>
+                     <field name="date" interval="year" type="col"/>
+                     <field name="price_total" type="measure"/>
+                 </graph>
+             </field>
+        </record>
+
         <!-- analisis de facturas filtrado por marcas -->
         <record id="action_account_invoice_report_filter" model="ir.actions.act_window">
             <field name="name">Invoices Analysis brand</field>
             <field name="res_model">account.invoice.report.filter</field>
             <field name="view_type">form</field>
             <field name="view_mode">graph</field>
-            <field name="context">{'search_default_current':1, 'search_default_customer':1, 'group_by':[], 'group_by_no_leaf':1, 'search_default_year': 1}</field>
+            <field name="context">{'search_default_current':1, 'search_default_section_id':1, 'search_default_year': 1}</field>
             <field name="search_view_id" ref="account.view_account_invoice_report_search"/>
-            <field name="view_id" ref="account.view_account_invoice_report_graph"/>
+            <field name="view_id" ref="view_account_invoice_report_brand_graph"/>
         </record>
 
         <menuitem action="action_account_invoice_report_filter" id="menu_action_account_invoice_report_filter"
                   name="Invoices Analysis brand" parent="base.next_id_64"/>
     </data>
 </openerp>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/project-addons/custom_account/i18n/es.po
+++ b/project-addons/custom_account/i18n/es.po
@@ -924,3 +924,18 @@ msgstr "Marca"
 msgid "Product"
 msgstr "Producto"
 
+#. module: custom_account
+#: view:account.invoice.report:custom_account.account_invoice_report_add_filters
+#: field:account.invoice.report,brand_name:0
+msgid "Brand name"
+msgstr "Nombre de la marca"
+
+
+#. module: custom_account
+#: view:account.invoice.report:custom_account.account_invoice_report_add_filters
+#: field:account.invoice.report,area_id:0
+msgid "Area"
+msgstr "Zona"
+
+
+

--- a/project-addons/custom_account/report/account_invoice_report_view.xml
+++ b/project-addons/custom_account/report/account_invoice_report_view.xml
@@ -28,6 +28,7 @@
                     <filter string="country" name="country_id" context="{'group_by':'country_id'}"/>
                     <filter string="Payment mode" name="payment_mode_id" context="{'group_by':'payment_mode_id'}"/>
                     <filter string="Brand name" name="brand_name" context="{'group_by':'brand_name'}"/>
+                    <filter string="Area" name="area" context="{'group_by': 'area_id'}"/>
                 </filter>
             </field>
         </record>

--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -54,3 +54,39 @@ msgstr "Por favor, valide la dirección de envío."
 #, python-format
 msgid "Please, introduce a shipping cost line."
 msgstr "Por favor, introduzca una línea de gastos de envío."
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:118
+#, python-format
+msgid "Warning! the address is incorrect, the following fields are empty:\n"
+msgstr "Aviso! la dirección es incorrecta, faltan los siguentes campos:\n"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:107
+#, python-format
+msgid "Street"
+msgstr "Calle"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:108
+#, python-format
+msgid "Zip"
+msgstr "Código postal"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:109
+#, python-format
+msgid "City"
+msgstr "Ciudad"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:110
+#, python-format
+msgid "Estate"
+msgstr "Provincia"
+
+#. module: sale_custom
+#: code:addons/sale_custom/sale.py:111
+#, python-format
+msgid "Country"
+msgstr "País"

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -94,11 +94,8 @@
             <field name="arch" type="xml">
                 <field name="partner_shipping_id" position="after">
                     <field name="validated_dir" invisible="1"/>
-                    <label for="compute_variables"/>
-                    <button name="validate_address"
-                            string="Validate address" type="object"
-                            class="oe_highlight"
-                            attrs="{'invisible': [('validated_dir', '=', True)]}"/>
+                    <label for="validate_address"/>
+                    <button name="validate_address" string="Validate address" type="object" class="oe_highlight"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION

- [IMP][I18N]'sale_custom':  implementación para verificar en los pedidos la dirección creada desde web.

- [IMP]'account_invoce_report_filter_brand': implementación para filtrar en el análisis facturas marca por equipo de ventas y por años.

- [IMP][I18N]'custom_account': implementación para añadir un filtro y su traducción.