### PR TITLE
[11.0] Cambios en compras

### DIFF
--- a/project-addons/custom_account/views/account_view.xml
+++ b/project-addons/custom_account/views/account_view.xml
@@ -47,6 +47,18 @@
             </field>
         </record>
 
+        <record id="invoice_supplier_tree" model="ir.ui.view">
+            <field name="name">account.invoice.supplier.currency.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_tree"/>
+            <field name="arch" type="xml">
+                <!-- It makes no sense to do the sum of multiple currencies, but, used just when it is a group of same currency-->
+                <field name="amount_total_signed" position="attributes">
+                    <attribute name="sum">Amount</attribute>
+                </field>
+            </field>
+        </record>
+
         <record id="invoice_form_add_pick" model="ir.ui.view">
             <field name="name">account.invoice.form.add_pick</field>
             <field name="model">account.invoice</field>

--- a/project-addons/purchase_picking/models/purchase.py
+++ b/project-addons/purchase_picking/models/purchase.py
@@ -29,6 +29,8 @@ class PurchaseOrder(models.Model):
 
     picking_created = fields.Boolean('Picking created', compute='is_picking_created')
 
+    date_planned = fields.Datetime(string='Scheduled Date', compute='', store=True, index=True)
+
     @api.multi
     def test_moves_done(self):
         '''PO is done at the delivery side if all the incoming shipments
@@ -80,6 +82,12 @@ class PurchaseOrder(models.Model):
 class PurchaseOrderLine(models.Model):
 
     _inherit = 'purchase.order.line'
+    #
+    # @api.depends('order_id.date_planned')
+    # def _computedate(self):
+    #     self.date_planned = self.order_id.date_planned
+    #
+    # date_planned = fields.Datetime(string='Scheduled Date',compute='_computedate', required=True, index=True)
 
     @api.multi
     def _prepare_stock_moves(self, picking):

--- a/project-addons/purchase_picking/views/purchase_view.xml
+++ b/project-addons/purchase_picking/views/purchase_view.xml
@@ -19,6 +19,30 @@
                         attrs="{'invisible': [('state','in',('draft', 'cancel'))]}"
                         class="oe_highlight"/>
             </button>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='name']" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='date_planned']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+             <xpath expr="//field[@name='order_line']/tree//field[@name='account_analytic_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='analytic_tag_ids']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='product_qty']" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='price_unit']" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='taxes_id']" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='discount']" position="attributes">
+                <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/project-addons/purchase_picking/views/purchase_view.xml
+++ b/project-addons/purchase_picking/views/purchase_view.xml
@@ -22,9 +22,9 @@
             <xpath expr="//field[@name='order_line']/tree//field[@name='name']" position="attributes">
                 <attribute name="attrs">{'readonly': [('state', '=', 'purchase')]}</attribute>
             </xpath>
-            <xpath expr="//field[@name='order_line']/tree//field[@name='date_planned']" position="attributes">
+            <!--xpath expr="//field[@name='order_line']/tree//field[@name='date_planned']" position="attributes">
                 <attribute name="invisible">1</attribute>
-            </xpath>
+            </xpath-->
              <xpath expr="//field[@name='order_line']/tree//field[@name='account_analytic_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>

--- a/project-addons/stock_custom/i18n/es.po
+++ b/project-addons/stock_custom/i18n/es.po
@@ -353,3 +353,8 @@ msgstr "El último cliente en posesión del producto"
 #: model:ir.model.fields,field_description:stock_custom.field_stock_move_line_date_expected
 msgid "Date Expected"
 msgstr "Fecha prevista"
+
+#. module: stock_custom
+#: model:ir.ui.view,arch_db:stock_custom.view_move_line_tree_add_date
+msgid "Ordered Qty"
+msgstr "Cantidad pedida"

--- a/project-addons/stock_custom/views/stock_view.xml
+++ b/project-addons/stock_custom/views/stock_view.xml
@@ -245,13 +245,13 @@
             <field name="qty_done" position="before">
                 <field name="picking_id"/>
                 <field name="date_expected"/>
-                <field name="product_uom_qty"/>
+                <field name="product_uom_qty" string="Ordered Qty"/>
             </field>
         </field>
     </record>
 
     <record id="stock.stock_move_line_action" model="ir.actions.act_window">
-        <field name="context">{'search_default_todo': 1}</field>
+        <field name="context">{'search_default_todo': 1, 'search_default_incoming': 1}</field>
     </record>
 
     <record id="view_move_tree_add_sale" model="ir.ui.view">


### PR DESCRIPTION
- [IMP]'stock_custom': añadido filtro a la ventana de movimiento de producto
- [IMP]'purchase_picking': lineas de PO en solo lectura cuando el estado es pedido de compra
- [IMP]'purchase_picking': quitado compute de la fecha prevista por quese necesita fijar a mano
- [IMP]'custom_account': añadido suma total, para sumar otras monedas cuando está filtrado