### PR TITLE
Adaptación de claim_type a Many2one

### DIFF
--- a/project-addons/crm_claim_rma/__manifest__.py
+++ b/project-addons/crm_claim_rma/__manifest__.py
@@ -75,7 +75,8 @@ Contributors:
                 'product_warranty',
                 'equivalent_products',
                 'mrp_repair',
-                'stock_reserve'
+                'stock_reserve',
+                'crm_claim_type'
                 ],
     'data': ['wizard/claim_make_picking_view.xml',
              'wizard/claim_make_repair_view.xml',

--- a/project-addons/crm_claim_rma/report/crm_claim_report.py
+++ b/project-addons/crm_claim_rma/report/crm_claim_report.py
@@ -56,9 +56,8 @@ class CrmClaimReport(models.Model):
     email = fields.Integer('# Emails', readonly=True)
     subject = fields.Char('Claim Subject', readonly=True)
     nbr = fields.Float('RMA cost', readonly=True)
-    claim_type = fields.Selection([('customer', 'Customer'),
-                                   ('supplier', 'Supplier')],
-                                  string='Claim type', readonly=True)
+    claim_type = fields.Many2one('crm.claim.type',
+                                 string='Claim type', readonly=True)
 
     def init(self):
 

--- a/project-addons/crm_claim_rma/tests/test_lp_1282584.py
+++ b/project-addons/crm_claim_rma/tests/test_lp_1282584.py
@@ -36,6 +36,8 @@ class test_lp_1282584(common.TransactionCase):
         ClaimLine = self.registry('claim.line')
         Claim = self.registry('crm.claim')
 
+        customer_type = self.ref('crm_claim_type.crm_claim_type_customer').id
+
         self.product_id = self.ref('product.product_product_4')
 
         self.partner_id = self.ref('base.res_partner_12')
@@ -46,7 +48,7 @@ class test_lp_1282584(common.TransactionCase):
             {
                 'name': 'TEST CLAIM',
                 'number': 'TEST CLAIM',
-                'claim_type': 'customer',
+                'claim_type': customer_type,
                 'delivery_address_id': self.partner_id,
             })
 

--- a/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
+++ b/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
@@ -235,7 +235,6 @@
         <field name="partner_id" position="replace">
             <field name="partner_id" string="Partner" required="1" domain="[('is_company', '=', True)]"/>
             <field name="invoice_type"/>
-	    <field name="warehouse_id" invisible="1"/>
             <field name="invoice_id" domain="['|',('commercial_partner_id','=',partner_id),('partner_id','=',partner_id)]" attrs="{'invisible': [('invoice_type', '!=', 'refund')]}"/>
             <field name="invoice_method" attrs="{'invisible': [('invoice_type', '!=', 'invoice')]}" colspan="2"/>
             <button type="action" name="%(action_mrp_repair_invoice_from_claim_view)d" string="Invoice" colspan="2" attrs="{'invisible': ['|',('invoice_type', '!=', 'invoice'),('invoice_method','=','none')]}"/>
@@ -360,37 +359,37 @@
                 <div class="oe_right oe_button_box" name="buttons">
                     <button class="oe_stat_button" name="%(act_crm_claim_rma_sale_orders)d" type="action" icon="fa-pencil-square-o"
                             string="Quotations and Sales"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_customer)d)]}"
                             context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-pencil-square-o" name="%(act_crm_claim_rma_invoice_out)d" type="action"
                             string="Customer Invoices"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_customer)d)]}"
                             context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-pencil-square-o" name="%(act_crm_claim_rma_refunds_out)d" type="action"
                             string="Customer Refunds"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_customer)d)]}"
                             context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-pencil-square-o" name="%(act_crm_claim_rma_invoice_in)d" type="action"
                             string="Supplier Invoices"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_supplier)d)]}"
                             context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-truck" name="%(act_crm_claim_rma_refunds_in)d" type="action"
                             string="Supplier Refunds"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_supplier)d)]}"
                             context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-truck" name="%(act_crm_claim_rma_picking_in)d" type="action"
                             string="Returned Products"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_customer)d)]}"
                             context="{'search_default_claim_id': id,'search_default_user_id':False}"
                            />
                     <button class="oe_inline oe_stat_button" icon="fa-truck" name="%(act_crm_claim_rma_picking_out)d" type="action"
                             string="Deliveries"
