### PR TITLE
Modificación condiciones para obtener apuntes sin conciliar del cliente

### DIFF
--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -111,6 +111,8 @@ class CreditCommunication(models.Model):
                     ('move_id.state', '!=', 'draft'),
                     ('company_id', '=', self.company_id.id),
                     ('blocked', '!=', True),
+                    '|', ('invoice_id.state', '!=', 'paid'),
+                    ('invoice_id', '=', False),
                     '|', ('date_maturity', '=', False),
                     ('date_maturity', '<=', search_date)])
         return move_lines

--- a/project-addons/account_move_line_followup/models/res_partner.py
+++ b/project-addons/account_move_line_followup/models/res_partner.py
@@ -26,7 +26,8 @@ class ResPartner(models.Model):
             search([('partner_id', '=', self.id),
                     ('account_id.internal_type', '=', 'receivable'),
                     ('full_reconcile_id', '=', False),
-                    ('move_id.state', '!=', 'draft')])
+                    ('move_id.state', '!=', 'draft'),
+                    '|', ('invoice_id.state', '!=', 'paid'), ('invoice_id', '=', False)])
         return move_lines
 
     @api.multi
@@ -53,7 +54,8 @@ class ResPartner(models.Model):
             read_group([('account_id.internal_type', '=', 'receivable'),
                         ('full_reconcile_id', '=', False),
                         ('partner_id', '!=', False),
-                        ('move_id.state', '!=', 'draft')],
+                        ('move_id.state', '!=', 'draft'),
+                        '|', ('invoice_id.state', '!=', 'paid'), ('invoice_id', '=', False)],
                        ['partner_id', 'balance'], ['partner_id'])
         valid_partner_ids = []
         for partner_data in partners_data:


### PR DESCRIPTION
[FIX] account_move_line_followup: Corrección en el cálculo de apuntes sin conciliar del cliente para que no tenga en cuenta los que están asociados a facturas con importe a 0 (se quedan pagadas pero el efecto sin conciliar)