### PR TITLE
[11.0] Permitir validar factura si está marcado Permitir confirmar en pedido

### DIFF
--- a/project-addons/block_invoices/models/account_invoice.py
+++ b/project-addons/block_invoices/models/account_invoice.py
@@ -19,8 +19,11 @@ class AccountInvoice(models.Model):
             # Compruebo la empresa actual y su padre...
             for partner in invoice.partner_id.get_partners_to_check():
                 if partner.blocked_sales and not invoice.allow_confirm_blocked:
-                    message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
-                    raise exceptions.Warning(message)
+                    if not invoice.sale_order_ids or \
+                            (invoice.sale_order_ids
+                             and any(not order.allow_confirm_blocked for order in invoice.sale_order_ids)):
+                        message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
+                        raise exceptions.Warning(message)
         return super().invoice_validate()
 
     @api.onchange('partner_id')


### PR DESCRIPTION
[IMP] block_invoices: No mostrar error de cliente bloqueado por impagos al validar una factura si proviene de un pedido en el cual se ha marcado como Permitir confirmar