### PR TITLE
Cambios en los campos de RMA

### DIFF
--- a/project-addons/block_invoices/models/sale_order.py
+++ b/project-addons/block_invoices/models/sale_order.py
@@ -46,7 +46,7 @@ class SaleOrder(models.Model):
             return {'warning': warning}
 
     @api.onchange('partner_id', 'team_id', 'payment_term_id')
-    def onchange_block_magrep(self):
+    def onchange_block_magreb(self):
         if (self.team_id.name == 'Magreb' or self.partner_id.team_id.name == 'Magreb') \
                 and self.allow_confirm_blocked_magreb is False:
             self.blocked_magreb = True

--- a/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
+++ b/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
@@ -96,7 +96,6 @@
                 <field name="move_out_customer_state"/>
                 <field name="supplier_id"/>
                 <field name="internal_description"/>
-                <button name="%(action_claim_make_repair)d" type="action" string="Create repair" attrs="{'invisible': [('repair_id', '!=', False)]}"/>
             </tree>
         </field>
     </record>
@@ -123,7 +122,6 @@
                 <field name="move_out_customer_state"/>
                 <field name="supplier_id"/>
                 <field name="internal_description"/>
-                <button name="%(action_claim_make_repair)d" type="action" string="Create repair" attrs="{'invisible': [('repair_id', '!=', False)]}"/>
             </tree>
         </field>
     </record>

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -61,9 +61,7 @@
         <field name="arch" type="xml">
             <field name="rma_cost" position="after">
                 <field name="date_received"/>
-                <field name="allow_confirm_blocked"
-                       attrs="{'invisible': [('claim_type', '!=', %(crm_claim_type.crm_claim_type_customer)d)]}"
-                       groups="account.group_account_manager"/>
+                <field name="allow_confirm_blocked" attrs="{'invisible': [('claim_type', '!=', %(crm_claim_type.crm_claim_type_customer)d)]}" groups="account.group_account_manager"/>
             </field>
             <field name="email_from" position="after">
                 <field name="comercial"/>
@@ -77,30 +75,28 @@
                 <page string="Invoicing">
                     <field name="claim_inv_line_ids" nolabel="1" colspan="4" editable="bottom">
                         <tree editable="bottom">
-                            <field name="sequence" widget="handle"/>
-                            <field name="invoice_id"
-                                   domain="[('partner_id', 'child_of', parent.partner_id),('state', '!=', 'draft')]"/>
-                            <field name="product_id"/>
-                            <field name="product_description"/>
-                            <field name="qty"/>
-                            <field name="price_unit"/>
-                            <field name="discount"/>
-                            <field name="tax_ids" widget="many2many_tags"
-                                   domain="[('parent_id','=',False),('type_tax_use','=','sale')]"/>
-                            <field name="price_subtotal"/>
-                            <field name="invoiced"/>
+                          <field name="sequence" widget="handle"/>
+                          <field name="invoice_id" domain="[('partner_id', 'child_of', parent.partner_id),('state', '!=', 'draft')]"/>
+                          <field name="product_id"/>
+                          <field name="product_description"/>
+                          <field name="qty"/>
+                          <field name="price_unit"/>
+                          <field name="discount"/>
+                          <field name="tax_ids" widget="many2many_tags" domain="[('parent_id','=',False),('type_tax_use','=','sale')]"/>
+                          <field name="price_subtotal"/>
+                          <field name="invoiced"/>
                         </tree>
                     </field>
                     <group>
-                        <group>
-                            <button name="calculate_invoices" type="object"
-                                    string="Calculate"
-                                    attrs="{'invisible': [('invoice_ids', '!=', [])]}" colspan="2"/>
-                            <separator/>
-                            <button name="make_refund_invoice"
-                                    attrs="{'invisible': [('claim_inv_line_ids', '=', [])]}"
-                                    type="object" string="New Refund" class="btn-primary" colspan="2"/>
-                        </group>
+                      <group>
+                          <button name="calculate_invoices" type="object"
+                            string="Calculate"
+                            attrs="{'invisible': [('invoice_ids', '!=', [])]}" colspan="2"/>
+                          <separator/>
+                          <button name="make_refund_invoice"
+                              attrs="{'invisible': [('claim_inv_line_ids', '=', [])]}"
+                              type="object" string="New Refund" class="btn-primary" colspan="2"/>
+                      </group>
                     </group>
                 </page>
             </xpath>
