### PR TITLE
Arreglo en subestado RMA y DHL

### DIFF
--- a/project-addons/crm_claim_rma_custom/models/stock.py
+++ b/project-addons/crm_claim_rma_custom/models/stock.py
@@ -52,7 +52,7 @@ class StockPicking(models.Model):
             if picking.claim_id:
                 for move in picking.move_lines:
                     if move.claim_line_id:
-                        if picking.picking_type_code == 'incoming':
+                        if picking.picking_type_code == 'incoming' and picking.location_dest_id.name == 'RMA':
                             move.claim_line_id.substate_id = self.env.ref(
                                 'crm_claim_rma_custom.substate_received')
                         elif picking.picking_type_code == 'outgoing':


### PR DESCRIPTION
- [FIX]crm_claim_rma_custom: no permitir poner linea a recibido cuando se genera el albarán de playa
- [FIX]sale_order_board: Arreglado problema en DHL cuando viene un solo servicio