### PR TITLE
Configuración rappel

### DIFF
--- a/project-addons/custom_partner/rappel_view.xml
+++ b/project-addons/custom_partner/rappel_view.xml
@@ -32,6 +32,7 @@
                     <field name="description"/>
                     <field name="sequence" groups="base.group_system"/>
                     <field name="discount_voucher" groups="base.group_system"/>
+                    <field name="partner_add_conditions" groups="base.group_system"/>
                     <field name="pricelist_ids" groups="base.group_system"
                            attrs="{'invisible':[('discount_voucher','=', False)]}"/>
                 </field>


### PR DESCRIPTION

[IMP] 'custom_partner': Nuevo campo para introducir condiciones adiocionales para que se actualice con el cron automáticamente los clientes que pertenecen al rappel y corrección de búsqueda de facturas cuando se configura el rappel por producto comprado