### PR TITLE
Modificación de name_get de producto

### DIFF
--- a/project-addons/custom_account/models/stock.py
+++ b/project-addons/custom_account/models/stock.py
@@ -74,26 +74,13 @@ class ProductProduct(models.Model):
 
     @api.multi
     def name_get(self):
-        partner_id = self.env.context.get('partner_id', False)
-        if partner_id:
-            partner_ids = \
-                [partner_id,
-                 self.env['res.partner'].browse(partner_id).
-                 commercial_partner_id.id]
-        else:
-            partner_ids = []
+        partner = self.env['res.partner'].browse(self.env.context.get('partner_id', False))
         result = []
-        for record in self:
-            default = True
-            if partner_ids:
-                supplier_info = self.env['product.supplierinfo'].sudo().\
-                    search([('product_tmpl_id', '=',
-                             record.product_tmpl_id.id),
-                            ('name', 'in', partner_ids)])
-                if supplier_info:
-                    result.extend(super(ProductProduct, record).name_get())
-                    default = False
-            if default:
+        if partner.supplier:
+            for record in self:
+                result.append((record.id, "[%s] %s" % ((record.ref_manufacturer or record.default_code), record.default_code)))
+        else:
+            for record in self:
                 result.append((record.id, "%s" % record.default_code))
         return result
 

--- a/project-addons/custom_account/models/stock.py
+++ b/project-addons/custom_account/models/stock.py
@@ -79,12 +79,12 @@ class ProductProduct(models.Model):
         if partner and partner.supplier:
             for record in self:
                 result.append((record.id, "[%s] %s" % ((record.ref_manufacturer or record.default_code), record.default_code)))
-        elif partner:
-            for record in self:
-                result.append((record.id, "%s" % record.default_code))
-        elif self.env.context.get('partner', False):
-            for record in self:
-                result.append((record.id, "%s" % record.default_code))
+        # elif partner:
+        #     for record in self:
+        #         result.append((record.id, "%s" % record.default_code))
+        # elif self.env.context.get('partner', False):
+        #     for record in self:
+        #         result.append((record.id, "%s" % record.default_code))
         else:
             for record in self:
                 result.append((record.id, "%s" % record.default_code))

--- a/project-addons/custom_account/models/stock.py
+++ b/project-addons/custom_account/models/stock.py
@@ -76,9 +76,15 @@ class ProductProduct(models.Model):
     def name_get(self):
         partner = self.env['res.partner'].browse(self.env.context.get('partner_id', False))
         result = []
-        if partner.supplier:
+        if partner and partner.supplier:
             for record in self:
                 result.append((record.id, "[%s] %s" % ((record.ref_manufacturer or record.default_code), record.default_code)))
+        elif partner:
+            for record in self:
+                result.append((record.id, "%s" % record.default_code))
+        elif self.env.context.get('partner', False):
+            for record in self:
+                result.append((record.id, "%s" % record.default_code))
         else:
             for record in self:
                 result.append((record.id, "%s" % record.default_code))


### PR DESCRIPTION
He modificado por completo esta función ya que estábamos teniendo un comportamiento bastante errático. A veces aparecía el nombre bien, otras veces se le quitaba el corchete al modificar algo de los productos y otras aparecían incluso duplicados con referencias extrañas, total, hemos decidido sobreescribirla y hacer que se comporte como realmente debería.
No se si lo verás bien, es cierto que perder la herencia de una función como esa no me gusta nada, pero es la única solución que hemos encontrado.