### PR TITLE
[11.0] Comunicados control de crédito desde ficha cliente

### DIFF
--- a/project-addons/account_move_line_followup/__init__.py
+++ b/project-addons/account_move_line_followup/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/project-addons/account_move_line_followup/__manifest__.py
+++ b/project-addons/account_move_line_followup/__manifest__.py
@@ -11,6 +11,7 @@
                 'custom_account'],
     'data': ['data/ir_cron.xml',
              'data/credit_control_data.xml',
+             'views/credit_control_communication_view.xml',
              'views/partner_view.xml',
              'wizard/wiz_send_followup_partner_view.xml'],
     'description': '''Update follow-up data in account move lines''',

--- a/project-addons/account_move_line_followup/__manifest__.py
+++ b/project-addons/account_move_line_followup/__manifest__.py
@@ -11,7 +11,8 @@
                 'custom_account'],
     'data': ['data/ir_cron.xml',
              'data/credit_control_data.xml',
-             'views/partner_view.xml'],
+             'views/partner_view.xml',
+             'wizard/wiz_send_followup_partner_view.xml'],
     'description': '''Update follow-up data in account move lines''',
     'installable': True,
 }

--- a/project-addons/account_move_line_followup/i18n/es.po
+++ b/project-addons/account_move_line_followup/i18n/es.po
@@ -20,3 +20,44 @@ msgstr ""
 msgid "Worst C&C notify date"
 msgstr "Peor fecha notificación C&C"
 
+#. module: account_move_line_followup
+#: model:ir.model.fields,field_description:account_move_line_followup.field_credit_control_communication_move_line_ids
+msgid "Account Move Lines"
+msgstr "Apuntes contables"
+
+#. module: account_move_line_followup
+#: model:ir.model.fields,field_description:account_move_line_followup.field_credit_control_communication_email_type
+msgid "Email Type"
+msgstr "Tipo Email"
+
+#. module: account_move_line_followup
+#: selection:credit.control.communication,email_type:0
+msgid "Automatic email"
+msgstr "Email automático"
+
+#. module: account_move_line_followup
+#: selection:credit.control.communication,email_type:0
+msgid "Manual email"
+msgstr "Email manual"
+
+#. module: account_move_line_followup
+#: model:ir.model.fields,field_description:account_move_line_followup.field_wiz_send_followup_partner_level_id
+msgid "Followup Level"
+msgstr "Nivel de seguimiento"
+
+#. module: account_move_line_followup
+#: model:ir.ui.view,arch_db:account_move_line_followup.view_partners_form_add_communication_button
+msgid "Debt communications"
+msgstr "Comunicación deuda"
+
+#. module: account_move_line_followup
+#: model:ir.ui.view,arch_db:account_move_line_followup.view_partner_inherit_followup_form_3
+msgid "Send debt email"
+msgstr "Enviar email deuda"
+
+#. module: account_move_line_followup
+#: model:ir.ui.view,arch_db:account_move_line_followup.send_partner_followup_view
+#: model:ir.actions.act_window,name:account_move_line_followup.action_send_partner_followup
+msgid "Send Partner Followup"
+msgstr "Enviar seguimiento deuda"
+

--- a/project-addons/account_move_line_followup/i18n/es.po
+++ b/project-addons/account_move_line_followup/i18n/es.po
@@ -61,3 +61,9 @@ msgstr "Enviar email deuda"
 msgid "Send Partner Followup"
 msgstr "Enviar seguimiento deuda"
 
+#. module: account_move_line_followup
+#: model:ir.actions.act_window,name:account_move_line_followup.action_customer_followup_debt
+#: model:ir.ui.menu,name:account_move_line_followup.credit_control_customer_followup_action_menu
+msgid "Customer Follow-Ups"
+msgstr "Foto deuda"
+

--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -67,14 +67,26 @@ class CreditControlRun(models.Model):
         if lines:
             comm_obj = self.env['credit.control.communication']
             comms_email = comm_obj._generate_comm_from_credit_lines_custom(lines)
-            comms_email._generate_emails()
+            for comm in comms_email:
+                email = comm._generate_emails()
+                # Associate communication_id to generated email
+                email.write({'model': 'credit.control.communication',
+                             'res_id': comm.id})
+                # Send email
+                email.send()
 
 
 class CreditCommunication(models.TransientModel):
 
-    _inherit = "credit.control.communication"
+    _name = 'credit.control.communication'
+    _inherit = ['credit.control.communication', 'mail.thread']
+    _order = 'report_date desc, id desc'
 
     move_line_ids = fields.Many2many('account.move.line', rel='comm_aml_rel', string="Account Move Lines")
