### PR TITLE
[11.0] No comprobar ventas bloqueadas en rectificativas

### DIFF
--- a/project-addons/block_invoices/models/account_invoice.py
+++ b/project-addons/block_invoices/models/account_invoice.py
@@ -18,12 +18,14 @@ class AccountInvoice(models.Model):
         for invoice in self:
             # Compruebo la empresa actual y su padre...
             for partner in invoice.partner_id.get_partners_to_check():
-                if partner.blocked_sales and not invoice.allow_confirm_blocked:
-                    if not invoice.sale_order_ids or \
-                            (invoice.sale_order_ids
-                             and any(not order.allow_confirm_blocked for order in invoice.sale_order_ids)):
-                        message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
-                        raise exceptions.Warning(message)
+                # Comprobar ventas bloqueadas si es una factura de cliente o si es una factura de un proveedor que es cliente también
+                if invoice.type == 'out_invoice' or (invoice.type == 'in_invoice' and partner.customer):
+                    if partner.blocked_sales and not invoice.allow_confirm_blocked:
+                        if not invoice.sale_order_ids or \
+                                (invoice.sale_order_ids
+                                 and any(not order.allow_confirm_blocked for order in invoice.sale_order_ids)):
+                            message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
+                            raise exceptions.Warning(message)
         return super().invoice_validate()
 
     @api.onchange('partner_id')

--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -263,8 +263,7 @@ class CrmClaimRma(models.Model):
 
                 line.invoiced = True
 
-            invoice_id.write({'origin_invoices_ids': [(6, 0, list(set(rectified_invoice_ids)))],
-                              'allow_confirm_blocked': claim_obj.allow_confirm_blocked})
+            invoice_id.write({'origin_invoices_ids': [(6, 0, list(set(rectified_invoice_ids)))]})
             invoice_id.compute_taxes()
             invoice_id.action_invoice_open()
 


### PR DESCRIPTION
[FIX] block_invoices, crm_claim_rma_custom: No comprobar ventas bloqueadas si es rectificativa o facturas de proveedor que no sea cliente también