### PR TITLE
No bloquear facturas de cliente

### DIFF
--- a/project-addons/block_invoices/__init__.py
+++ b/project-addons/block_invoices/__init__.py
@@ -1,4 +1,4 @@
 # © 2019 Comunitea
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import models
-from . import wizard
+# from . import wizard

--- a/project-addons/block_invoices/models/account_invoice.py
+++ b/project-addons/block_invoices/models/account_invoice.py
@@ -18,14 +18,14 @@ class AccountInvoice(models.Model):
         for invoice in self:
             # Compruebo la empresa actual y su padre...
             for partner in invoice.partner_id.get_partners_to_check():
-                # Comprobar ventas bloqueadas si es una factura de cliente o si es una factura de un proveedor que es cliente también
-                if invoice.type == 'out_invoice' or (invoice.type == 'in_invoice' and partner.customer):
-                    if partner.blocked_sales and not invoice.allow_confirm_blocked:
-                        if not invoice.sale_order_ids or \
-                                (invoice.sale_order_ids
-                                 and any(not order.allow_confirm_blocked for order in invoice.sale_order_ids)):
-                            message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
-                            raise exceptions.Warning(message)
+                # Comprobar ventas bloqueadas si es una factura de un proveedor que es cliente también
+                if invoice.type == 'in_invoice' and partner.customer and \
+                        partner.blocked_sales and not invoice.allow_confirm_blocked:
+                    if not invoice.sale_order_ids or \
+                            (invoice.sale_order_ids
+                             and any(not order.allow_confirm_blocked for order in invoice.sale_order_ids)):
+                        message = _('Customer blocked by lack of payment. Check the maturity dates of their account move lines.')
+                        raise exceptions.Warning(message)
         return super().invoice_validate()
 
     @api.onchange('partner_id')


### PR DESCRIPTION
[IMP] block_invoices: Permitir validar factura aunque el cliente tenga las ventas bloqueadas porque da problemas en facturación automática