+    email_type = fields.Selection([
+        ('automatic', 'Automatic email'),
+        ('manual', 'Manual email')],
+        "Email Type")
 
     @api.model
     def _clean_all_partner_followup(self):
@@ -152,6 +164,7 @@ class CreditCommunication(models.TransientModel):
                     data['partner_id'] = group['partner_id']
                     data['current_policy_level'] = partner_policy_level_id
                     data['currency_id'] = group['currency_id'] or company_currency.id
+                    data['email_type'] = 'automatic'
                     comm = self.create(data)
 
                     move_lines = comm._get_unreconciled_move_lines()

--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -69,6 +69,7 @@ class CreditControlRun(models.Model):
             comms_email = comm_obj._generate_comm_from_credit_lines_custom(lines)
             comms_email._generate_emails()
 
+
 class CreditCommunication(models.TransientModel):
 
     _inherit = "credit.control.communication"

--- a/project-addons/account_move_line_followup/models/res_partner.py
+++ b/project-addons/account_move_line_followup/models/res_partner.py
@@ -38,9 +38,16 @@ class ResPartner(models.Model):
             partner.payment_amount_overdue = amount_overdue
             partner.payment_earliest_due_date = worst_due_date
 
+    @api.multi
+    def _communications_count(self):
+        communications_obj = self.env['credit.control.communication']
+        for partner in self:
+            partner.communications_count = communications_obj.search_count([('partner_id', 'child_of', [partner.id])])
+
+    communications_count = fields.Integer(string="Communication", compute='_communications_count')
+
     payment_amount_due = fields.Float(compute='_get_amounts_and_date', string="Amount Due", store=True, readonly=True)
     payment_amount_overdue = fields.Float(compute='_get_amounts_and_date', string="Amount Overdue", readonly=True)
     payment_earliest_due_date = fields.Date(compute='_get_amounts_and_date', string="Worst Due Date", readonly=True)
     latest_followup_level_id = fields.Many2one('credit.control.policy.level', "Latest Follow-up Level", readonly=True)
-
 

--- a/project-addons/account_move_line_followup/views/credit_control_communication_view.xml
+++ b/project-addons/account_move_line_followup/views/credit_control_communication_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!--Communication Form View -->
+        <record model="ir.ui.view" id="partner_credit_control_communications_form">
+            <field name="name">Credit Control Communication Form</field>
+            <field name="model">credit.control.communication</field>
+            <field name="arch" type="xml">
+                <form string="Communication" create="false" edit="false">
+                    <sheet>
+                        <div>
+                            <group name="form_data">
+                                <field name="current_policy_level"/>
+                                <field name="report_date"/>
+                                <field name="move_line_ids"/>
+                            </group>
+                        </div>
+                    </sheet>
+                    <div class="oe_chatter">
+                      <field name="message_follower_ids" widget="mail_followers" groups="base.group_user"/>
+                      <field name="message_ids" widget="mail_thread"/>
+                  </div>
+                </form>
+            </field>
+        </record>
+
+        <!--Communication Form Tree -->
+        <record model="ir.ui.view" id="partner_credit_control_communications_tree">
+            <field name="name">Credit Control Communication Tree</field>
+            <field name="model">credit.control.communication</field>
+            <field name="arch" type="xml">
+                <tree string="Communications" create="false" edit="false">
+                    <field name="report_date"/>
+                    <field name="current_policy_level"/>
+                    <field name="email_type"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="partner_credit_control_communications_action">
+            <field name="name">Credit Control Communication</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">credit.control.communication</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/account_move_line_followup/views/partner_view.xml
+++ b/project-addons/account_move_line_followup/views/partner_view.xml
@@ -70,5 +70,26 @@
                 sequence="40"
                 id="credit_control_customer_followup_action_menu"/>
 
+        <record id="view_partners_form_add_communication_button" model="ir.ui.view">
+            <field name="name">view.res.partner.form.inherited.add.communications</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="groups_id" eval="[(4, ref('sales_team.group_sale_manager')),
+                                           (4, ref('base.group_partner_manager'))]"/>
+            <field eval="20" name="priority"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//div[@name='button_box']" position="inside">
+                        <button class="oe_inline oe_stat_button" type="action"
+                                name="%(account_move_line_followup.partner_credit_control_communications_action)d"
+                                icon="fa-file-text-o"
+                                context="{'search_default_partner_id': active_id}">
+                            <field string="Debt communications" name="communications_count" widget="statinfo"/>
+                        </button>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/project-addons/account_move_line_followup/wizard/__init__.py
+++ b/project-addons/account_move_line_followup/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wiz_send_followup_partner

