### PR TITLE
Cambio de campos en albarán de entrada

### DIFF
--- a/project-addons/custom_account/i18n/es.po
+++ b/project-addons/custom_account/i18n/es.po
@@ -1060,3 +1060,13 @@ msgstr "wizard.reconcile.payment.statement.line"
 #: model:ir.model,name:custom_account.model_wzd_remove_partner_payment_order
 msgid "wzd.remove.partner.payment.order"
 msgstr "wzd.remove.partner.payment.order"
+
+#. module: custom_account
+#: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "Supplier Reference"
+msgstr "Referencia de proveedor"
+
+#. module: custom_account
+#: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "N. Supplier Invoice (SII)"
+msgstr "Nº factura proveedor (SII)"

--- a/project-addons/custom_account/i18n/es.po
+++ b/project-addons/custom_account/i18n/es.po
@@ -1063,10 +1063,12 @@ msgstr "wzd.remove.partner.payment.order"
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+#: model:ir.model.fields,field_description:custom_account.field_account_invoice_name
 msgid "Supplier Reference"
 msgstr "Referencia de proveedor"
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+#: model:ir.model.fields,field_description:custom_account.field_account_invoice_reference
 msgid "N. Supplier Invoice (SII)"
-msgstr "Nº factura proveedor (SII)"
+msgstr "N. factura proveedor (SII)"

--- a/project-addons/custom_account/i18n/it.po
+++ b/project-addons/custom_account/i18n/it.po
@@ -1029,12 +1029,20 @@ msgstr "wizard.reconcile.payment.statement.line"
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "Supplier Reference"
+msgstr "Riferimento fornitore "
+
+#. module: custom_account
 #: model:ir.model.fields,field_description:custom_account.field_account_invoice_name
 msgid "Supplier Reference"
 msgstr "Riferimento fornitore "
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "N. Supplier Invoice (SII)"
+msgstr "N. fattura fornitore (SII)"
+
+#. module: custom_account
 #: model:ir.model.fields,field_description:custom_account.field_account_invoice_reference
 msgid "N. Supplier Invoice (SII)"
 msgstr "N. fattura fornitore (SII)"

--- a/project-addons/custom_account/i18n/it.po
+++ b/project-addons/custom_account/i18n/it.po
@@ -1029,10 +1029,12 @@ msgstr "wizard.reconcile.payment.statement.line"
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+#: model:ir.model.fields,field_description:custom_account.field_account_invoice_name
 msgid "Supplier Reference"
 msgstr "Riferimento fornitore "
 
 #. module: custom_account
 #: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+#: model:ir.model.fields,field_description:custom_account.field_account_invoice_reference
 msgid "N. Supplier Invoice (SII)"
 msgstr "N. fattura fornitore (SII)"

--- a/project-addons/custom_account/i18n/it.po
+++ b/project-addons/custom_account/i18n/it.po
@@ -1026,3 +1026,13 @@ msgstr "wizard.reclassify.move.line.balance"
 #: model:ir.model,name:custom_account.model_wizard_reconcile_payment_statement_line
 msgid "wizard.reconcile.payment.statement.line"
 msgstr "wizard.reconcile.payment.statement.line"
+
+#. module: custom_account
+#: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "Supplier Reference"
+msgstr "Riferimento fornitore "
+
+#. module: custom_account
+#: model:ir.ui.view,arch_db:custom_account.invoice_supplier_form_add_pick
+msgid "N. Supplier Invoice (SII)"
+msgstr "N. fattura fornitore (SII)"

--- a/project-addons/custom_account/models/account.py
+++ b/project-addons/custom_account/models/account.py
@@ -79,6 +79,9 @@ class AccountInvoice(models.Model):
     state_web = fields.Char('State web', compute='_get_state_web', store=True)
     payment_mode_id = fields.Many2one(states={'draft': [('readonly', False)], 'open': [('readonly', False)]})
 
+    name = fields.Char(string='Supplier Reference')
+    reference = fields.Char(string='N. Supplier Invoice (SII)')
+
     @api.multi
     @api.depends('state', 'payment_mode_id', 'payment_move_line_ids')
     def _get_state_web(self):

--- a/project-addons/custom_account/views/account_view.xml
+++ b/project-addons/custom_account/views/account_view.xml
@@ -44,6 +44,16 @@
                 <field name="date_due" position="attributes">
                     <attribute name="attrs">{}</attribute>
                 </field>
+                <xpath expr="//page[@name='other_info']/group/group/field[@name='name']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <field name="purchase_id" position="before">
+                    <field name="name" string="Supplier Reference"/>
+                </field>
+                <field name="reference" position="attributes">
+                    <attribute name="string">N. Supplier Invoice (SII)</attribute>
+                    <attribute name="help">Invoice supplier number</attribute>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
-  [IMP]custom_account: movido campo descripción a la cabecera e intercambio de nombres con referencia de proveedor
- [IMP]custom_account: añadido override de string de campos y traducciones 
- [IMP]custom_account: modificada traducción italiano

Hola, tenemos un problemilla con las traducciones de esto. Aparentemente el archivo está bien, no se si se me está escapando algo, pero luego en la búsqueda, no aparece ninguno de los dos campos que se han cambiado. (A la hora de añadir un filtro sobre esos campos en la vista tree de los albaranes de entrada). En el formulario del albarán si aparecen ya que en principio añadimos el string en el xml.