### PR TITLE
[11.0] Fix de albaranes de sat.

### DIFF
--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -127,6 +127,8 @@ class SaleOrder(models.Model):
                     message = _('Please, introduce a shipping cost line.')
                     raise exceptions.Warning(message)
 
+            self.apply_commercial_rules()
+
         return super().action_confirm()
 
 

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -139,7 +139,8 @@ class StockMove(models.Model):
 
     def _action_done(self):
         res = super()._action_done()
-        self.product_id.product_tmpl_id.recalculate_standard_price_2()
+        for line in self:
+            line.product_id.product_tmpl_id.recalculate_standard_price_2()
         return res
 
 


### PR DESCRIPTION
[FIX]'stock_custom': arreglo rápido al transferir albaranes de entrada
[FIX]'sale_custom': añadido aplicar promos al transpasar pedido 

Necesitaríamos este cambio aplicado cuanto antes, por que da un error al transferir albaranes de entrada y el departamento de sat está parado en las pruebas. Añado también un mini commit sobre promos.

Gracias.