### PR TITLE
[11.0] stock pedidos

### DIFF
--- a/project-addons/sale_display_stock/models/product.py
+++ b/project-addons/sale_display_stock/models/product.py
@@ -186,3 +186,11 @@ class ProductProduct(models.Model):
             else:
                 product.virtual_stock_conservative = product.qty_available - product.outgoing_qty - \
                                                 product.qty_available_wo_wh - product.qty_available_input_loc
+
+    @api.multi
+    def _compute_reservation_count(self):
+        for product in self:
+            domain = [('product_id', '=', product.id),
+                      ('state', 'in', ['draft', 'assigned', 'confirmed'])]
+            reservations = self.env['stock.reservation'].search(domain)
+            product.reservation_count = sum(reservations.mapped('product_qty'))


### PR DESCRIPTION
Hola, en este cambio hemos añadido las reservas que están esperando disponibilidad, por que las necesitamos que las tenga en cuenta a la hora de calcular el stock en pedidos, ya que si no se nos descuadraba el stock disponible.
Subo este cambio aparte por que esa función está en stock_reserve y no se si debería estar por defecto corregido alli o no.
Si no debería, pues aplicamos el parche, si no cancelamos el PR.