### PR TITLE
[11.0] Arreglo en las promos y estado de pedido

### DIFF
--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -256,9 +256,7 @@ class CrmClaimRma(models.Model):
                     'account_analytic_id': False
                 }
                 if line.tax_ids:
-                    fiscal_position = claim_obj.partner_id. \
-                        property_account_position_id
-                    taxes_ids = fp_obj.map_tax(fiscal_position,line.tax_ids)
+                    taxes_ids = fp_obj.map_tax(line.tax_ids)
                     vals['invoice_line_tax_ids'] = [(6, 0, taxes_ids)]
                 line_obj = self.env['account.invoice.line']
                 line_obj.create(vals)

--- a/project-addons/reserve_without_save_sale/i18n/es.po
+++ b/project-addons/reserve_without_save_sale/i18n/es.po
@@ -27,3 +27,8 @@ msgstr "Esperando"
 #: model:ir.ui.view,arch_db:reserve_without_save_sale.view_stock_reservation_search_add_waiting
 msgid "Moves are waiting for product"
 msgstr "Movimientos esperando por productos"
+
+#. module: reserve_without_save_sale
+#: selection:sale.order,state:0
+msgid "Done"
+msgstr "Tramitado"

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -7,7 +7,15 @@ class SaleOrder(models.Model):
 
     _inherit = 'sale.order'
 
-    state = fields.Selection(selection_add=[('reserve', 'Reserved')])
+    # state = fields.Selection(selection_add=[('reserve', 'Reserved')])
+    state = fields.Selection([
+        ('draft', 'Quotation'),
+        ('sent', 'Quotation Sent'),
+        ('reserve', 'Reserved'),
+        ('sale', 'Sales Order'),
+        ('done', 'Done'),
+        ('cancel', 'Cancelled'),
+    ])
 
     @api.multi
     @api.depends('state',

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -72,7 +72,7 @@ class PromotionsRulesConditionsExprs(models.Model):
         elif attribute == 'order_pricelist':
             return """order.pricelist_id.name %s %s""" % (comparator, value)
         elif attribute == 'web_discount':
-            return "kwargs[%s]" % attribute
+            return "kwargs['%s']" % attribute
         else:
             return super().serialise(attribute, comparator, value)
 

--- a/project-addons/sale_promotions_extend/views/sale_view.xml
+++ b/project-addons/sale_promotions_extend/views/sale_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="commercial_rules.view_sale_promo_form" />
         <field name="arch" type="xml">
             <button name="apply_commercial_rules" position="replace">
-                <button name="apply_commercial_rules" type="object" states="draft,reserve" string="Compute final price" />
+                <button name="apply_commercial_rules" type="object" states="draft,reserve" string="Apply Promotions" />
             </button>
         </field>
     </record>
@@ -20,7 +20,7 @@
         <field name="arch" type="xml">
             <button name="action_cancel" position="before">
                 <group colspan="4" col="13">
-                    <button name="apply_commercial_rules" type="object" states="draft" string="Apply Promotions" />
+                    <button name="apply_commercial_rules" type="object" states="draft,reserve" string="Apply Promotions" />
                 </group>
             </button>
         </field>


### PR DESCRIPTION
- [FIX]'crm_claim_rma_custom': eliminado parámetro innecesario
- [IMP]'sale_promotions_extend': arreglado fallo en web_discount 
- [FIX]'reserve_without_save_sale': arreglado orden de statusbar y traducción