### PR TITLE
Cambio de estado a tramitado al finalizar albarán

### DIFF
--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -63,6 +63,10 @@ class StockPicking(models.Model):
                 picking_template.with_context(
                     lang=picking.partner_id.lang).send_mail(picking.id)
 
+            picking_states = picking.sale_id.picking_ids.mapped('state')
+            if all(state in ('done', 'cancel') for state in picking_states) \
+                    and not all(state == 'cancel' for state in picking_states):
+                picking.sale_id.action_done()
         return res
 
 


### PR DESCRIPTION
He vuelto a añadir este cambio ya que ahora mismo el estado del pedido funciona de manera extraña. Ahora mismo tenemos marcada en ajustes de venta la opción de **bloquear pedidos al confirmar** (que tendríamos que desactivar si subimos este cambio), y esto hace que se pasen a _Tramitado_ cuando se tramitan los pedidos. Si quitamos esta opción se quedan en _Pedido en preparación_ pero nunca pasan a _Tramitado_ ni cuando se termina el albarán ni cuando se facturan.
Entonces, con este cambio, hacemos que se pasen a _Tramitado_ cuando finaliza el albarán, que es justo lo que necesitamos. Hemos probado y aunque este tramitado el pedido, deja facturarlo todo bien.