### PR TITLE
Pequeños cambios de campos

### DIFF
--- a/project-addons/custom_account/views/partner_view.xml
+++ b/project-addons/custom_account/views/partner_view.xml
@@ -25,7 +25,7 @@
                         <field name="date" string="Created date" readonly="True"/>
                         <field name="lang" attrs="{'required': [('is_company', '=', True),('customer', '=', True),('dropship', '=', False),('prospective', '=', False)]}"/>
                         <field name="web" attrs="{'invisible': [('is_company', '!=', True)]}"/>
-                        <field name="email_web" attrs="{'invisible': [('web', '!=', True)], 'required': [('web', '=', True)]}"/>
+                        <field name="email_web" attrs="{'invisible': [('web', '!=', True),('dropship', '=', True)], 'required': [('web', '=', True),('dropship', '=', False)]}"/>
                     </group>
                 </xpath>
                 <field name="ref" position="attributes">

--- a/project-addons/custom_report_link/data/email_template.xml
+++ b/project-addons/custom_report_link/data/email_template.xml
@@ -12,6 +12,7 @@
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="email_to" >${(object.partner_id.email or '')|safe}</field>
             <field name="partner_to">${object.partner_id.id or ''}</field>
+            <field name="reply_to">${(object.user_id.email or 'noreply@localhost')|safe}</field>
             <field name="auto_delete" eval="False"/>
             <field name="report_template" ref="custom_report_link.report_picking_custom_valued_action"/>
             <field name="report_name">Albarán Valorado_${(object.name or '').replace('/','_')}</field>

--- a/project-addons/custom_report_link/data/email_template.xml
+++ b/project-addons/custom_report_link/data/email_template.xml
@@ -12,7 +12,7 @@
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="email_to" >${(object.partner_id.email or '')|safe}</field>
             <field name="partner_to">${object.partner_id.id or ''}</field>
-            <field name="reply_to">${(object.user_id.email or 'noreply@localhost')|safe}</field>
+            <field name="reply_to">${('noreply@localhost')|safe}</field>
             <field name="auto_delete" eval="False"/>
             <field name="report_template" ref="custom_report_link.report_picking_custom_valued_action"/>
             <field name="report_name">Albarán Valorado_${(object.name or '').replace('/','_')}</field>

--- a/project-addons/transportation/views/res_partner_view.xml
+++ b/project-addons/transportation/views/res_partner_view.xml
@@ -8,10 +8,8 @@
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
                 <field name="company_id" position="after">
-                    <!-- TODO: añadir al migrar custom_partner field name="transporter_id" attrs="{'required': [('is_company', '=', True),('customer','=', True),('dropship', '=', False),('prospective', '=', False)]}"/>
-                    <field name="service_id" attrs="{'required': [('is_company', '=', True),('customer','=', True),('dropship', '=', False),('prospective', '=', False)]}"/-->
-                    <field name="transporter_id" attrs="{'required': [('is_company', '=', True),('customer','=', True)]}"/>
-                    <field name="service_id" attrs="{'required': [('is_company', '=', True),('customer','=', True)]}"/>
+                    <field name="transporter_id" attrs="{'required': [('is_company', '=', True),('customer','=', True),('active', '=', True)]}"/>
+                    <field name="service_id" attrs="{'required': [('is_company', '=', True),('customer','=', True),('active', '=', True)]}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
- [FIX]custom_report_link: añadido reply_to a plantilla de aviso de envío 
- [FIX]custom_account: añadia comprobación para que el email web no sea necesario al editar un dropship
- [FIX]transportation: quitar obligatorio cuando cliente inactivo 
- [FIX]custom_report_link: quitado correo de comercial de la plantilla ya que no hay user_id en el picking