### PR TITLE
Añadir equipo de ventas en context de email

### DIFF
--- a/project-addons/custom_account/models/account_payment_order.py
+++ b/project-addons/custom_account/models/account_payment_order.py
@@ -108,6 +108,7 @@ class AccountPaymentOrder(models.Model):
                     # we add the email2, means the accounting email to use it later on the template
                     'partner_email2': line.partner_id.email2,
                     'partner_name': line.partner_id.name,
+                    'partner_team': line.partner_id.team_id,
                     'obj': line
                 })
                 mail_id = template.with_context(ctx).send_mail(order.id)


### PR DESCRIPTION
[IMP] custom_account: Incluir en el context el equipo de ventas del cliente para poder utilizarlo en las plantillas de emails de Aviso de recibo y devolución