-                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                            attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','!=',%(crm_claim_type.crm_claim_type_customer)d)]}"
                             context="{'search_default_claim_id': id,'search_default_user_id':False}"
                            />
                 </div>
@@ -400,7 +399,7 @@
             </field>
             <field name="priority" position="before">
                 <field name="name" />
-                <field name="supplier_number" attrs="{'invisible': [('claim_type','in', ['customer',])]}"/>
+                <field name="supplier_number" attrs="{'invisible': [('claim_type','!=',%(crm_claim_type.crm_claim_type_supplier)d)]}"/>
                 <field name="date"/>
             </field>
         </field>
@@ -482,8 +481,10 @@
     <record model="ir.actions.act_window" id="crm_claim.crm_case_categ_claim0">
         <field name="name">Customer Claims</field>
         <field name="res_model">crm.claim</field>
-        <field name="context">{"stage_type":'claim', "claim_type": 'customer'}</field>
-        <field name="domain" eval="[('claim_type','=','customer')]" />
+         <field name="context" eval="{'stage_type': 'claim',
+                                     'claim_type': ref('crm_claim_type.crm_claim_type_customer'),
+                                     'default_claim_type': ref('crm_claim_type.crm_claim_type_customer')}"/>
+        <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer'))]" />
     </record>
 
 
@@ -496,8 +497,10 @@
         <field name="view_type">form</field>
         <field name="view_mode">tree,calendar,form</field>
         <field name="view_id" ref="crm_case_claims_tree_view"/>
-        <field name="context">{"stage_type":'claim', "claim_type": 'supplier'}</field>
-        <field name="domain" eval="[('claim_type','=','supplier')]" />
+        <field name="context" eval="{'stage_type': 'claim',
+                                     'claim_type': ref('crm_claim_type.crm_claim_type_supplier'),
+                                     'default_claim_type': ref('crm_claim_type.crm_claim_type_supplier')}"/>
+        <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_supplier'))]" />
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
@@ -515,7 +518,7 @@
         <field name="res_model">claim.line</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain" eval="[('claim_type','=','customer')]" />
+        <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer'))]" />
         <field name="context">{}</field>
         <field name="view_id" ref="crm_claim_line_tree_view2"/>
         <field name="search_view_id" ref="view_crm_claim_lines_filter"/>
@@ -526,7 +529,7 @@
         <field name="res_model">claim.line</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain" eval="[('claim_type','=','supplier')]" />
+        <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_supplier'))]" />
         <field name="context">{}</field>
         <field name="view_id" ref="crm_claim_line_tree_view"/>
         <field name="search_view_id" ref="view_crm_claim_lines_filter"/>

