### PR TITLE
[11.0] Corrección export partner flask

### DIFF
--- a/project-addons/account_move_line_followup/__manifest__.py
+++ b/project-addons/account_move_line_followup/__manifest__.py
@@ -13,7 +13,10 @@
              'data/credit_control_data.xml',
              'views/credit_control_communication_view.xml',
              'views/partner_view.xml',
-             'wizard/wiz_send_followup_partner_view.xml'],
+             'wizard/wiz_send_followup_partner_view.xml',
+             "security/account_security.xml",
+             "security/ir.model.access.csv",
+             ],
     'description': '''Update follow-up data in account move lines''',
     'installable': True,
 }

--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -76,7 +76,7 @@ class CreditControlRun(models.Model):
                 email.send()
 
 
-class CreditCommunication(models.TransientModel):
+class CreditCommunication(models.Model):
 
     _name = 'credit.control.communication'
     _inherit = ['credit.control.communication', 'mail.thread']

--- a/project-addons/account_move_line_followup/security/account_security.xml
+++ b/project-addons/account_move_line_followup/security/account_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="credit_control_communication_rule" model="ir.rule">
+            <field name="name">Credit Control Communication</field>
+            <field name="model_id" ref="model_credit_control_communication"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/account_move_line_followup/security/ir.model.access.csv
+++ b/project-addons/account_move_line_followup/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_credit_control_communication_user,credit_control_communication_user,account_credit_control.model_credit_control_communication,account_credit_control.group_account_credit_control_user,1,1,1,1

--- a/project-addons/flask_middleware_connector/models/res_partner/common.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/common.py
@@ -117,7 +117,7 @@ class PartnerListener(Component):
         elif partner.web and 'active' in fields and \
                 partner.active or 'prospective' in fields and \
                 partner.prospective:
-            record.with_delay(priority=1, eta=60).export_partner()
+            self.export_partner_data(record)
 
         elif partner.web:
             if 'category_id' in fields:

--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -129,7 +129,7 @@ class StockReservation(models.Model):
     def delete_orphan_reserves(self):
         now = fields.Datetime.now()
         d = datetime.strptime(now, '%Y-%m-%d %H:%M:%S') + \
-            timedelta(minutes=-30)
+            timedelta(minutes=-10)
         last_date = datetime.strftime(d, '%Y-%m-%d %H:%M:%S')
         reserves = self.search([('create_date', '<=', last_date),
                                 ('sale_line_id', '=', False),

--- a/scripts/credit_control.diff
+++ b/scripts/credit_control.diff
@@ -1,0 +1,13 @@
+diff --git a/account_credit_control/wizard/credit_control_communication.py b/account_credit_control/wizard/credit_control_communication.py
+index 6abbf53..2f2aa49 100644
+--- a/account_credit_control/wizard/credit_control_communication.py
++++ b/account_credit_control/wizard/credit_control_communication.py
+@@ -8,7 +8,7 @@ from odoo import api, fields, models
+ logger = logging.getLogger(__name__)
+ 
+ 
+-class CreditCommunication(models.TransientModel):
++class CreditCommunication(models.Model):
+     """Shell class used to provide a base model to email template and reporting
+     Il use this approche in version 7 a browse record
+     will exist even if not saved


### PR DESCRIPTION
- [FIX] flask_middleware_connector: Exportar todo el historial del cliente al activarlo de nuevo
- [FIX] account_move_line_followup: Cambio tipo clase credit control communication