### PR TITLE
[11.0] Campo C&C en cliente y facturación antes de entrega

### DIFF
--- a/project-addons/order_invoice_policy/models/sale_order.py
+++ b/project-addons/order_invoice_policy/models/sale_order.py
@@ -29,7 +29,7 @@ class SaleOrderLine(models.Model):
         for line in lines:
             # Allow to invoice only quantity with stock (reserved)
             line.qty_to_invoice = sum(line.move_ids.filtered(lambda mv: mv.state == 'assigned').mapped('product_qty')) \
-                                  - line.qty_delivered - line.qty_invoiced
+                                  - (line.qty_invoiced - line.qty_delivered)
 
         super(SaleOrderLine, self - lines)._get_to_invoice_qty()
 

--- a/project-addons/order_invoice_policy/views/sale_order_view.xml
+++ b/project-addons/order_invoice_policy/views/sale_order_view.xml
@@ -7,9 +7,6 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_pay']/field[@name='invoice_status']" position="after">
                 <field name="order_invoice_policy"/>
-                <button name="change_order_invoice_policy" string="Change policy"
-                        type="object" groups="order_invoice_policy.group_change_order_invoice_policy"
-                        attrs="{'invisible': ['|', ('invoice_status', '=', 'invoiced'), ('state', '!=', 'sale')]}"/>
             </xpath>
         </field>
     </record>

--- a/project-addons/reserve_without_save_sale/controllers/main.py
+++ b/project-addons/reserve_without_save_sale/controllers/main.py
@@ -27,6 +27,16 @@ class WebsiteReservation(http.Controller):
                 'price_unit': float(post['price_unit']),
                 'unique_js_id': post['unique_js_id']
             }
+            if post.get('order_id'):
+                sale = request.env['sale.order'].browse(int(post['order_id']))
+                if not sale.procurement_group_id:
+                    group_id = self.env['procurement.group'].create({
+                            'name': sale.name,
+                            'move_type': sale.picking_policy,
+                            'sale_id': sale.id,
+                            'partner_id': sale.partner_shipping_id.id})
+                    sale.procurement_group_id = group_id.id
+                vals['group_id'] = sale.procurement_group_id.id
             new_reservation = request.env['stock.reservation'].create(vals)
             new_reservation.reserve()
             line_ids = request.env['sale.order.line'].search(

--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -106,6 +106,7 @@ class StockReservation(models.Model):
                     {'move_id': move.id, 'sale_line_id': current_sale_line_id})
             reservation.message_post(
                 body=_("Reserva modificada. Estado '%s'") % reservation.state)
+        res.mapped('picking_id').not_sync = True
         return res
 
     def release(self):

--- a/project-addons/reserve_without_save_sale/static/src/js/sale_order_line.js
+++ b/project-addons/reserve_without_save_sale/static/src/js/sale_order_line.js
@@ -23,6 +23,7 @@ odoo.define('reserve_without_save_sale', function(require) {
                 'price_unit': element.data.price_unit,
                 'name': element.data.name,
                 'warehouse': recordData.warehouse_id.data.id,
+                'order_id': recordData.id,
                 'csrf_token': require('web.core').csrf_token
             }
         },


### PR DESCRIPTION

- [UPD] account_move_line_followup: Mostrar campo "Siniestro declarado a C&C" en la ficha de cliente
- [FIX] order_invoice_policy: Corrección en la facturación antes de entrega. Se facturara solo lo que esté reservado.