--- a/project-addons/crm_claim_rma/wizard/claim_make_picking.py
+++ b/project-addons/crm_claim_rma/wizard/claim_make_picking.py
@@ -38,11 +38,13 @@ class ClaimMakePicking(models.TransientModel):
         lines, or if different, return None."""
         context = self.env.context
         loc_id = False
+        supplier_type = self.env.ref('crm_claim_type.crm_claim_type_supplier').id
+        customer_type = self.env.ref('crm_claim_type.crm_claim_type_customer').id
         if context.get('picking_type') == 'out':
             partner = self.env['res.partner'].browse(context.get('partner_id'))
-            if context.get('type') == 'supplier':
+            if context.get('type') == supplier_type:
                 loc_id = partner.property_stock_supplier
-            elif context.get('type') == 'customer':
+            elif context.get('type') == customer_type:
                 loc_id = partner.property_stock_customer
         elif context.get('picking_type') == 'in':
             # Add the case of return to supplier !
@@ -74,19 +76,21 @@ class ClaimMakePicking(models.TransientModel):
     def _get_source_loc(self):
         loc_id = False
         context = self.env.context
+        supplier_type = self.env.ref('crm_claim_type.crm_claim_type_supplier').id
+        customer_type = self.env.ref('crm_claim_type.crm_claim_type_customer').id
         if context.get('picking_type') == 'out':
             warehouse = self.env['stock.warehouse'].browse(context.get('warehouse_id'))
-            if context.get('type') == 'supplier':
+            if context.get('type') == supplier_type:
                 loc_id = warehouse.lot_breakdown_id
-            if context.get('type') == 'customer':
+            if context.get('type') == customer_type:
                 loc_id = warehouse.lot_rma_id
 
         elif context.get('picking_type') == 'in':
             partner = self.env['res.partner'].browse(context.get('partner_id'))
-            if context.get('type') == 'supplier':
+            if context.get('type') == supplier_type:
                 loc_id = partner.property_stock_supplier
 
-            if context.get('type') == 'customer':
+            if context.get('type') == customer_type:
                 loc_id = partner.property_stock_customer
         return loc_id
 

--- a/project-addons/crm_claim_rma/wizard/claim_send_supplier.py
+++ b/project-addons/crm_claim_rma/wizard/claim_send_supplier.py
@@ -35,6 +35,7 @@ class ClaimSendSupplier(models.TransientModel):
         claim_obj = self.env['crm.claim']
         wh_ids = wh_obj.search([('company_id', '=',
                                  self.env.user.company_id.id)])
+        supplier_type = self.env.ref('crm_claim_type.crm_claim_type_supplier').id
 
         lines = self.env['claim.line'].browse(self.env.context['active_ids'])
         supplier_lines = {}
@@ -55,7 +56,7 @@ class ClaimSendSupplier(models.TransientModel):
         for supplier in partner_obj.browse(supplier_lines.keys()):
             claims_created = claim_obj.search(
                 [('partner_id', '=', supplier.id),
-                 ('claim_type', '=', 'supplier'),
+                 ('claim_type', '=', supplier_type),
                  ('stage_id.closed', '=', False)])
             if claims_created:
                 claim = claims_created[0]
@@ -63,7 +64,7 @@ class ClaimSendSupplier(models.TransientModel):
                 claim_vals = {
                     'name': supplier.name,
                     'user_id': self.env.user.id,
-                    'claim_type': 'supplier',
+                    'claim_type': supplier_type,
                     'partner_id': supplier.id,
                     'partner_phone': supplier.phone,
                     'email_from': supplier.email,

--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -61,15 +61,6 @@ class CrmClaimRma(models.Model):
 
     check_states = ['substate_received', 'substate_process', 'substate_due_receive']
 
-    @api.onchange('claim_type')
-    def onchange_claim_type(self):
-        if self.claim_type == 'customer':
-            return {'domain': {'partner_id': [('customer', '=', True),
-                                              ('is_company', '=', True)]}}
-        else:
-            return {'domain': {'partner_id': [('supplier', '=', True),
-                                              ('is_company', '=', True)]}}
-
     @api.multi
     def write(self, vals):
         if 'stage_id' in vals:
@@ -103,7 +94,8 @@ class CrmClaimRma(models.Model):
     @api.model
     def _get_sequence_number(self):
         seq_obj = self.env['ir.sequence']
-        if 'claim_type' in self.env.context and self.env.context['claim_type'] == 'supplier':
+        supplier_type = self.env.ref('crm_claim_type.crm_claim_type_supplier').id
+        if 'claim_type' in self.env.context and self.env.context['claim_type'] == supplier_type:
             res = seq_obj.get('crm.claim.rma.supplier') or '/'
         else:
             res = seq_obj.get('crm.claim.rma') or '/'

--- a/project-addons/crm_claim_rma_custom/models/mrp_repair.py
+++ b/project-addons/crm_claim_rma_custom/models/mrp_repair.py
@@ -32,8 +32,8 @@ class MrpRepair(models.Model):
         order_obj = self.browse(self.id)
         claim_line_obj = self.env['claim.line'].browse(self.claim_id.id)
         claim_obj = self.env['crm.claim'].browse(claim_line_obj.id)
-
-        if claim_obj.claim_type == u'customer':
+        customer_type = self.env.ref('crm_claim_type.crm_claim_type_customer').id
+        if claim_obj.claim_type.id == customer_type:
             for operation in order_obj.operations.ids:
                 operation_obj = order_obj.operations.browse(operation)
                 if operation_obj.type == u'add':

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -61,7 +61,7 @@
         <field name="arch" type="xml">
             <field name="rma_cost" position="after">
                 <field name="date_received"/>
-                <field name="allow_confirm_blocked" attrs="{'invisible': [('claim_type', '!=', 'customer')]}" groups="account.group_account_manager"/>
+                <field name="allow_confirm_blocked" attrs="{'invisible': [('claim_type', '!=', %(crm_claim_type.crm_claim_type_customer)d)]}" groups="account.group_account_manager"/>
             </field>
             <field name="email_from" position="after">
                 <field name="comercial"/>
@@ -109,9 +109,6 @@
       <field name="inherit_id" ref="crm_claim_rma.crm_claim_rma_form_view"/>
       <field name="arch" type="xml">
           <field name="invoice_id" position="replace"/>
-          <field name="partner_id" position="before">
-              <field name="claim_type" invisible="1"/>
-          </field>
       </field>
     </record>
 
@@ -267,30 +264,16 @@
         </field>
     </record>
 
-    <record model="ir.actions.act_window" id="crm_claim_rma.crm_case_categ_claim_supplier">
-        <field name="name">Claims</field>
-        <field name="res_model">crm.claim</field>
-        <field name="view_type">form</field>
-        <field name="view_mode">tree,calendar,form</field>
-        <field name="view_id" ref="crm_claim_rma.crm_case_claims_tree_view"/>
-        <field name="context">{"search_default_user_id":uid, "stage_type":'claim', "claim_type": 'supplier', "default_claim_type": 'supplier'}</field>
-        <field name="domain" eval="[('claim_type','=','supplier')]" />
-        <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
-        <field name="help" type="html">
-            <p class="oe_view_nocontent_create">
-                Record and track your suppliers' claims. Claims may be linked to a sales order or a lot.You can send emails with attachments and keep the full history for a claim (emails sent, intervention type and so on).Claims may automatically be linked to an email address using the mail gateway module.
-            </p>
-        </field>
-    </record>
-
     <record model="ir.actions.act_window" id="crm_case_categ_claim_sort">
         <field name="name">Received Claims</field>
         <field name="res_model">crm.claim</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,calendar,form</field>
         <field name="view_id" ref="crm_case_claims_tree_view_received"/>
-        <field name="domain">[('claim_type', '=', 'customer')]</field>
-        <field name="context">{"stage_type":'claim', "claim_type": 'customer'}</field>
+        <field name="context" eval="{'stage_type': 'claim',
+                                     'claim_type': ref('crm_claim_type.crm_claim_type_customer'),
+                                     'default_claim_type': ref('crm_claim_type.crm_claim_type_customer')}"/>
+        <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer'))]"/>
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">


### PR DESCRIPTION
[REF] crm_claim_rma, crm_claim_rma_custom: Cambios para adaptar claim_type al tipo de dato que viene del módulo original y así evitar incongruencias en la base de datos que provocaban que se mezclasen RMAs con RMPs


Habría que ejecutar estas queries para dejarlo todo bien actualizado:
```
-- Actualizar tipo de reclamación en RMA y sus líneas
UPDATE claim_line cl
SET claim_type = 1
FROM crm_claim cc 
WHERE cc.id = cl.claim_id AND cc.number like 'RMA%';

UPDATE crm_claim
SET claim_type = 1
WHERE number like 'RMA%';


-- Actualizar tipo de reclamación en RMP y sus líneas
UPDATE claim_line cl
SET claim_type = 2
FROM crm_claim cc 
WHERE cc.id = cl.claim_id AND cc.number like 'RMP%';

UPDATE crm_claim
SET claim_type = 2
WHERE number like 'RMP%';
```