@@ -108,12 +104,12 @@
     </record>
 
     <record model="ir.ui.view" id="crm_claim_rma_form_view_invoice_method">
-        <field name="name">CRM - Claim product return Form</field>
-        <field name="model">crm.claim</field>
-        <field name="inherit_id" ref="crm_claim_rma.crm_claim_rma_form_view"/>
-        <field name="arch" type="xml">
-            <field name="invoice_id" position="replace"/>
-        </field>
+      <field name="name">CRM - Claim product return Form</field>
+      <field name="model">crm.claim</field>
+      <field name="inherit_id" ref="crm_claim_rma.crm_claim_rma_form_view"/>
+      <field name="arch" type="xml">
+          <field name="invoice_id" position="replace"/>
+      </field>
     </record>
 
     <record model="ir.ui.view" id="crm_claim_line_tree_view_invisible_states">
@@ -142,27 +138,26 @@
             <field name="claim_origine" position="after">
                 <!-- <field name="invoice_id"/> -->
                 <field name="partner_id" invisible="1"/>
-                <field name="invoice_id"
-                       domain="[('partner_id', 'child_of', [parent.partner_id]),('state', '!=', 'draft')]"/>
+                <field name="invoice_id" domain="[('partner_id', 'child_of', [parent.partner_id]),('state', '!=', 'draft')]"/>
             </field>
         </field>
     </record>
 
     <record model="ir.ui.view" id="inherit2_crm_case_claims_tree_view">
-        <field name="name">CRM - Claims Tree</field>
-        <field name="model">crm.claim</field>
-        <field name="inherit_id" ref="crm_claim_rma.crm_case_claims_tree_view"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='team_id']" position="replace">
-                <field name="team_id" invisible="1"/>
-            </xpath>
-            <xpath expr="//field[@name='claim_type']" position="replace">
-                <field name="claim_type" invisible="1"/>
-            </xpath>
-            <xpath expr="//field[@name='date']" position="after">
-                <field name="date_received" readonly="True"/>
-            </xpath>
-        </field>
+      <field name="name">CRM - Claims Tree</field>
+      <field name="model">crm.claim</field>
+      <field name="inherit_id" ref="crm_claim_rma.crm_case_claims_tree_view"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='team_id']" position="replace">
+          <field name="team_id" invisible="1"/>
+        </xpath>
+        <xpath expr="//field[@name='claim_type']" position="replace">
+          <field name="claim_type" invisible="1"/>
+        </xpath>
+        <xpath expr="//field[@name='date']" position="after">
+          <field name="date_received" readonly="True"/>
+        </xpath>
+      </field>
     </record>
 
     <record model="ir.ui.view" id="inherit_crm_case_claims_tree_view">
@@ -196,13 +191,9 @@
                 <field name="name"/>
             </xpath>
             <xpath expr="//field[@name='delivery_address_id']" position="attributes">
-                <attribute name="domain">[('id', 'child_of', [partner_id]),'|',('is_company', '=', True),('type', '=',
-                    'delivery')]
-                </attribute>
-                <attribute name="context">{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree',
-                    'default_type':'delivery', 'default_dropship': True,
-                    'default_not_print_picking': True, 'default_parent_id': partner_id, 'show_address':1}
-                </attribute>
+                <attribute name="domain">[('id', 'child_of', [partner_id]),'|',('is_company', '=', True),('type', '=', 'delivery')]</attribute>
+                <attribute name="context">{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree', 'default_type':'delivery', 'default_dropship': True,
+                                           'default_not_print_picking': True, 'default_parent_id': partner_id, 'show_address':1}</attribute>
                 <attribute name="options">{"always_reload": True}</attribute>
             </xpath>
         </field>
