### PR TITLE
[11.0] Cambios varios

### DIFF
--- a/project-addons/custom_partner/i18n/es.po
+++ b/project-addons/custom_partner/i18n/es.po
@@ -443,6 +443,14 @@ msgid "Customer situation"
 msgstr "Situación del cliente"
 
 #. module: custom_partner
+#: model:ir.ui.view,arch_db:custom_partner.view_partner_inherit_followup_form
+#: model:ir.ui.view,arch_db:custom_partner.view_partner_situation_tree
+#: model:ir.actions.act_window,name:custom_partner.partner_situation_action
+#: model:ir.ui.view,arch_db:custom_partner.res_partner_view_buttons_add_followup
+msgid "Supplier Situation"
+msgstr "Situación del proveedor"
+
+#. module: custom_partner
 #: model:ir.ui.view,arch_db:custom_partner.view_partner_situation_tree
 msgid "Partial reconciliation"
 msgstr "Reconciliación parcial"

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -353,6 +353,16 @@
                 ('account_id.internal_type', '=', 'receivable')]</field>
         </record>
 
+        <record model="ir.actions.act_window" id="supplier_situation_action">
+            <field name="name">Supplier Situation</field>
+            <field name="res_model">account.move.line</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_partner_situation_tree"/>
+            <field name="domain">[('full_reconcile_id', '=', False),('account_id.deprecated','=', False),
+                ('account_id.internal_type', '=', 'payable'), ('account_id.not_payment_followup', '=', False)]</field>
+        </record>
+
         <record id="res_partner_view_buttons_add_followup" model="ir.ui.view">
             <field name="name">res.partner.view.buttons.add_followup</field>
             <field name="model">res.partner</field>
@@ -360,9 +370,15 @@
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_inline oe_stat_button" type="action" name="%(partner_situation_action)d"
-                        string="Customer situation"
+                        string="Customer Situation"
                         icon="fa-thermometer-half"
-                        context="{'search_default_partner_id': active_id}"/>
+                        context="{'search_default_partner_id': active_id}"
+                        attrs="{'invisible': [('customer','=', False)]}"/>
+                    <button class="oe_inline oe_stat_button" type="action" name="%(supplier_situation_action)d"
+                        string="Supplier Situation"
+                        icon="fa-thermometer-half"
+                        context="{'search_default_partner_id': active_id}"
+                        attrs="{'invisible': [('supplier','=', False)]}"/>
                 </xpath>
             </field>
         </record>

--- a/project-addons/custom_theme/views/menu_icons.xml
+++ b/project-addons/custom_theme/views/menu_icons.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <menuitem id="crm.crm_menu_root" web_icon="custom_theme,static/description/CRM_Icon_2.png"/>
-        <menuitem id="calendar.mail_menu_calendar" web_icon="custom_theme,static/description/Calendar_Icon_2.png"/>
-        <menuitem id="sale.sale_menu_root" web_icon="custom_theme,static/description/Sales_Icon_2.png"/>
-        <menuitem id="queue_job.menu_queue_job_root" web_icon="custom_theme,static/description/Queue_Icon_2.png"/>
-        <menuitem id="purchase.menu_purchase_root" web_icon="custom_theme,static/description/Purchases_Icon_2.png"/>
-        <menuitem id="stock.menu_stock_root" web_icon="custom_theme,static/description/Warehouse_Icon_2.png"/>
-        <menuitem id="account.menu_finance" web_icon="custom_theme,static/description/Invoicing_Icon_2.png"/>
-        <menuitem id="base.menu_management" web_icon="custom_theme,static/description/Modules_Icon_2.png"/>
-        <menuitem id="mrp.menu_mrp_root" web_icon="custom_theme,static/description/Production_Icon_2.png"/>
+        <menuitem id="crm.crm_menu_root" name="CRM" web_icon="custom_theme,static/description/CRM_Icon_2.png"/>
+        <menuitem id="calendar.mail_menu_calendar" name="Calendar" web_icon="custom_theme,static/description/Calendar_Icon_2.png"/>
+        <menuitem id="sale.sale_menu_root" name="Sales" web_icon="custom_theme,static/description/Sales_Icon_2.png"/>
+        <menuitem id="queue_job.menu_queue_job_root" name="Job Queue" web_icon="custom_theme,static/description/Queue_Icon_2.png"/>
+        <menuitem id="purchase.menu_purchase_root" name="Purchases" web_icon="custom_theme,static/description/Purchases_Icon_2.png"/>
+        <menuitem id="stock.menu_stock_root" name="Warehouse" web_icon="custom_theme,static/description/Warehouse_Icon_2.png"/>
+        <menuitem id="account.menu_finance" name="Invoicing" web_icon="custom_theme,static/description/Invoicing_Icon_2.png"/>
+        <menuitem id="base.menu_management" name="Apps" web_icon="custom_theme,static/description/Modules_Icon_2.png"/>
+        <menuitem id="mrp.menu_mrp_root" name="Manufacturing" web_icon="custom_theme,static/description/Production_Icon_2.png"/>
     </data>
 </odoo>

