### PR TITLE
[11.0] Correcciones varias

### DIFF
--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -432,6 +432,7 @@
 
                 <field name="vat" position="replace">
                     <field name="att"/> <!-- TODO Ya no existe campo use_parent_address: attrs="{'readonly': [('use_parent_address','=',True)]}"/> -->
+                    <field name="team_id" invisible="1" force_save="1"/>
                 </field>
                 <xpath expr="//field[@name='child_ids']/form//field[@name='street2']" position="after">
                     <field name="att" placeholder="A/A"/>

--- a/project-addons/custom_report_link/views/custom_layout.xml
+++ b/project-addons/custom_report_link/views/custom_layout.xml
@@ -1775,7 +1775,7 @@ SWIFT/BIC: BESCPTPL
                     </tbody>
                 </table>
             </div>
-            <!--div style="font-size:13px; color:#da1f2e">
+            <div style="font-size:13px; color:#da1f2e">
                 <div class="pull-left col-xs-6 row">
                     <t t-if="o.move_lines and o.move_lines[0].sale_line_id.order_id.note">
                         <strong>Terms and Conditions:</strong>
@@ -1783,7 +1783,7 @@ SWIFT/BIC: BESCPTPL
                     </t>
                 </div>
 
-                <div class="pull-right col-xs-5 row">
+                <!--div class="pull-right col-xs-5 row">
                     <strong>Bank Account:</strong>
                     <t t-if="lang == 'es_ES'">
                         <pre style="font-size:12px; color:#6D6E70">
@@ -1822,12 +1822,9 @@ SWIFT/BIC: BESCPTPL
             SWIFT/BIC: BESCPTPL
                         </pre>
                     </t>
-                </div>
+                </div!-->
             </div>
-            <div class="text-center" style="font-size: 10px; font-weight: bold; color:#6D6E70;">
-                <label><t t-raw="company.name"/> <span t-field="company.report_footer"/></label>
-            </div-->
-
+        <div class="pull-right col-xs-6 row">
             <!-- Obtener el idioma del cliente dependiendo de si es un contacto o una empresa -->
             <t t-set="lang" t-value="'undefined'"/>
             <t t-if="o.partner_id.parent_id.id">
@@ -1867,6 +1864,12 @@ SWIFT/BIC: BESCPTPL
                     Mit diesem Lieferschein wird nur das von unserem Lager gelieferte Material aufgeschlüsselt. Konzepte im Zusammenhang mit Dienstleistungen wie Versandkosten sind hier nicht aufgeführt, können jedoch in der entsprechenden Rechnung eingesehen werden. Denken Sie daran, dass die Kits oder Packs in ihre Bestandteile zerlegt sind
                 </p>
             </t>
+            </div>
+
+            <!--p class="text-center" style="font-size: 10px; font-weight: bold; color:#6D6E70;">
+                <label><t t-raw="company.name"/> <span t-field="company.report_footer"/></label>
+            </p-->
+
 
         </div>
 

--- a/project-addons/prospective_customer/views/res_partner_view.xml
+++ b/project-addons/prospective_customer/views/res_partner_view.xml
@@ -7,7 +7,11 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
+                <button name="toggle_active" position="attributes">
+                <attribute name="invisible">True</attribute>
+                </button>
                 <xpath expr="//group[@name='sale']/field[@name='customer']" position="after">
+                    <field name="active"/>
                     <field name="prospective" attrs="{'invisible':[('customer', '=', False)]}"/>
                 </xpath>
             </field>

--- a/scripts/account_payment_order.diff
+++ b/scripts/account_payment_order.diff
@@ -1,0 +1,13 @@
+diff --git a/account_payment_order/models/account_payment_order.py b/account_payment_order/models/account_payment_order.py
+index 2a402c1..fd53aa5 100644
+--- a/account_payment_order/models/account_payment_order.py
++++ b/account_payment_order/models/account_payment_order.py
+@@ -280,7 +280,7 @@ class AccountPaymentOrder(models.Model):
+                             payline.ml_maturity_date,
+                             requested_date))
+                 # Write requested_date on 'date' field of payment line
+-                payline.date = requested_date
++                payline.write({'date': requested_date})
+                 # Group options
+                 if order.payment_mode_id.group_lines:
+                     hashcode = payline.payment_line_hashcode()


### PR DESCRIPTION
- [FIX] custom_partner: Forzar guardado del equipo de ventas del cliente al cambiar comercial o zona
- [IMP] prospective_customer: Quitado botón activo/archivado para evitar desactivar clientes sin querer. Se ha llevado el campo Active como check en pestaña Ventas y compras
- [FIX] custom_report_link: Correción para que se vean las notas que vienen del pedido en la plantilla de albarán valorado
- [FIX] script: Cambio a write la escritura de un campo del módulo de la OCA account_payment_order para que no actualice con datos de la caché