@@ -287,9 +278,7 @@
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
-                Record and track your customers' claims. Claims may be linked to a sales order or a lot.You can send
-                emails with attachments and keep the full history for a claim (emails sent, intervention type and so
-                on).Claims may automatically be linked to an email address using the mail gateway module.
+                Record and track your customers' claims. Claims may be linked to a sales order or a lot.You can send emails with attachments and keep the full history for a claim (emails sent, intervention type and so on).Claims may automatically be linked to an email address using the mail gateway module.
             </p>
         </field>
     </record>
@@ -311,5 +300,5 @@
     </record>
 
     <menuitem name="Received Claims" id="menu_crm_case_claims"
-              parent="crm_claim.menu_aftersale" action="crm_case_categ_claim_sort" sequence="1"/>
+        parent="crm_claim.menu_aftersale" action="crm_case_categ_claim_sort" sequence="1"/>
 </odoo>

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -61,7 +61,9 @@
         <field name="arch" type="xml">
             <field name="rma_cost" position="after">
                 <field name="date_received"/>
-                <field name="allow_confirm_blocked" attrs="{'invisible': [('claim_type', '!=', %(crm_claim_type.crm_claim_type_customer)d)]}" groups="account.group_account_manager"/>
+                <field name="allow_confirm_blocked"
+                       attrs="{'invisible': [('claim_type', '!=', %(crm_claim_type.crm_claim_type_customer)d)]}"
+                       groups="account.group_account_manager"/>
             </field>
             <field name="email_from" position="after">
                 <field name="comercial"/>
@@ -75,28 +77,30 @@
                 <page string="Invoicing">
                     <field name="claim_inv_line_ids" nolabel="1" colspan="4" editable="bottom">
                         <tree editable="bottom">
-                          <field name="sequence" widget="handle"/>
-                          <field name="invoice_id" domain="[('partner_id', 'child_of', parent.partner_id),('state', '!=', 'draft')]"/>
-                          <field name="product_id"/>
-                          <field name="product_description"/>
-                          <field name="qty"/>
-                          <field name="price_unit"/>
-                          <field name="discount"/>
-                          <field name="tax_ids" widget="many2many_tags" domain="[('parent_id','=',False),('type_tax_use','=','sale')]"/>
-                          <field name="price_subtotal"/>
-                          <field name="invoiced"/>
+                            <field name="sequence" widget="handle"/>
+                            <field name="invoice_id"
+                                   domain="[('partner_id', 'child_of', parent.partner_id),('state', '!=', 'draft')]"/>
+                            <field name="product_id"/>
+                            <field name="product_description"/>
+                            <field name="qty"/>
+                            <field name="price_unit"/>
+                            <field name="discount"/>
+                            <field name="tax_ids" widget="many2many_tags"
+                                   domain="[('parent_id','=',False),('type_tax_use','=','sale')]"/>
+                            <field name="price_subtotal"/>
+                            <field name="invoiced"/>
                         </tree>
                     </field>
                     <group>
-                      <group>
-                          <button name="calculate_invoices" type="object"
-                            string="Calculate"
-                            attrs="{'invisible': [('invoice_ids', '!=', [])]}" colspan="2"/>
-                          <separator/>
-                          <button name="make_refund_invoice"
-                              attrs="{'invisible': [('claim_inv_line_ids', '=', [])]}"
-                              type="object" string="New Refund" class="btn-primary" colspan="2"/>
-                      </group>
+                        <group>
+                            <button name="calculate_invoices" type="object"
+                                    string="Calculate"
+                                    attrs="{'invisible': [('invoice_ids', '!=', [])]}" colspan="2"/>
+                            <separator/>
+                            <button name="make_refund_invoice"
+                                    attrs="{'invisible': [('claim_inv_line_ids', '=', [])]}"
+                                    type="object" string="New Refund" class="btn-primary" colspan="2"/>
+                        </group>
                     </group>
                 </page>
             </xpath>
