### PR TITLE
Cambiado el momento en el que se envía el email con el tracking

### DIFF
--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -91,7 +91,7 @@ class StockPicking(models.Model):
             if vals.get('carrier_tracking_ref', False) and \
                     picking.picking_type_code == 'outgoing' and \
                     picking.sale_id\
-                    and picking.carrier_tracking_ref is False:
+                    and not picking.carrier_tracking_ref:
                 picking_template = self.env. \
                     ref('stock_custom.picking_done_template')
                 picking_template.with_context(

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -90,7 +90,8 @@ class StockPicking(models.Model):
         for picking in self:
             if vals.get('carrier_tracking_ref', False) and \
                     picking.picking_type_code == 'outgoing' and \
-                    picking.sale_id:
+                    picking.sale_id\
+                    and picking.carrier_tracking_ref is False:
                 picking_template = self.env. \
                     ref('stock_custom.picking_done_template')
                 picking_template.with_context(


### PR DESCRIPTION
- [DEV] stock_custom: Enviar email cuando se actualiza ref seguimiento de transportista en vez de cuando se transfiere el albarán
- [FIX]stock_custom: añadida condición para enviar correo
- [FIX]stock_custom: mejorada condición al enviar correo de tracking 