### PR TITLE
[11.0] Corrección aplicar promo4x3

### DIFF
--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -248,7 +248,7 @@ class PromotionsRulesActions(models.Model):
         vals = {
             'order_id': order.id,
             'sequence': sequence,
-            # 'product_id':product_id.id,
+            'product_id': self.env.ref('commercial_rules.product_discount').id,
             'name': '%s (%s)' % (
                      product_id.default_code,
                      self.promotion.name),


### PR DESCRIPTION

[FIX] sale_promotion_extend: Corregido aplicar promociones en pedidos para promo4x3

