### PR TITLE
[11.0] Cambios en apartado comercial

### DIFF
--- a/project-addons/custom_account/views/stock_view.xml
+++ b/project-addons/custom_account/views/stock_view.xml
@@ -8,14 +8,17 @@
           <field name="arch" type="xml">
             <field name="note" position="replace">
               <group colspan="6" col="6">
-                    <field name="note" class="oe_inline" placeholder="Setup default terms and conditions in your sales settings ..." nolabel="1"/>
-                    <field name="internal_notes" class="oe_inline" placeholder="Internal Notes" nolabel="1"/>
-                    <field name="sale_notes" class="oe_inline" placeholder="Sale Order Internal Notes" nolabel="1"/>
+                    <field name="note" placeholder="Setup default terms and conditions in your sales settings ..." nolabel="1"/>
+                    <field name="internal_notes" placeholder="Internal Notes" nolabel="1"/>
+                    <field name="sale_notes" placeholder="Sale Order Internal Notes" nolabel="1"/>
                 </group>
             </field>
             <field name="partner_id" position="after">
                 <field name="partner_tags" widget="many2many_tags"/>
                 <field name="ref_partner" />
+            </field>
+            <field name="validity_date" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
           </field>
       </record>

--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -404,6 +404,11 @@ msgid "Global data"
 msgstr "Datos globales"
 
 #. module: custom_partner
+#: model:ir.ui.view,arch_db:custom_partner.partner_view_add_sale_analysis
+msgid "Sale analysis"
+msgstr "Análisis de ventas"
+
+#. module: custom_partner
 #: model:ir.ui.view,arch_db:custom_partner.view_res_partner_filter_add_comercial
 msgid "No current month sales"
 msgstr "Sin ventas este mes"

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -17,7 +17,7 @@
                     <field name="eur_currency" invisible="1"/>
                     <field name="purchase_quantity" groups="purchase.group_purchase_user" widget="monetary" options="{'currency_field': 'supplier_currency'}"/>
                 </field>
-                <xpath expr="//page[@name='sales_purchases']/group" position="after">
+                <xpath expr="//page[@name='sales_purchases']/group[2]" position="after">
                     <group string="Sale analysis" name="sale_analysis">
                         <field name="growth_rate"/>
                         <label for="average_margin" attrs="{'invisible': [('is_company', '!=', True)]}"/>

--- a/project-addons/purchase_picking/views/stock_view.xml
+++ b/project-addons/purchase_picking/views/stock_view.xml
@@ -39,6 +39,9 @@
                 <field name="usage" invisible="1"/>
                 <field name="shipping_identifier" attrs="{'required':[('usage', '=', 'supplier'), ('picking_type_code', '=', 'incoming')], 'invisible': [('picking_type_code', '!=', 'incoming')]}"/>
             </field>
+            <button name="button_scrap" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </button>
         </field>
     </record>
 

--- a/project-addons/sale_custom/__manifest__.py
+++ b/project-addons/sale_custom/__manifest__.py
@@ -14,6 +14,7 @@
         "base",
         "sale",
         "purchase",
+        "sale_stock",
         "sale_display_stock",
         "sale_margin_percentage",
         "partner_risk_advice",

--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -92,3 +92,8 @@ msgstr "Información del riesgo contable de una empresa"
 #, python-format
 msgid "Warnings"
 msgstr "Avisos"
+
+#. module: sale_custom
+#: view:sale.order:sale_custom.view_order_form_inherit_sale_stock_change_string
+msgid "Pickings"
+msgstr "Albaranes"

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -186,5 +186,17 @@
                 </header>
             </field>
         </record>
+    view_order_form_inherit_sale_stock
+
+    <record id="view_order_form_inherit_sale_stock_change_string" model="ir.ui.view">
+        <field name="name">sale.order.form.change.button.string</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
+        <field name="arch" type="xml">
+            <field name="delivery_count" position="attributes">
+                <attribute name="string">Pickings</attribute>
+            </field>
+        </field>
+    </record>
 
 </odoo>

--- a/project-addons/sale_order_board/wizard/picking_rated_wizard.py
+++ b/project-addons/sale_order_board/wizard/picking_rated_wizard.py
@@ -19,12 +19,13 @@
 ##############################################################################
 
 from odoo import models, fields
+from odoo.addons import decimal_precision as dp
 
 
 class PickingRatedWizard(models.TransientModel):
     _name = 'picking.rated.wizard'
 
-    total_weight = fields.Char('Total Weight (Kgs)', readonly=True)
+    total_weight = fields.Char('Total Weight (Kgs)', readonly=True, digits=dp.get_precision('Stock Weight'))
     products_wo_weight = fields.Char('', readonly=True)
     data = fields.One2many('picking.rated.wizard.tree', 'wizard_id', string='Shipping Data', readonly=True)
 

--- a/project-addons/sale_product_customize/view/sale_view.xml
+++ b/project-addons/sale_product_customize/view/sale_view.xml
@@ -12,11 +12,6 @@
                     <field name="requires_mount"  invisible="1"/>
                     <field name="can_mount_id" widget="selection" domain="[('head_product_id', '=', product_id)]" attrs="{'invisible': [('requires_mount', '=', False)], 'required': [('requires_mount', '=', True)]}"/>/>
                 </xpath>
-                <xpath expr="//field[@name='order_line']/tree//field[@name='tax_id']" position="after">
-                    <field name="customization_types"  widget="many2many_tags"/>
-                    <field name="requires_mount"  invisible="1"/>
-                    <field name="can_mount_id"  widget="selection" domain="[('head_product_id', '=', product_id)]" attrs="{'readonly': [('requires_mount', '=', False)], 'required': [('requires_mount', '=', True)]}"/>
-                </xpath>
                 <xpath expr="//field[@name='order_line']/tree//field[@name='product_id']" position="attributes">
                     <attribute name="domain">[('custom', '=', False),('sale_ok', '=', True)]</attribute>
                 </xpath>

--- a/project-addons/scheduled_shipment/models/sale.py
+++ b/project-addons/scheduled_shipment/models/sale.py
@@ -20,7 +20,7 @@ class SaleOrder(models.Model):
 
     _inherit = 'sale.order'
 
-    scheduled_date = fields.Datetime('Scheduled Date')
+    scheduled_date = fields.Datetime('Scheduled shipping date')
 
     @api.multi
     def write(self, vals):

--- a/project-addons/scheduled_shipment/views/sale_view.xml
+++ b/project-addons/scheduled_shipment/views/sale_view.xml
@@ -35,6 +35,9 @@
                 <field name="priority" position="after">
                     <field name="scheduled_shipping_date"/>
                 </field>
+                <field name="scheduled_date" position="before">
+                    <field name="date"/>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
- [MIG]'sale_product_customize': eliminados campos personaliza y monta de lineas de pedido
- [UPD]'custom_account': redimensionados campos de notas y ocultada fecha de caducidad
- [FIX]'sale_order_board': añadida limitación de decimales 
- [UPD]'sale_custom': cambio de etiqueta del botón de albaranes en pedido 
- [UPD]'scheduled_shipment': añadido campo de fecha de creación al albarán 
- [UPD]'purchase_picking': ocultado boton de desechar 
- [UPD]'custom_partner': reorganizada vista de Ventas y compras 