### PR TITLE
Correción facturar antes de entrega y cálculo PVM con coste 2

### DIFF
--- a/project-addons/order_invoice_policy/models/sale_order.py
+++ b/project-addons/order_invoice_policy/models/sale_order.py
@@ -68,7 +68,7 @@ class SaleOrderLine(models.Model):
             pack = self.env['mrp.bom']._bom_find(product=line.product_id)
             if pack and pack.type == 'phantom':
                 # Calcular cantidad del pack a facturar
-                moves_pack = lines.move_ids.filtered(lambda mv: 'assigned' in mv.state)
+                moves_pack = line.move_ids.filtered(lambda mv: 'assigned' in mv.state)
                 quantities = line._get_bom_component_qty(pack)
                 assign_components_qty = {}
                 for move in moves_pack:

--- a/project-addons/product_pricelist_custom/models/product.py
+++ b/project-addons/product_pricelist_custom/models/product.py
@@ -35,6 +35,7 @@ class ProductPricelistItem(models.Model):
     pricelist_calculated_price = fields.Float("Price calculated", compute='_get_pricelist_calculated_price')
     margin = fields.Float("Margin (%)", compute='_get_margin', readonly=True, store=True)
     name_pricelist = fields.Char(related='pricelist_id.name', readonly=True)
+    base = fields.Selection(selection_add=[('standard_price_2', 'Cost 2')])
 
     @api.multi
     @api.depends('fixed_price')
@@ -50,6 +51,8 @@ class ProductPricelistItem(models.Model):
                         item.pricelist_calculated_price = item.fixed_price * (1 - rule.price_discount / 100)
                     elif rule.base == 'standard_price':
                         item.pricelist_calculated_price = product_id.standard_price * (1 - rule.price_discount / 100)
+                    elif rule.base == 'standard_price_2':
+                        item.pricelist_calculated_price = product_id.standard_price_2 * (1 - rule.price_discount / 100)
 
     @api.multi
     @api.depends('fixed_price', 'product_id.standard_price_2', 'product_tmpl_id.standard_price_2')


### PR DESCRIPTION
- [TYPO] order_invoice_policy: Corregido consultar movimientos de la línea ("line" en vez de "lines")
- [IMP] product_pricelsit_custom: Permitir calcular precio de tarifas PVM con el coste 2 del producto