### PR TITLE
Cambios en outlet y RMA

### DIFF
--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -160,6 +160,8 @@ class CrmClaimRma(models.Model):
             self.country = self.partner_id.country_id    # Get country_id from res.partner
             if self.partner_id.user_id:
                 self.comercial = self.partner_id.user_id.id
+            if self.partner_id.rma_warn_msg:
+                self.description = self.partner_id.rma_warn_msg
         return result
 
     @api.onchange('name')

--- a/project-addons/product_outlet/wizard/product_outlet_wizard.py
+++ b/project-addons/product_outlet/wizard/product_outlet_wizard.py
@@ -51,7 +51,7 @@ class ProductOutletWizard(models.TransientModel):
     def onchange_warehouse(self):
         if self.warehouse_id:
             product = self.env['product.product']. \
-                with_context(warehouse_id=self.warehouse_id.id). \
+                with_context(warehouse=self.warehouse_id.id). \
                 browse(self.env.context['active_id'])
             self.qty = product.qty_available
         else:

--- a/project-addons/product_outlet_loss/i18n/es.po
+++ b/project-addons/product_outlet_loss/i18n/es.po
@@ -173,10 +173,10 @@ msgid "Qty from stock"
 msgstr "Cantidad a Mover"
 
 #. module: product_outlet_loss
-#: code:addons/product_outlet_loss/wizard/product_outlet_wizard.py:97
+#: code:addons/product_outlet_loss/wizard/product_outlet_wizard.py:58
 #, python-format
-msgid "Qty to outlet must be <= qty available"
-msgstr "La cantidad que se mueve a outlet debe ser menor o igual a la cantidad siponible en Existencias"
+msgid "Qty to outlet must be <= qty available on the location"
+msgstr "La cantidad que se mueve a outlet debe ser menor o igual a la cantidad disponible en la ubicación"
 
 #. module: product_outlet_loss
 #: code:addons/product_outlet_loss/wizard/product_outlet_wizard.py:99

--- a/project-addons/product_outlet_loss/wizard/product_outlet_wizard.py
+++ b/project-addons/product_outlet_loss/wizard/product_outlet_wizard.py
@@ -55,7 +55,7 @@ class ProductOutletWizard(models.TransientModel):
         if self.state == "first":
             res = super(ProductOutletWizard, self).make_move()
         else:
-            if self.product_id.with_context({'location': self.location_orig_id.id}).qty_available < self.qty:
+            if self.product_id.with_context({'location': self.location_orig_id.id, 'warehouse': self.warehouse_id.id}).qty_available < self.qty:
                 raise ValidationError(_("Qty to outlet must be <= qty available on the location"))
             if self.qty <= 0:
                 raise ValidationError(_("Qty to outlet must be >=0"))

--- a/project-addons/product_outlet_loss/wizard/product_outlet_wizard.py
+++ b/project-addons/product_outlet_loss/wizard/product_outlet_wizard.py
@@ -55,8 +55,8 @@ class ProductOutletWizard(models.TransientModel):
         if self.state == "first":
             res = super(ProductOutletWizard, self).make_move()
         else:
-            if self.product_id.qty_available < self.qty:
-                raise ValidationError(_("Qty to outlet must be <= qty available"))
+            if self.product_id.with_context({'location': self.location_orig_id.id}).qty_available < self.qty:
+                raise ValidationError(_("Qty to outlet must be <= qty available on the location"))
             if self.qty <= 0:
                 raise ValidationError(_("Qty to outlet must be >=0"))
             category_selected = self.env['product.category'].browse(int(self.categ_id))


### PR DESCRIPTION
- [FIX]product_outlet_loss: ahora se mira el stock en la ubicacion que se selecciona en el asistente
- [FIX]product_outlet_loss: añadido almacén al calculo de stock 
- [FIX]product_outlet: corregido parámetro erróneo 
- [IMP]crm_claim_rma_custom: arrastramos el aviso de RMA a la descripción 