### PR TITLE
Estado pedidos en flask y filtro productos con stock en valoración inventario

### DIFF
--- a/project-addons/flask_middleware_connector/models/res_partner/common.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/common.py
@@ -18,8 +18,7 @@ class PartnerListener(Component):
         sales = self.env['sale.order'].search(
             [('partner_id', 'child_of', [record.id]),
                 ('company_id', '=', 1),
-                ('state', 'in',
-                 ['done', 'progress', 'draft', 'reserve'])])
+                ('state', 'in', ['done', 'sale'])])
         for sale in sales:
             sale.with_delay(priority=5, eta=120).export_order()
             for line in sale.order_line:

--- a/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
+++ b/project-addons/flask_middleware_connector/wizard/middleware_wizard.py
@@ -187,7 +187,7 @@ class MiddlewareBackend(models.TransientModel):
                                                   ('web', '=', True),
                                                   ('customer', '=', True)])
                 sales = self.env['sale.order'].search([('partner_id', 'child_of', partner_ids.ids),
-                                                          ('state', 'in', ['done', 'progress', 'draft', 'reserve']),
+                                                          ('state', 'in', ['done', 'sale']),
                                                           ('date_order', '>=', self.start_date),
                                                           ('date_order', '<=', self.finish_date),
                                                           ('company_id', '=', 1)])

--- a/project-addons/stock_custom/models/product.py
+++ b/project-addons/stock_custom/models/product.py
@@ -258,5 +258,5 @@ class StockQuantityHistory(models.TransientModel):
     def open_table(self):
         res = super().open_table()
         if res.get('domain'):
-            res['domain'] = "[('type', '=', 'product')]"
+            res['domain'] = "[('type', '=', 'product'), ('qty_available', '!=', 0)]"
         return res

--- a/project-addons/stock_custom/models/product.py
+++ b/project-addons/stock_custom/models/product.py
@@ -258,5 +258,5 @@ class StockQuantityHistory(models.TransientModel):
     def open_table(self):
         res = super().open_table()
         if res.get('domain'):
-            res['domain'] = "[('type', '=', 'product'), ('qty_available', '!=', 0)]"
+            res['domain'] = "[('type', '=', 'product')]"
         return res


### PR DESCRIPTION
- [FIX] flask_middleware_connector: Modificado filtrado de pedidos por estado en la exportación de clientes a flask
- [IMP] stock_custom: Añadido condición en el domain para que salgan so lo los productos con stock en la valoración de inventario