### PR TITLE
Nuevo campo Estado factura del Pedido 

### DIFF
--- a/project-addons/order_invoice_policy/__manifest__.py
+++ b/project-addons/order_invoice_policy/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'sale',
     'description': """""",
     'author': 'Visiotech',
-    "depends": ['base', 'sale'],
+    "depends": ['base', 'sale', 'sale_stock'],
     "data": ['security/sale_security.xml',
              'views/sale_order_view.xml'],
     "installable": True

--- a/project-addons/order_invoice_policy/i18n/es.po
+++ b/project-addons/order_invoice_policy/i18n/es.po
@@ -40,3 +40,33 @@ msgstr "Antes de la Entrega"
 #: model:ir.ui.view,arch_db:order_invoice_policy.view_order_form_invoice_policy
 msgid "Change policy"
 msgstr "Cambiar política"
+
+#. module: order_invoice_policy
+#: model:ir.model.fields,field_description:order_invoice_policy.field_sale_order_invoice_status_2
+msgid "Invoice Status"
+msgstr "Estado factura"
+
+#. module: order_invoice_policy
+#: selection:sale.order,invoice_status_2:0
+msgid "Nothing to Invoice"
+msgstr "Nada que facturar"
+
+#. module: order_invoice_policy
+#: selection:sale.order,invoice_status_2:0
+msgid "To Invoice"
+msgstr "Para facturar"
+
+#. module: order_invoice_policy
+#: selection:sale.order,invoice_status_2:0
+msgid "Fully Invoiced"
+msgstr "Facturado"
+
+#. module: order_invoice_policy
+#: selection:sale.order,invoice_status_2:0
+msgid "Partially invoiced"
+msgstr "Parcialmente facturado"
+
+#. module: order_invoice_policy
+#: selection:sale.order.line,invoice_status:0
+msgid "Cancelled"
+msgstr "Cancelado"

--- a/project-addons/order_invoice_policy/models/sale_order.py
+++ b/project-addons/order_invoice_policy/models/sale_order.py
@@ -16,9 +16,45 @@ class SaleOrder(models.Model):
         default='by_product'
     )
 
+    invoice_status_2 = fields.Selection([
+        ('invoiced', 'Fully Invoiced'),
+        ('to_invoice', 'To Invoice'),
+        ('no', 'Nothing to Invoice'),
+        ('partially_invoiced', 'Partially invoiced')
+        ], string='Invoice Status', compute='_get_invoice_status_2', store=True, readonly=True)
+
+    @api.depends('state', 'order_line.invoice_status')
+    def _get_invoice_status_2(self):
+        """
+        Compute the invoice status (2) of a SO. Possible statuses:
+        - no: if the SO is not in status 'sale' or 'done', we consider that there is nothing to
+          invoice. This is also the default value if the conditions of no other status is met.
+        - to invoice: if any SO line with product (not services) is 'to invoice' or all lines are services,
+          the whole SO is 'to invoice'
+        - invoiced: if all SO lines are invoiced, the SO is invoiced.
+        """
+        for order in self:
+            if order.state not in ('sale', 'done'):
+                invoice_status = 'no'
+            elif any(line.invoice_status == 'to invoice'
+                     for line in order.order_line.filtered(lambda p: p.product_id.type == 'product')) or \
+                    all(line.invoice_status == 'to invoice' and line.product_id.type == 'service'
+                        for line in order.order_line):
+                invoice_status = 'to_invoice'
+            elif all(line.invoice_status in ('invoiced', 'cancel') for line in order.order_line):
+                invoice_status = 'invoiced'
+            elif any(line.invoice_status == 'invoiced' for line in order.order_line):
+                invoice_status = 'partially_invoiced'
+            else:
+                invoice_status = 'no'
+
+            order.invoice_status_2 = invoice_status
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
+
+    invoice_status = fields.Selection(selection_add=[('cancel', 'Cancelled')])
 
     @api.depends('order_id.order_invoice_policy')
     def _get_to_invoice_qty(self):
@@ -31,4 +67,18 @@ class SaleOrderLine(models.Model):
                                   - (line.qty_invoiced - line.qty_delivered)
 
         super(SaleOrderLine, self - lines)._get_to_invoice_qty()
+
+    @api.depends('move_ids.state')
+    def _compute_invoice_status(self):
+        """ Add new invoice status:
+        - cancel: if all moves associated to a SO line are 'cancel', the invoice state of this line is 'cancel'
+        """
+        super(SaleOrderLine, self)._compute_invoice_status()
+        for line in self:
+            if line.order_id.state in ('sale', 'done') \
+                    and line.product_id.type == 'product'\
+                    and line.product_id.invoice_policy == 'delivery'\
+                    and line.move_ids \
+                    and all(move.state == 'cancel' for move in line.move_ids):
+                line.invoice_status = 'cancel'
 

--- a/project-addons/order_invoice_policy/views/sale_order_view.xml
+++ b/project-addons/order_invoice_policy/views/sale_order_view.xml
@@ -7,8 +7,43 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_pay']/field[@name='invoice_status']" position="after">
                 <field name="order_invoice_policy" groups="order_invoice_policy.group_change_order_invoice_policy"/>
+                <field name="invoice_status_2"/>
+            </xpath>
+            <xpath expr="//group[@name='sale_pay']/field[@name='invoice_status']" position="attributes">
+                    <attribute name="invisible">True</attribute>
             </xpath>
         </field>
+    </record>
+
+    <record id="sale_order_view_tree_invoice_status" model="ir.ui.view">
+        <field name="name">sale.order.tree.invoice.status.2</field>
+        <field name="model">sale.order</field>
+        <field name="priority">2</field>
+        <field name="inherit_id" ref="sale.view_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="invoice_status" position="replace">
+                <field name="invoice_status_2"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="sale.action_orders_to_invoice" model="ir.actions.act_window">
+         <field name="name">Orders to Invoice</field>
+         <field name="type">ir.actions.act_window</field>
+         <field name="res_model">sale.order</field>
+         <field name="view_type">form</field>
+         <field name="view_mode">tree,form,calendar,graph,pivot,kanban</field>
+         <field name="context">{'create': False}</field>
+         <field name="domain">[('invoice_status_2','=','to_invoice')]</field>
+         <field name="search_view_id" ref="sale.view_sales_order_filter"/>
+         <field name="help" type="html">
+          <p>
+            You will find here all orders that are ready to be invoiced.
+          </p><p>
+            You can select all orders and invoice them in batch, or check
+            every order and invoice them one by one.
+          </p>
+         </field>
     </record>
 </odoo>
 

--- a/project-addons/order_invoice_policy/views/sale_order_view.xml
+++ b/project-addons/order_invoice_policy/views/sale_order_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_pay']/field[@name='invoice_status']" position="after">
                 <field name="order_invoice_policy" groups="order_invoice_policy.group_change_order_invoice_policy"/>
-                <field name="invoice_status_2"/>
+                <field name="invoice_status_2" states="sale,done"/>
             </xpath>
             <xpath expr="//group[@name='sale_pay']/field[@name='invoice_status']" position="attributes">
                     <attribute name="invisible">True</attribute>


### PR DESCRIPTION
- [IMP] order_invoice_policy: Añadido nuevo campo estado de factura del pedido para distinguir cuándo realmente se debe facturar algo o no. Añadido también estado "cancelado" en la línea para cuando se cancela el albarán asociado.
- [FIX] order_invoice_policy: Visibilidad del campo invoice_status_2 segun estado del pedido