### PR TITLE
Ref de devolución en seguimiento cliente y cambio plantilla albarán valorado

### DIFF
--- a/project-addons/custom_account/models/payment_return.py
+++ b/project-addons/custom_account/models/payment_return.py
@@ -13,6 +13,9 @@ class PaymentReturn(models.Model):
         for return_line in self.line_ids:
             for move_line in return_line.move_line_ids:
                 move_line.blocked = True
+                # Actualizar referencia de pago del apunte asociado a la(s)
+                # factura(s) devueltas con la referencia de la devolución
+                move_line.mapped('matched_debit_ids.origin_returned_move_ids').write({'ref_line': self.name})
 
         return res
 

--- a/project-addons/custom_report_link/views/custom_layout.xml
+++ b/project-addons/custom_report_link/views/custom_layout.xml
@@ -1505,7 +1505,7 @@ SWIFT/BIC: BESCPTPL
                         <t t-set="final_price" t-value="0"/>
                         <t t-foreach="taxes" t-as="t">
                             <tr>
-                                <td><span t-esc="t.name"/></td>
+                                <td><span t-esc="t.amount"/>%</td>
                                 <td><span t-esc="t_value" t-esc-options="{'widget': 'monetary', 'display_currency': monetary_widget}"/></td>
                                 <td><span t-esc="(t.amount * t_value)/100" t-esc-options="{'widget': 'monetary', 'display_currency': monetary_widget}"/></td>
 


### PR DESCRIPTION
- [IMP] custom_report_link: Mostrar solamente porcentaje de impuesto en vez del nombre completo en informe albarán valorado
- [IMP] custom_account: Arrastrar referencia de devolución en el apunte asociado a la factura para que desde el seguimiento de cliente se pueda ver que sigue abierta porque ha sido devuelta