### PR TITLE
[11.0] Crear abonos desde RMA para clientes bloqueados

### DIFF
--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -263,7 +263,8 @@ class CrmClaimRma(models.Model):
 
                 line.invoiced = True
 
-            invoice_id.write({'origin_invoices_ids': [(6, 0, list(set(rectified_invoice_ids)))]})
+            invoice_id.write({'origin_invoices_ids': [(6, 0, list(set(rectified_invoice_ids)))],
+                              'allow_confirm_blocked': claim_obj.allow_confirm_blocked})
             invoice_id.compute_taxes()
             invoice_id.action_invoice_open()
 


### PR DESCRIPTION
[FIX] crm_claim_rma_custom: Marcar "Permitir confirmar" del abono generado para clientes bloqueados cuando en el RMA está marcado el check "Permitir envío"