### PR TITLE
HOTFIX - Recuperar botón para reparar 2

### DIFF
--- a/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
+++ b/project-addons/crm_claim_rma/views/crm_claim_rma_view.xml
@@ -96,6 +96,7 @@
                 <field name="move_out_customer_state"/>
                 <field name="supplier_id"/>
                 <field name="internal_description"/>
+                <button name="%(action_claim_make_repair)d" type="action" string="Create repair" attrs="{'invisible': [('repair_id', '!=', False)]}"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
- [FIX]crm_claim_rma: recuperado botón de reparar en una vista

Se me había pasado esto, si no está el botón en la vista padre no lo va a encontrar en el código del primer hotfix.