@@ -104,12 +108,12 @@
     </record>
 
     <record model="ir.ui.view" id="crm_claim_rma_form_view_invoice_method">
-      <field name="name">CRM - Claim product return Form</field>
-      <field name="model">crm.claim</field>
-      <field name="inherit_id" ref="crm_claim_rma.crm_claim_rma_form_view"/>
-      <field name="arch" type="xml">
-          <field name="invoice_id" position="replace"/>
-      </field>
+        <field name="name">CRM - Claim product return Form</field>
+        <field name="model">crm.claim</field>
+        <field name="inherit_id" ref="crm_claim_rma.crm_claim_rma_form_view"/>
+        <field name="arch" type="xml">
+            <field name="invoice_id" position="replace"/>
+        </field>
     </record>
 
     <record model="ir.ui.view" id="crm_claim_line_tree_view_invisible_states">
@@ -130,37 +134,35 @@
             </field>
             <field name="product_returned_quantity" position="after">
                 <button name="action_split" type="object" string="Split" icon="fa-cut"
-                    attrs="{'invisible': ['|','|','|',('move_in_customer_state','!=',False),('move_out_customer_state','!=',False),('repair_id','!=',False),('product_returned_quantity','&lt;=',1.0)]}"/>
+                        attrs="{'invisible': ['|','|','|',('move_in_customer_state','!=',False),('move_out_customer_state','!=',False),('repair_id','!=',False),('product_returned_quantity','&lt;=',1.0)]}"/>
             </field>
-            <button name="%(crm_claim_rma.action_claim_make_repair)d" position="replace">
-                <button name="create_repair" type="object" icon="fa-wrench" string="Create repair" attrs="{'invisible': [('repair_id', '!=', False)]}"/>
-            </button>
             <field name="product_id" position="attributes">
                 <attribute name="options">{'no_quick_create':True,'no_create_edit':True}</attribute>
             </field>
             <field name="claim_origine" position="after">
                 <!-- <field name="invoice_id"/> -->
                 <field name="partner_id" invisible="1"/>
-                <field name="invoice_id" domain="[('partner_id', 'child_of', [parent.partner_id]),('state', '!=', 'draft')]"/>
+                <field name="invoice_id"
+                       domain="[('partner_id', 'child_of', [parent.partner_id]),('state', '!=', 'draft')]"/>
             </field>
         </field>
     </record>
 
     <record model="ir.ui.view" id="inherit2_crm_case_claims_tree_view">
-      <field name="name">CRM - Claims Tree</field>
-      <field name="model">crm.claim</field>
-      <field name="inherit_id" ref="crm_claim_rma.crm_case_claims_tree_view"/>
-      <field name="arch" type="xml">
-        <xpath expr="//field[@name='team_id']" position="replace">
-          <field name="team_id" invisible="1"/>
-        </xpath>
-        <xpath expr="//field[@name='claim_type']" position="replace">
-          <field name="claim_type" invisible="1"/>
-        </xpath>
-        <xpath expr="//field[@name='date']" position="after">
-          <field name="date_received" readonly="True"/>
-        </xpath>
-      </field>
+        <field name="name">CRM - Claims Tree</field>
+        <field name="model">crm.claim</field>
+        <field name="inherit_id" ref="crm_claim_rma.crm_case_claims_tree_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='team_id']" position="replace">
+                <field name="team_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='claim_type']" position="replace">
+                <field name="claim_type" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="date_received" readonly="True"/>
+            </xpath>
+        </field>
     </record>
 
     <record model="ir.ui.view" id="inherit_crm_case_claims_tree_view">
@@ -194,9 +196,13 @@
                 <field name="name"/>
             </xpath>
             <xpath expr="//field[@name='delivery_address_id']" position="attributes">
