### PR TITLE
[11.0] cambios en producto, pedido y albaranes

### DIFF
--- a/project-addons/custom_account/views/stock_view.xml
+++ b/project-addons/custom_account/views/stock_view.xml
@@ -23,6 +23,17 @@
           </field>
       </record>
 
+      <record id="view_order_form_change_button_2" model="ir.ui.view">
+          <field name="name">sale.order.form.change_button_2</field>
+          <field name="model">sale.order</field>
+          <field name="inherit_id" ref="sale_advance_payment.view_order_form_change_button"/>
+          <field name="arch" type="xml">
+            <button name="%(sale_advance_payment.action_view_account_voucher_wizard)d" position="attributes">
+                <attribute name="attrs">{'invisible': ['|',('state', '=', 'cancel'),('invoice_status', 'in', ['invoiced'])]}</attribute>
+            </button>
+          </field>
+      </record>
+
         <record id="sale.action_orders" model="ir.actions.act_window">
             <field name="domain">[('state', 'not in', ('draft', 'sent', 'cancel', 'reserve'))]</field>
             <field name="context">{

--- a/project-addons/product_states/__manifest__.py
+++ b/project-addons/product_states/__manifest__.py
@@ -25,7 +25,7 @@
     'description': """Adds states to the product""",
     'author': 'Pexego Sistemas Informáticos',
     'website': 'www.pexego.es',
-    "depends": ["base", "product", "sale_stock", "stock"],
+    "depends": ["base", "product", "sale_stock", "stock", "purchase"],
     "data": ["views/product_view.xml"],
     "installable": True
 }

--- a/project-addons/product_states/views/product_view.xml
+++ b/project-addons/product_states/views/product_view.xml
@@ -33,4 +33,15 @@
             </group>
         </field>
     </record>
+
+     <record id="product_change_purchase_page" model="ir.ui.view">
+        <field name="name">product.change.purchase.page</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="purchase.view_product_supplier_inherit"/>
+        <field name="arch" type="xml">
+            <page name="purchase" position="attributes">
+                <attribute name="attrs">{'invisible': 0}</attribute>
+            </page>
+        </field>
+    </record>
 </odoo>

--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -36,7 +36,7 @@ class StockContainer(models.Model):
                             picking_ids.append(move.picking_id)
                 date_expected = container.date_expected
                 for picking in picking_ids:
-                    new_vals = {'min_date': date_expected}
+                    new_vals = {'scheduled_date': date_expected}
                     picking.write(new_vals)
 
         return True

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -155,8 +155,7 @@ class SaleOrder(models.Model):
             if not sale.is_all_reserved and 'confirmed' not in self.env.context:
                 message = "Some of the products of this order {} aren't available now".format(self.name)
                 self.env.user.notify_info(title="Please consider that!",
-                                             message=message,
-                                             sticky=True)
+                                          message=message)
         return super().action_confirm()
 
 

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -94,6 +94,12 @@ class StockMove(models.Model):
     lots_text = fields.Text('Lots', help="Value must be separated by commas")
     sale_id = fields.Many2one('sale.order', related='sale_line_id.order_id', readonly=True)
 
+    def _compute_is_initial_demand_editable(self):
+        super()._compute_is_initial_demand_editable()
+        for move in self:
+            if move.picking_id.state == 'draft':
+                move.is_initial_demand_editable = True
+
     def _compute_responsible(self):
         for move in self:
             responsible = None

--- a/project-addons/transportation/models/stock.py
+++ b/project-addons/transportation/models/stock.py
@@ -55,84 +55,83 @@ class StockPicking(models.Model):
 
     @api.multi
     def button_check_tracking(self):
