### PR TITLE
Arreglo envío email albarán

### DIFF
--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -87,16 +87,22 @@ class StockPicking(models.Model):
 
     @api.multi
     def write(self, vals):
+        pickings_to_send = []
         for picking in self:
-            if vals.get('carrier_tracking_ref', False) and \
-                    picking.picking_type_code == 'outgoing' and \
-                    picking.sale_id\
-                    and not picking.carrier_tracking_ref:
-                picking_template = self.env. \
-                    ref('stock_custom.picking_done_template')
-                picking_template.with_context(
-                    lang=picking.partner_id.commercial_partner_id.lang).send_mail(picking.id)
-        return super().write(vals)
+            # We do this huge condition to ensure that both fields are not empty when the mail is sent
+            if ((vals.get('carrier_tracking_ref', False) and picking.carrier_name and not picking.carrier_tracking_ref) or
+                    (vals.get('carrier_name', False) and picking.carrier_tracking_ref and not picking.carrier_name) or
+                    (vals.get('carrier_name', False) and vals.get('carrier_tracking_ref', False) and not picking.carrier_name and not picking.carrier_tracking_ref)) and\
+                    picking.picking_type_code == 'outgoing' and picking.sale_id:
+                pickings_to_send.append(picking.id)
+        result = super().write(vals)
+        if pickings_to_send:
+            pickings = self.env["stock.picking"].browse(pickings_to_send)
+            for picking in pickings:
+                # We need to do this after the write, otherwise the email template won't get well some  picking values
+                picking_template = self.env.ref('stock_custom.picking_done_template')
+                picking_template.with_context(lang=picking.partner_id.commercial_partner_id.lang).send_mail(picking.id)
+        return result
 
 
 class StockMoveLine(models.Model):


### PR DESCRIPTION
 [FIX]stock_custom: arreglado comportamiento de arreglar envío de email de tracking

Hemos tenido que enviar el email después de hacer el write, ya que había casos donde, al no estar escrito el campo en el objeto todavía, la plantilla se enviaba vacía.