### PR TITLE
[11.0] Arreglos SAT

### DIFF
--- a/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
+++ b/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
@@ -22,12 +22,6 @@ class EquivalentProductsWizard(models.TransientModel):
             res['product_tag_ids'] = [(6, 0, claim_line_id.product_id.tag_ids.ids)]
         return res
 
-    @api.onchange('product_id')
-    def onchange_product_id(self):
-        self.virtual_stock = self.product_id.virtual_available
-        self.real_stock = self.product_id.qty_available
-        self.product_tag_ids = self.product_id.tag_ids
-
     @api.multi
     def select_product(self):
         self.line_id.equivalent_product_id = self.product_id

--- a/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
+++ b/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
@@ -24,8 +24,6 @@ class EquivalentProductsWizard(models.TransientModel):
 
     @api.onchange('product_id')
     def onchange_product_id(self):
-        import ipdb
-        ipdb.set_trace()
         self.virtual_stock = self.product_id.virtual_available
         self.real_stock = self.product_id.qty_available
         self.product_tag_ids = self.product_id.tag_ids

--- a/project-addons/crm_claim_rma_custom/data/substate_data.xml
+++ b/project-addons/crm_claim_rma_custom/data/substate_data.xml
@@ -28,11 +28,6 @@
         <field name="active" eval="True"/>
     </record>
 
-    <record id="substate_pending_default" model="substate.substate">
-        <field name="name">Pte. por Impago</field>
-        <field name="active" eval="True"/>
-    </record>
-
     <record id="substate_replaced" model="substate.substate">
         <field name="name">Sustituido</field>
         <field name="active" eval="True"/>

--- a/project-addons/crm_claim_rma_custom/models/account_invoice.py
+++ b/project-addons/crm_claim_rma_custom/models/account_invoice.py
@@ -28,7 +28,7 @@ class AccountInvoice(models.Model):
     def write(self, vals):
         res = super(AccountInvoice, self).write(vals)
         if 'state' in vals.keys():
-            if vals['state'] == 'paid':
+            if vals['state'] == 'open':
                 for invoice in self:
                     invoice_line_ids = [x.id for x in invoice.invoice_line_ids]
                     substate_id = self.env.ref(

--- a/project-addons/crm_claim_rma_custom/models/stock.py
+++ b/project-addons/crm_claim_rma_custom/models/stock.py
@@ -47,7 +47,7 @@ class StockPicking(models.Model):
         return res
 
     @api.model
-    def do_transfer(self):
+    def action_done(self):
         for picking in self:
             if picking.claim_id:
                 for move in picking.move_lines:
@@ -62,7 +62,7 @@ class StockPicking(models.Model):
                             elif not move.claim_line_id.repair_id:
                                 move.claim_line_id.substate_id = self.env.ref(
                                     'crm_claim_rma_custom.substate_checked')
-        return super(StockPicking, self).do_transfer()
+        return super(StockPicking, self).action_done()
 
 
 class StockLocation(models.Model):

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -92,6 +92,7 @@
                           <button name="calculate_invoices" type="object"
                             string="Calculate"
                             attrs="{'invisible': [('invoice_ids', '!=', [])]}" colspan="2"/>
+                          <separator/>
                           <button name="make_refund_invoice"
                               attrs="{'invisible': [('claim_inv_line_ids', '=', [])]}"
                               type="object" string="New Refund" class="btn-primary" colspan="2"/>

--- a/project-addons/crm_claim_rma_custom/wizard/claim_make_picking.py
+++ b/project-addons/crm_claim_rma_custom/wizard/claim_make_picking.py
@@ -125,6 +125,5 @@ class ClaimMakePicking(models.TransientModel):
             if partner.commercial_partner_id.blocked_sales and not \
                     claim.allow_confirm_blocked:
                 raise exceptions.Warning(
-                    _("Warning for %s") % partner.commercial_partner_id.name,
                     _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.'))
         return super(ClaimMakePicking, self).default_get(vals)

--- a/project-addons/crm_claim_rma_custom/wizard/equivalent_products_wizard.py
+++ b/project-addons/crm_claim_rma_custom/wizard/equivalent_products_wizard.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class EquivalentProductsWizard(models.TransientModel):
@@ -17,8 +17,12 @@ class EquivalentProductsWizard(models.TransientModel):
             res['virtual_stock_conservative'] = claim_line_id.product_id.virtual_stock_conservative
         return res
 
-    def onchange_product_id(self):
-        super(EquivalentProductsWizard, self).onchange_product_id()
+    @api.onchange('product_id')
+    def onchange_product(self):
+        # super(EquivalentProductsWizard, self).onchange_product()
         self.kitchen_stock = self.product_id.qty_available_wo_wh
         self.virtual_stock_conservative = self.product_id.virtual_stock_conservative
         self.qty_available_external = self.product_id.qty_available_external
+        self.virtual_stock = self.product_id.virtual_available
+        self.real_stock = self.product_id.qty_available
+        self.product_tag_ids = self.product_id.tag_ids

--- a/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
+++ b/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
@@ -49,7 +49,7 @@ class ClaimMakePickingFromPicking(models.TransientModel):
                 loc_field = 'lot_%s_id' % context_loc
             else:
                 loc_field = "wh_input_stock_loc_id"
-            loc_id = warehouse_id.read([loc_field])[0]['id']
+            loc_id = warehouse_id.read([loc_field])[0][loc_field][0]
         return loc_id
 
     picking_line_source_location = fields.Many2one('stock.location',

--- a/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
+++ b/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking.py
@@ -49,7 +49,7 @@ class ClaimMakePickingFromPicking(models.TransientModel):
                 loc_field = 'lot_%s_id' % context_loc
             else:
                 loc_field = "wh_input_stock_loc_id"
-            loc_id = warehouse_id.read([loc_field])[0][loc_field][0]
+            loc_id = warehouse_id.read([loc_field])[0]['id']
         return loc_id
 
     picking_line_source_location = fields.Many2one('stock.location',

--- a/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking_view.xml
+++ b/project-addons/crm_rma_advance_location/wizard/claim_make_picking_from_picking_view.xml
@@ -11,8 +11,10 @@
         <field name="arch" type="xml">
             <form string="Select lines to add in picking">
                 <separator string="Locations" colspan="4"/>
-                <field name="picking_line_source_location" nolabel="1" />
-                <field name="picking_line_dest_location" nolabel="1" />
+                <group>
+                    <field name="picking_line_source_location" nolabel="1" colspan="4"/>
+                    <field name="picking_line_dest_location" nolabel="1" colspan="4" />
+                </group>
                 <separator string="Select lines for picking" colspan="4"/>
                 <field name="picking_line_ids" nolabel="1" colspan="4"/>
                 <footer>


### PR DESCRIPTION
- [FIX]'crm_claim_rma_custom': areglado cambio automatico de subestado en rma y añadido separador
- [FIX]'crm_claim_rma_custom': arreglado warning problemático
- [DEL]'crm_claim_rma_custom': Borrado estado sin uso
- [FIX]'crm_rma_advance_location': arreglado problema al recuperar localización del almacén
- [FIX]'crm_rma_advance_location': revertido cambio anterior 
- [IMP]'crm_claim_rma_custom': se pone el producto abonado al crear una nueva factura
- [IMP]'crm_rma_advance_location': alargados campos de localización
- [FIX]'crm_claim_rma': eliminado ipdb
- [FIX]'crm_claim_rma_custom': añadida función entera de onchange de product
- [FIX]'crm_claim_rma': eliminada función de onchange de product, movida a crm_claim_rma_custom