-        pass
-        # # TODO: Revisar este botón al tener datos de tracking
-        # carrier_ref = self.carrier_tracking_ref
-        # carrier = self.carrier_name
-        # status_list = self.env['picking.tracking.status.list']
-        # url = self.env['ir.config_parameter'].sudo().get_param('url.visiotech.web.tracking')
-        # password = self.env['ir.config_parameter'].sudo().get_param('url.visiotech.web.tracking.pass')
-        # language = self.env.user.lang or u'es_ES'
-        # if 'Correos' in carrier:
-        #     carrier_ref = carrier_ref[-13:]
-        # elif 'UPS' in carrier:
-        #     carrier_ref = carrier_ref[:35]
-        #
-        # data = {'request_API': {
-        #             "numRef": carrier_ref,
-        #             "transportista": carrier,
-        #             "password": password,
-        #             "language": language
-        # }}
-        #
-        # response = requests.session().post(url, data=json.dumps(data))
-        # if response.status_code != 200:
-        #     raise Exception(response.text)
-        # if 'error' in response.url:
-        #     raise Exception("Could not find information on url '%s'" % response.url)
-        # info = json.loads(response.text)
-        #
-        # # Update picking field "number of packages"
-        # if info['Num_bags']:
-        #     self.number_of_packages = info['Num_bags']
-        #
-        # view_id = self.env['picking.tracking.status']
-        # ctx = {'information': info}
-        # new = view_id.with_context(ctx).create({})
-        # # Update wizard field "num packages"
-        # new.write({'num_packages': info['Num_bags']})
-        # status_list.search([('picking_id', '=', self.id)]).unlink()
-        #
-        # if info["Bags"]:
-        #     for package in info["Bags"]:
-        #         info_package = info["Bags"][package]
-        #         data_status = {
-        #             'wizard_id': new.id,
-        #             'picking_id': self.id,
-        #             'packages_reference': info_package["Tracking"][0] + ' (x' + str(info_package["Num_bags"]) + ')',
-        #             'status': package.upper()
-        #         }
-        #         new.write({'status_list': [(0, 0, data_status)]})
-        #         last_status = True
-        #         for status in info_package["Activity"]:
-        #             city_country = status["City"]
-        #             if status["Country"]:
-        #                 city_country += ' (' + status["Country"] + ')'
-        #
-        #             date_time = status["Date"] + ' ' + status["Time"]
-        #
-        #             data_status = {
-        #                 'wizard_id': new.id,
-        #                 'picking_id': self.id,
-        #                 'status': status["Status"],
-        #                 'city': city_country,
-        #                 'date': date_time,
-        #                 'last_record': last_status
-        #             }
-        #             new.write({'status_list': [(0, 0, data_status)]})
-        #             last_status = False
-        #
-        #  return {
-        #     'name': 'Tracking status information',
-        #     'view_type': 'form',
-        #     'view_mode': 'form',
-        #     'target': 'new',
-        #     'res_model': 'picking.tracking.status',
-        #     'res_id': new.id,
-        #     'src_model': 'stock.picking',
-        #     'type': 'ir.actions.act_window',
-        #     'id': 'action_picking_tracking_status',
-        #     }
+        # TODO: Revisar este botón al tener datos de tracking
+        carrier_ref = self.carrier_tracking_ref
+        carrier = self.carrier_name
+        status_list = self.env['picking.tracking.status.list']
+        url = self.env['ir.config_parameter'].sudo().get_param('url.visiotech.web.tracking')
+        password = self.env['ir.config_parameter'].sudo().get_param('url.visiotech.web.tracking.pass')
+        language = self.env.user.lang or u'es_ES'
+        if 'Correos' in carrier:
+            carrier_ref = carrier_ref[-13:]
+        elif 'UPS' in carrier:
+            carrier_ref = carrier_ref[:35]
+
+        data = {'request_API': {
+                    "numRef": carrier_ref,
+                    "transportista": carrier,
+                    "password": password,
+                    "language": language
+        }}
+
+        response = requests.session().post(url, data=json.dumps(data))
+        if response.status_code != 200:
+            raise Exception(response.text)
+        if 'error' in response.url:
+            raise Exception("Could not find information on url '%s'" % response.url)
+        info = json.loads(response.text)
+
+        # Update picking field "number of packages"
+        if info['Num_bags']:
+            self.number_of_packages = info['Num_bags']
+
+        view_id = self.env['picking.tracking.status']
+        ctx = {'information': info}
+        new = view_id.with_context(ctx).create({})
+        # Update wizard field "num packages"
+        new.write({'num_packages': info['Num_bags']})
+        status_list.search([('picking_id', '=', self.id)]).unlink()
+
+        if info["Bags"]:
+            for package in info["Bags"]:
+                info_package = info["Bags"][package]
+                data_status = {
+                    'wizard_id': new.id,
+                    'picking_id': self.id,
+                    'packages_reference': info_package["Tracking"][0] + ' (x' + str(info_package["Num_bags"]) + ')',
+                    'status': package.upper()
+                }
+                new.write({'status_list': [(0, 0, data_status)]})
+                last_status = True
+                for status in info_package["Activity"]:
+                    city_country = status["City"]
+                    if status["Country"]:
+                        city_country += ' (' + status["Country"] + ')'
+
+                    date_time = status["Date"] + ' ' + status["Time"]
+
+                    data_status = {
+                        'wizard_id': new.id,
+                        'picking_id': self.id,
+                        'status': status["Status"],
+                        'city': city_country,
+                        'date': date_time,
+                        'last_record': last_status
+                    }
+                    new.write({'status_list': [(0, 0, data_status)]})
+                    last_status = False
+
+        return {
+            'name': 'Tracking status information',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'target': 'new',
+            'res_model': 'picking.tracking.status',
+            'res_id': new.id,
+            'src_model': 'stock.picking',
+            'type': 'ir.actions.act_window',
+            'id': 'action_picking_tracking_status',
+        }
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
- [FIX]'product_states': fijada pestaña de compra en producto
- [IMP]'custom_account': puesto visible boton de anticipos en pedidos tramitados
- [MIG]'transportation': migrado boton de seguimiento de envios 
- [FIX]'stock_custom': poder cambiar cantidad pedida en los albaranes hechos a mano
- [FIX]'purchase_picking': arreglado campo que ya no existe en los contenedores
- [IMP]'sale_custom': quitado sticky de mensaje de stock