--- a/project-addons/picking_incidences/i18n/es.po
+++ b/project-addons/picking_incidences/i18n/es.po
@@ -82,7 +82,7 @@ msgid "Qty confirmed"
 msgstr "Cant. confirmada"
 
 #. module: picking_incidences
-#: model:ir.model.fields,field_description:picking_incidences.field_stock_move_qty_ready
+#: model:ir.ui.view,arch_db:picking_incidences.view_move_picking_tree_add_ready_qty
 msgid "Qty ready"
 msgstr "Cant. preparada"
 

--- a/project-addons/picking_incidences/i18n/es.po
+++ b/project-addons/picking_incidences/i18n/es.po
@@ -87,6 +87,11 @@ msgid "Qty ready"
 msgstr "Cant. preparada"
 
 #. module: picking_incidences
+#: model:ir.ui.view,arch_db:picking_incidences.view_move_picking_tree_add_ready_qty
+msgid "Qty ordered"
+msgstr "Cant. pedida"
+
+#. module: picking_incidences
 #: model:ir.model,name:picking_incidences.model_stock_move
 msgid "Stock Move"
 msgstr "Movimiento de existencias"

--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -109,10 +109,10 @@ class StockPicking(models.Model):
                 # ignore stock moves cancelled or already done
                 continue
             precision = move.product_uom.rounding
-            remaining_qty = move.product_uom_qty - move.qty_ready
+            remaining_qty = move.product_uom_qty - move.quantity_done
             remaining_qty = float_round(remaining_qty,
                                         precision_rounding=precision)
-            if not move.qty_ready:
+            if not move.quantity_done:
                 new_moves.append(move.id)
             elif float_compare(remaining_qty, 0, precision_rounding=precision) > 0 and \
                  float_compare(remaining_qty, move.product_qty, precision_rounding=precision) < 0:
@@ -121,7 +121,7 @@ class StockPicking(models.Model):
         if new_moves:
             new_moves = self.env['stock.move'].browse(new_moves)
             bcko = self._create_backorder_incidences(new_moves)
-            new_moves.write({'qty_ready': 0.0})
+            new_moves.write({'quantity_done': 0.0})
             #self.do_unreserve()
             #self.action_assign()
             #self.recheck_availability()

--- a/project-addons/picking_incidences/views/picking_view.xml
+++ b/project-addons/picking_incidences/views/picking_view.xml
@@ -41,6 +41,9 @@
                 <xpath expr="//field[@name='move_lines']/tree/field[@name='product_uom_qty']" position="after">
                     <field name="qty_confirmed"/>
                 </xpath>
+                <xpath expr="//field[@name='move_lines']/tree/field[@name='product_uom_qty']" position="attributes">
+                    <attribute name="string">Qty ordered</attribute>
+                </xpath>
             </field>
         </record>
 

--- a/project-addons/picking_incidences/views/picking_view.xml
+++ b/project-addons/picking_incidences/views/picking_view.xml
@@ -31,11 +31,15 @@
                 <xpath expr="//field[@name='move_lines']/tree/field[@name='product_id']" position="after">
                     <field name="location_id"/>
                     <field name="location_dest_id"/>
-                    <field name="qty_ready"/>
-                    <field name="qty_confirmed"/>
                 </xpath>
                 <xpath expr="//field[@name='move_lines']/tree/field[@name='quantity_done']" position="after">
                     <field name="state"/>
+                </xpath>
+                <xpath expr="//field[@name='move_lines']/tree/field[@name='quantity_done']" position="attributes">
+                    <attribute name="string">Qty ready</attribute>
+                </xpath>
+                <xpath expr="//field[@name='move_lines']/tree/field[@name='product_uom_qty']" position="after">
+                    <field name="qty_confirmed"/>
                 </xpath>
             </field>
         </record>
@@ -46,7 +50,6 @@
         <field name="inherit_id" ref="stock.view_move_picking_form"/>
         <field name="arch" type="xml">
             <field name="product_tmpl_id" position="before">
-                <field name="qty_ready"/>
                 <field name="qty_confirmed"/>
             </field>
         </field>

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -301,4 +301,8 @@
 
     <menuitem id="sale.sale_menu_root" action="action_orders_reserve"/>
 
+    <record id="sale.action_order_report_all" model="ir.actions.act_window">
+        <field name="view_mode">pivot,graph</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
- [IMP]'custom_theme': añadidos nombres de menu para no romperlos en inglés
- [IMP]'sale_custom': cambiado modo de mostrar el informe de venta a pivote
- [MIG]'picking_incidences': eliminada cantidad preparada y reubicación de cantidades en albarán
- [IMP]'picking_incidences': cambiado nobmre de demanda inicial a cantidad pedida
- [MIG]'custom_partner': añadido boton de situación de proveedor