### PR TITLE
[11.0] Añadidas queries de ventas en 60 días

### DIFF
--- a/project-addons/purchase_proposal/models/product.py
+++ b/project-addons/purchase_proposal/models/product.py
@@ -1,7 +1,6 @@
 # © 2019 Comunitea
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import models, fields, api
-from odoo.tools.profiler import profile
 
 class ProductProduct(models.Model):
 
@@ -35,7 +34,7 @@ class ProductProduct(models.Model):
     security_margin = fields.Integer()
     average_margin = fields.Float("Average Margin Last Sales", readonly=True)
     ref_manufacturer = fields.Char(related='manufacturer_pref', readonly=True)
-    @profile
+
     @api.model
     def compute_last_sixty_days_sales(self, records=False):
         query = """select pp.id,(select sum(product_uom_qty) from stock_move

--- a/project-addons/sale_promotions_extend/models/product.py
+++ b/project-addons/sale_promotions_extend/models/product.py
@@ -31,7 +31,7 @@ class ProductTag(models.Model):
         for t in self:
             tagsb.append(t.name)
             if t.parent_id:
-                tagsa = t.parent_id._get_tag_recursivity([t.parent_id.id])
+                tagsa = t.parent_id._get_tag_recursivity()
                 if tagsa:
                     tags = list(set(tagsa + tagsb))
         if tags:


### PR DESCRIPTION
- [FIX]'sale_promotions_extend': quitado parámetro innecesario en función _get_tag_recursivity
- [UPD]'purchase_proposal': añadidas queries para el cálculo de ventas 60 días
- [UPD]'purchase_proposal': adaptado query y código a los nuevos campos de la v11
- [FIX]'purchase_proposal': eliminado profile