--- a/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner.py
+++ b/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner.py
@@ -1,0 +1,53 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class WizSendFollowupPartner(models.TransientModel):
+    _name = 'wiz.send.followup.partner'
+    _description = 'Send followup communication'
+
+    level_id = fields.Many2one('credit.control.policy.level', 'Level', required=True)
+    communication_id = fields.Many2one('credit.control.communication')
+    company_id = fields.Many2one('res.company', string='Company',
+                                 default=lambda self: self.env.user.company_id)
+
+    @api.multi
+    def preview_partner_followup_email(self):
+        partner_id = self.env['res.partner'].browse(self._context.get('active_ids', []))
+        composer_form_view_id = self.env.ref('mail.email_compose_message_wizard_form').id
+        if not self.level_id:
+            # Return warning required level policy
+            pass
+        self.communication_id = self.env['credit.control.communication']. create({
+            'partner_id': partner_id.id,
+            'current_policy_level': self.level_id.id,
+            'currency_id': self.env.user.company_id.currency_id.id
+        })
+        move_lines = self.communication_id._get_unreconciled_move_lines()
+        self.communication_id.write({'move_line_ids': [(6, 0, move_lines.ids)]})
+
+        template_id = self.level_id.email_template_id
+        """email_values = template.generate_email(self.communication_id.id)
+        self.email_body = email_values['body_html']
+
+        return {"type": "ir.actions.do_nothing"}"""
+        return {
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'mail.compose.message',
+            'view_id': composer_form_view_id,
+            'target': 'new',
+            'context': {
+                'default_composition_mode': 'comment',
+                'default_res_id': self.communication_id.id,
+                'default_model': 'credit.control.communication',
+                'default_use_template': bool(template_id.id),
+                'default_template_id': template_id.id,
+                'website_sale_send_recovery_email': True,
+                'active_ids': self.communication_id.id,
+            },
+        }
+
+
+

--- a/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner.py
+++ b/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner.py
@@ -1,36 +1,53 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
+from datetime import datetime
 
 
 class WizSendFollowupPartner(models.TransientModel):
     _name = 'wiz.send.followup.partner'
     _description = 'Send followup communication'
 
-    level_id = fields.Many2one('credit.control.policy.level', 'Level', required=True)
-    communication_id = fields.Many2one('credit.control.communication')
+    level_id = fields.Many2one('credit.control.policy.level', 'Followup Level', required=True)
     company_id = fields.Many2one('res.company', string='Company',
                                  default=lambda self: self.env.user.company_id)
 
     @api.multi
     def preview_partner_followup_email(self):
         partner_id = self.env['res.partner'].browse(self._context.get('active_ids', []))
+        communication_obj = self.env['credit.control.communication']
         composer_form_view_id = self.env.ref('mail.email_compose_message_wizard_form').id
-        if not self.level_id:
-            # Return warning required level policy
-            pass
-        self.communication_id = self.env['credit.control.communication']. create({
-            'partner_id': partner_id.id,
-            'current_policy_level': self.level_id.id,
-            'currency_id': self.env.user.company_id.currency_id.id
-        })
-        move_lines = self.communication_id._get_unreconciled_move_lines()
-        self.communication_id.write({'move_line_ids': [(6, 0, move_lines.ids)]})
+
+        # Search all manual communications for this partner
+        comm_manual = communication_obj.search(
+            [('partner_id', '=', partner_id.id),
+             ('email_type', '=', 'manual')])
+        # Search manual communications with email sent
+        comm_with_email = communication_obj.search(
+            [('partner_id', '=', partner_id.id),
+             ('email_type', '=', 'manual'),
+             ('message_ids.message_type', 'in', ['comment'])])
+        # The difference: manual communications without email sent
+        comm_without_email = set(tuple(comm_manual)) - set(tuple(comm_with_email))
+
+        if comm_without_email:
+            # Use that draft communication to generate a email preview
+            communication_id = tuple(comm_without_email)[0]
+            communication_id.write({
+                'report_date': datetime.now().strftime('%Y-%m-%d'),
+                'current_policy_level': self.level_id.id
+            })
+        else:
+            communication_id = communication_obj.create({
+                'partner_id': partner_id.id,
+                'current_policy_level': self.level_id.id,
+                'currency_id': self.env.user.company_id.currency_id.id,
+                'email_type': 'manual'
+            })
+
+        move_lines = communication_id._get_unreconciled_move_lines()
+        communication_id.write({'move_line_ids': [(6, 0, move_lines.ids)]})
 
         template_id = self.level_id.email_template_id
