### PR TITLE
Corrección sale_product_customize

### DIFF
--- a/project-addons/sale_product_customize/model/stock_reservation.py
+++ b/project-addons/sale_product_customize/model/stock_reservation.py
@@ -50,23 +50,24 @@ class StockPicking(models.Model):
     def write(self, vals):
         res = super(StockPicking, self).write(vals)
         production_obj = self.env['mrp.production']
-        if self.origin and 'MO' in self.origin and vals.get('date_done', False) and self.state == 'done':
-            mrp_production = production_obj.search([('name', '=', self.origin)])
-            if mrp_production.picking_out.id == self.id:
-                # Create in picking
-                pick_in = self.create({'partner_id': self.partner_id.id,
-                                       'picking_type_id': self.env.ref('stock.picking_type_in').id,
-                                       'origin': self.origin})
-                # Update reference in_picking and the state
-                mrp_production.write({'state': 'in_production',
-                                      'picking_in': pick_in.id})
-                cost_moves = sum(self.move_lines.mapped('price_unit'))
-                for move in production_obj.search([('name', '=', self.origin)]).move_created_ids:
-                    move.write({'price_unit': cost_moves,
-                                'picking_id': pick_in.id})
-                pick_in.action_assign()
-            elif mrp_production.picking_in.id == self.id:
-                mrp_production.action_production_end()
+        for picking in self:
+            if picking.origin and 'MO' in picking.origin and vals.get('date_done', False) and picking.state == 'done':
+                mrp_production = production_obj.search([('name', '=', picking.origin)])
+                if mrp_production.picking_out.id == picking.id:
+                    # Create in picking
+                    pick_in = picking.create({'partner_id': picking.partner_id.id,
+                                              'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                                              'origin': picking.origin})
+                    # Update reference in_picking and the state
+                    mrp_production.write({'state': 'in_production',
+                                          'picking_in': pick_in.id})
+                    cost_moves = sum(picking.move_lines.mapped('price_unit'))
+                    for move in production_obj.search([('name', '=', picking.origin)]).move_created_ids:
+                        move.write({'price_unit': cost_moves,
+                                    'picking_id': pick_in.id})
+                    pick_in.action_assign()
+                elif mrp_production.picking_in.id == picking.id:
+                    mrp_production.action_production_end()
         return res
 
 


### PR DESCRIPTION
[FIX] 'sale_product_customize': Arreglo para cuando se generan dos albaranes desde un pedido (depósitos incluidos en el mismo)