-                <attribute name="domain">[('id', 'child_of', [partner_id]),'|',('is_company', '=', True),('type', '=', 'delivery')]</attribute>
-                <attribute name="context">{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree', 'default_type':'delivery', 'default_dropship': True,
-                                           'default_not_print_picking': True, 'default_parent_id': partner_id, 'show_address':1}</attribute>
+                <attribute name="domain">[('id', 'child_of', [partner_id]),'|',('is_company', '=', True),('type', '=',
+                    'delivery')]
+                </attribute>
+                <attribute name="context">{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree',
+                    'default_type':'delivery', 'default_dropship': True,
+                    'default_not_print_picking': True, 'default_parent_id': partner_id, 'show_address':1}
+                </attribute>
                 <attribute name="options">{"always_reload": True}</attribute>
             </xpath>
         </field>
@@ -216,10 +222,13 @@
         <field name="model">crm.claim</field>
         <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
         <field name="arch" type="xml">
-
+            <field name="date" position="before">
+                <field name="partner_id"/>
+                <field name="category_id"/>
+            </field>
             <field name="user_id" position="replace"/>
             <field name="priority" position="replace">
-              <field name="priority"/>
+                <field name="priority"/>
             </field>
             <field name="date_deadline" position="after">
                 <field name="user_id"/>
@@ -227,12 +236,12 @@
 
             <xpath expr="/form/sheet/group/notebook/page/separator" position="replace"/>
             <field name="description" position="attributes">
-              <attribute name='invisible'>1</attribute>
+                <attribute name='invisible'>1</attribute>
             </field>
 
             <xpath expr="//sheet/group/notebook" position="after">
-              <separator colspan="4" string="Claim/Action Description" groups="base.group_user"/>
-              <field name="description" colspan="4" nolabel="1"/>
+                <separator colspan="4" string="Claim/Action Description" groups="base.group_user"/>
+                <field name="description" colspan="4" nolabel="1"/>
             </xpath>
         </field>
     </record>
@@ -246,6 +255,7 @@
                 <attribute name="default_order">claim_id asc</attribute>
             </tree>
             <field name="claim_id" position="after">
+                <field name="partner_id" />
                 <field name="claim_name" string="Claim Subject"/>
                 <field name="user_id"/>
                 <field name="comercial"/>
@@ -258,7 +268,7 @@
     <record model="ir.ui.view" id="crm_claim_add_seq_tree_view_inh_code_del">
         <field name="name">crm.claim.add.seq.tree.view.inh.code.del</field>
         <field name="model">crm.claim</field>
-        <field name="inherit_id" ref="crm_claim_code.crm_claim_add_seq_tree_view_inh" />
+        <field name="inherit_id" ref="crm_claim_code.crm_claim_add_seq_tree_view_inh"/>
         <field name="arch" type="xml">
             <field name="code" position="replace"/>
         </field>
@@ -277,7 +287,9 @@
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
-                Record and track your customers' claims. Claims may be linked to a sales order or a lot.You can send emails with attachments and keep the full history for a claim (emails sent, intervention type and so on).Claims may automatically be linked to an email address using the mail gateway module.
+                Record and track your customers' claims. Claims may be linked to a sales order or a lot.You can send
+                emails with attachments and keep the full history for a claim (emails sent, intervention type and so
+                on).Claims may automatically be linked to an email address using the mail gateway module.
             </p>
         </field>
     </record>
@@ -299,5 +311,5 @@
     </record>
 
     <menuitem name="Received Claims" id="menu_crm_case_claims"
-        parent="crm_claim.menu_aftersale" action="crm_case_categ_claim_sort" sequence="1"/>
+              parent="crm_claim.menu_aftersale" action="crm_case_categ_claim_sort" sequence="1"/>
 </odoo>


### PR DESCRIPTION
-  [IMP] crm_claim_rma: Añadido los campos "Empresa" y "etiquetas" para que aparezcan en el encabezado del RMA (RMAs recibidos). Se ha añadido también en "Líneas de cliente" una columna más que se vea la empresa.
-  [IMP] crm_claim_rma_custom: Eliminado el botón "Crear reparación" en "Líneas de clientes"
-  [FIX] block_invoices: Corregido el nombre de la función  "onchange_block_magrep" por "onchange_block_magreb"