### PR TITLE
Arreglo de email_web y modo de pago en facturas

### DIFF
--- a/project-addons/custom_account/models/account.py
+++ b/project-addons/custom_account/models/account.py
@@ -77,6 +77,7 @@ class AccountInvoice(models.Model):
     date_due = fields.Date(states={'draft': [('readonly', False)],
                                    'open': [('readonly', False)]})
     state_web = fields.Char('State web', compute='_get_state_web', store=True)
+    payment_mode_id = fields.Many2one(states={'draft': [('readonly', False)], 'open': [('readonly', False)]})
 
     @api.multi
     @api.depends('state', 'payment_mode_id', 'payment_move_line_ids')
@@ -234,6 +235,11 @@ class AccountInvoice(models.Model):
         if self.currency_id != line.order_id.currency_id:
             self.currency_id = line.order_id.currency_id
         return data
+
+    @api.onchange('payment_mode_id')
+    def _onchange_payment_mode_id(self):
+        super()._onchange_payment_mode_id()
+        self.move_id.line_ids.filtered(lambda l: l.account_id.code == '43000000').write({'payment_mode_id': self.payment_mode_id.id})
 
 
 class PaymentMode(models.Model):

--- a/project-addons/custom_account/views/partner_view.xml
+++ b/project-addons/custom_account/views/partner_view.xml
@@ -25,7 +25,7 @@
                         <field name="date" string="Created date" readonly="True"/>
                         <field name="lang" attrs="{'required': [('is_company', '=', True),('customer', '=', True),('dropship', '=', False),('prospective', '=', False)]}"/>
                         <field name="web" attrs="{'invisible': [('is_company', '!=', True)]}"/>
-                        <field name="email_web" attrs="{'invisible': [('web', '!=', True),('dropship', '=', True)], 'required': [('web', '=', True),('dropship', '=', False)]}"/>
+                        <field name="email_web" attrs="{'invisible': [('web', '!=', True),('dropship', '=', True)], 'required': [('web', '=', True),('dropship', '=', False),('is_company', '=', True)]}"/>
                     </group>
                 </xpath>
                 <field name="ref" position="attributes">


### PR DESCRIPTION
- [FIX]custom_account: añadida nueva restricción a la obligatoriedad del campo email_web
- [IMP]custom_account: permitir cambiar la forma de pago de las facturas abiertas