### PR TITLE
Corrección foto deuda (facturas a 0)

### DIFF
--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -111,8 +111,7 @@ class CreditCommunication(models.Model):
                     ('move_id.state', '!=', 'draft'),
                     ('company_id', '=', self.company_id.id),
                     ('blocked', '!=', True),
-                    '|', ('invoice_id.state', '!=', 'paid'),
-                    ('invoice_id', '=', False),
+                    '|', ('debit', '>', 0), ('credit', '>', 0),
                     '|', ('date_maturity', '=', False),
                     ('date_maturity', '<=', search_date)])
         return move_lines

--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -107,7 +107,7 @@ class CreditCommunication(models.Model):
         move_lines = move_line_obj.\
             search([('partner_id', '=', self.partner_id.id),
                     ('account_id.internal_type', '=', 'receivable'),
-                    ('full_reconcile_id', '=', False),
+                    ('reconciled', '=', False),
                     ('move_id.state', '!=', 'draft'),
                     ('company_id', '=', self.company_id.id),
                     ('blocked', '!=', True),

--- a/project-addons/account_move_line_followup/models/res_partner.py
+++ b/project-addons/account_move_line_followup/models/res_partner.py
@@ -26,7 +26,8 @@ class ResPartner(models.Model):
             search([('partner_id', '=', self.id),
                     ('account_id.internal_type', '=', 'receivable'),
                     ('reconciled', '=', False),
-                    ('move_id.state', '!=', 'draft')])
+                    ('move_id.state', '!=', 'draft'),
+                    '|', ('debit', '>', 0), ('credit', '>', 0)])
         return move_lines
 
     @api.multi
@@ -53,7 +54,8 @@ class ResPartner(models.Model):
             read_group([('account_id.internal_type', '=', 'receivable'),
                         ('reconciled', '=', False),
                         ('partner_id', '!=', False),
-                        ('move_id.state', '!=', 'draft')],
+                        ('move_id.state', '!=', 'draft'),
+                        '|', ('debit', '>', 0), ('credit', '>', 0)],
                        ['partner_id', 'balance'], ['partner_id'])
         valid_partner_ids = []
         for partner_data in partners_data:


### PR DESCRIPTION
[FIX] account_move_line_followup: Corrección en el cálculo de apuntes sin conciliar del cliente para que no tenga en cuenta los que están asociados a facturas con importe a 0