### PR TITLE
[11.0] Correcciones cron

### DIFF
--- a/project-addons/custom_partner/models/sale.py
+++ b/project-addons/custom_partner/models/sale.py
@@ -49,7 +49,8 @@ class SaleOrder(models.Model):
         sales = sale_obj.\
             search([('invoice_status', '=', 'to invoice'),
                     ('invoice_type_id.name', '=', 'Diaria'),
-                    ('tests', '=', False)],
+                    ('tests', '=', False),
+                    ('picking_ids.state', 'in', ['done'])],
                    order='confirmation_date')
 
         # Create invoice

--- a/project-addons/rappel_custom/models/res_partner_rappel_rel.py
+++ b/project-addons/rappel_custom/models/res_partner_rappel_rel.py
@@ -126,17 +126,13 @@ class ResPartnerRappelRel(models.Model):
 
                 if self.partner_id.invoice_type_id.name in \
                         ('Mensual', 'Quincenal', 'Semanal') and total_est:
-                    rappel_info,
-                    goal_percentage,
-                    total_rappel = self.compute_total(
+                    rappel_info, goal_percentage, total_rappel = self.compute_total(
                         rappel, total_est, rappel_info, True)
                 else:
                     rappel_info['amount_est'] = 0.0
 
                 if total:
-                    rappel_info,
-                    goal_percentage,
-                    total_rappel = self.compute_total(
+                    rappel_info, goal_percentage, total_rappel = self.compute_total(
                         rappel, total, rappel_info, False)
                 else:
                     rappel_info['amount'] = 0.0


### PR DESCRIPTION
[FIX] custom_partner, rappel_custom: Correcciones en crons. El de Facturación automática para que no facture solo gastos de envío; el de Rappel porque daba un error en local con la sintaxis anterior