### PR TITLE
[11.0] Arreglos en apartado comercial

### DIFF
--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -429,3 +429,7 @@ msgstr "Referencia de pago"
 msgid "Email web must be unique"
 msgstr "El email web debe ser único"
 
+#. module: custom_partner
+#: model:ir.ui.view,arch_db:custom_partner.res_partner_view_buttons_change_string
+msgid "Orders"
+msgstr "Pedidos"

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -471,6 +471,17 @@
             </field>
         </record>
 
+        <record id="res_partner_view_buttons_change_string" model="ir.ui.view">
+            <field name="name">res.partner.view.buttons.change.string</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="sale.res_partner_view_buttons"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button/field[@name='sale_order_count']" position="attributes">
+                    <attribute name="string">Orders</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <menuitem id="contacts.menu_localisation" name="Localization"
             parent="crm.crm_menu_config" sequence="5"/>
 

--- a/project-addons/partner_risk_advice/views/res_partner_view.xml
+++ b/project-addons/partner_risk_advice/views/res_partner_view.xml
@@ -4,9 +4,9 @@
     <record model="ir.ui.view" id="view_partner_form_risk_advice">
         <field name="name">res.partner.form.risk_advice</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="account.partner_view_buttons" />
+        <field name="inherit_id" ref="sale.res_partner_view_buttons" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_warn']/.." position="after">
+            <xpath expr="//field[@name='sale_warn']/.." position="after">
                 <group colspan="2" col="2">
                     <separator string="Warnign on the RMA" colspan="4"/>
                         <field name="rma_warn" nolabel="1"/>

--- a/project-addons/reserve_without_save_sale/views/sale.xml
+++ b/project-addons/reserve_without_save_sale/views/sale.xml
@@ -23,7 +23,7 @@
                 <attribute name="invisible">True</attribute>
             </xpath>
             <button name="action_cancel" position="attributes">
-                <attribute name="states">draft,sent,reserve</attribute>
+                <attribute name="states">draft,sent,reserve,sale</attribute>
             </button>
             <button name="print_quotation" position="after">
                 <button name="print_quotation" string="Print" type="object" states="reserve" class="o_sale_print"/>

--- a/project-addons/reserve_without_save_sale/views/stock_reserve.xml
+++ b/project-addons/reserve_without_save_sale/views/stock_reserve.xml
@@ -41,5 +41,33 @@
             </field>
         </field>
     </record>
+    view_stock_reservation_search
+
+    <record id="view_stock_reservation_search_add_waiting" model="ir.ui.view">
+        <field name="name">stock.reservation.inherit.view.search.add.waiting</field>
+        <field name="model">stock.reservation</field>
+        <field name="inherit_id" ref="stock_reserve.view_stock_reservation_search"/>
+        <field name="arch" type="xml">
+            <filter name="cancel" position="before">
+                <filter name="waiting" string="Waiting"
+                        domain="[('state', '=', 'confirmed')]"
+                        help="Moves are waiting for product."/>
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_stock_reservation_tree_add_color" model="ir.ui.view">
+        <field name="name">stock.reservation.inherit.view.search.add.color</field>
+        <field name="model">stock.reservation</field>
+        <field name="inherit_id" ref="stock_reserve.view_stock_reservation_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-info">state == 'draft'</attribute>
+                <attribute name="decoration-muted">state == 'cancel'</attribute>
+                <attribute name="decoration-danger">state == 'confirmed'</attribute>
+                <attribute name="decoration-success">state == 'assigned'</attribute>
+            </xpath>
+        </field>
+    </record>
 
 </odoo>

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -49,35 +49,36 @@
             <form string="status Warnings">
                 <group colspan="2" col="2">
                     <separator string="Warning on the Sales Order" colspan="4"/>
-                        <field name="sale_warn" nolabel="1" />
+                        <field name="sale_warn" nolabel="1" readonly="1"/>
                         <field name="sale_warn_msg" colspan="3" nolabel="1"
                                 attrs="{'required':[('sale_warn','!=','no-message')],'readonly':[('sale_warn','=','no-message')]}"/>
                 </group>
                 <group colspan="2" col="2">
                     <separator string="Warning on the Purchase Order" colspan="4"/>
-                    <field name="purchase_warn" nolabel="1" />
+                    <field name="purchase_warn" nolabel="1" readonly="1"/>
                     <field name="purchase_warn_msg" colspan="3" nolabel="1"
                             attrs="{'required':[('purchase_warn','!=','no-message')],'readonly':[('purchase_warn','=','no-message')]}"/>
                     </group>
                     <group colspan="2" col="2">
                     <separator string="Warning on the Picking" colspan="4"/>
-                    <field name="picking_warn" nolabel="1" />
+                    <field name="picking_warn" nolabel="1" readonly="1"/>
                     <field name="picking_warn_msg" colspan="3" nolabel="1"
                             attrs="{'required':[('picking_warn','!=','no-message')],'readonly':[('picking_warn','=','no-message')]}"/>
                 </group>
                 <group colspan="2" col="2">
                     <separator string="Warning on the Invoice" colspan="4"/>
-                    <field name="invoice_warn" nolabel="1" />
+                    <field name="invoice_warn" nolabel="1" readonly="1"/>
                     <field name="invoice_warn_msg" colspan="3" nolabel="1"
                             attrs="{'required':[('invoice_warn','!=','no-message')],'readonly':[('invoice_warn','=','no-message')]}"/>
                 </group>
 
                     <group colspan="2" col="2">
                     <separator string="Warnign on the RMA" colspan="4"/>
-                        <field name="rma_warn" nolabel="1"/>
+                        <field name="rma_warn" nolabel="1" readonly="1"/>
                         <field name="rma_warn_msg" colspan="3" nolabel="1"
                                 attrs="{'required':[('rma_warn','!=','no-message')],'readonly':[('rma_warn','=','no-message')]}"/>
                 </group>
+                <footer></footer>
             </form>
         </field>
     </record>


### PR DESCRIPTION

[FIX]'reserve_without_save_sale': Añadido botón de cancelar al estado pedido en preparación
[IMP]'partner_risk_advice': recolocado campos 
[FIX]'sale_custom': Puesto wizard de avisos en solo lectur 
[IMP]'custom_partner': cambio de literal de ventas a pedidos 
[FIX]'reserve_without_save_sale': añadido de nuevo filtro para esperando disponibilidad y colores en reservas