-        """email_values = template.generate_email(self.communication_id.id)
-        self.email_body = email_values['body_html']
-
-        return {"type": "ir.actions.do_nothing"}"""
         return {
             'type': 'ir.actions.act_window',
             'view_type': 'form',
@@ -40,14 +57,12 @@ class WizSendFollowupPartner(models.TransientModel):
             'target': 'new',
             'context': {
                 'default_composition_mode': 'comment',
-                'default_res_id': self.communication_id.id,
+                'default_res_id': communication_id.id,
                 'default_model': 'credit.control.communication',
                 'default_use_template': bool(template_id.id),
                 'default_template_id': template_id.id,
                 'website_sale_send_recovery_email': True,
-                'active_ids': self.communication_id.id,
+                'active_ids': communication_id.id,
             },
         }
-
-
 

--- a/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner_view.xml
+++ b/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+         <record id="send_partner_followup_view" model="ir.ui.view">
+               <field name="name">send_partner_followup</field>
+               <field name="model">wiz.send.followup.partner</field>
+               <field name="arch" type="xml">
+                    <form string="Send Partner Followup">
+                            <field name="company_id" invisible="1"/>
+                            <field name="level_id"
+                                   domain="[('policy_id.company_id', '=', company_id),
+                                            ('channel', '=', 'email')]"
+                                   options='{"create":False,"create_edit": False,"no_open": True}'/> 
+                             <button string="Preview" name="preview_partner_followup_email"
+                                    icon="fa-envelope" type="object" colspan="2"/>
+                    </form>
+               </field>
+          </record>
+
+          <record id="action_send_partner_followup" model="ir.actions.act_window">
+                 <field name="name">Send Partner Followup</field>
+                 <field name="res_model">wiz.send.followup.partner</field>
+                 <field name="type">ir.actions.act_window</field>
+                 <field name="view_type">form</field>
+                 <field name="view_mode">form</field>
+                 <field name="view_id" ref="send_partner_followup_view"/>
+                 <field name="target">new</field>
+           </record>
+
+          <record id="view_partner_inherit_followup_form_3" model="ir.ui.view">
+                <field name="name">res.partner.followup.form.inherit.3</field>
+                <field name="model">res.partner</field>
+                <field name="inherit_id" ref="account_move_line_followup.view_partner_inherit_followup_form_2"/>
+                <field name="arch" type="xml">
+                    <field name="worst_cyc_notify_date" position="after">
+                        <separator/>
+                        <button string="Send followup email" name="%(action_send_partner_followup)d"
+                                type="action" colspan="2"/>
+                    </field>
+                </field>
+           </record>
+
+    </data>
+</odoo>

--- a/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner_view.xml
+++ b/project-addons/account_move_line_followup/wizard/wiz_send_followup_partner_view.xml
@@ -7,14 +7,20 @@
                <field name="model">wiz.send.followup.partner</field>
                <field name="arch" type="xml">
                     <form string="Send Partner Followup">
+                        <group>
                             <field name="company_id" invisible="1"/>
                             <field name="level_id"
                                    domain="[('policy_id.company_id', '=', company_id),
                                             ('channel', '=', 'email')]"
-                                   options='{"create":False,"create_edit": False,"no_open": True}'/> 
-                             <button string="Preview" name="preview_partner_followup_email"
+                                   options="{'no_create': True, 'no_open': True}"/>
+                        </group>
+                        <footer>
+                        <button string="Preview" name="preview_partner_followup_email"
                                     icon="fa-envelope" type="object" colspan="2"/>
+                        <button string="Cancel" class="btn-default" special="cancel" />
+                        </footer>
                     </form>
+
                </field>
           </record>
 
@@ -35,7 +41,7 @@
                 <field name="arch" type="xml">
                     <field name="worst_cyc_notify_date" position="after">
                         <separator/>
-                        <button string="Send followup email" name="%(action_send_partner_followup)d"
+                        <button string="Send debt email" name="%(action_send_partner_followup)d"
                                 type="action" colspan="2"/>
                     </field>
                 </field>


### PR DESCRIPTION
- [DEV] account_move_line_followup: Añadida funcionalidad para enviar cominicados de control de crédito desde el cliente. Falta permitir ver comunicados ya enviados.
- [IMP] account_move_line_followup: Añadido smart button en cliente para ver todas las comunicaciones de deuda enviadas. Distinción entre automáticas y enviadas manualmente.
- [I18N] account_move_line_followup: Añadida traducción al menú de la deuda activa de clientes