### PR TITLE
Cambios necesarios para la sincronización del nuevo flask italia

### DIFF
--- a/project-addons/custom_partner/models/partner.py
+++ b/project-addons/custom_partner/models/partner.py
@@ -449,18 +449,17 @@ class ResPartner(models.Model):
                     raise exceptions. \
                         ValidationError(_('VAT must be unique'))
 
-
-    def check_email(self,email):
+    def check_email(self, email):
         any_char="^\s\t\r\n\(\)\<\>\,\:\;\[\]Çç\%\&@á-źÁ-Ź"
         if not re.match('^(['+any_char+']+@['+any_char+'\.]+(\.['+any_char+'\.]+)+;?)+$', email) and email!="-" and email!=".":
             message = _('The e-mail format is incorrect: ')
             raise exceptions.ValidationError(message+email)
 
-    @api.constrains('email','email2','email_web')
+    @api.constrains('email', 'email2', 'email_web')
     def check_emails(self):
-        email=self.email
-        email2=self.email2
-        email_web=self.email_web
+        email = self.email
+        email2 = self.email2
+        email_web = self.email_web
         if email:
             self.check_email(email)
         if email2:
@@ -680,6 +679,13 @@ class ResPartner(models.Model):
             }}
             if res:
                 return res
+
+    @api.multi
+    @api.onchange('vat')
+    def onchange_vat_country_completion(self):
+        country_code = self.commercial_partner_id.country_id.code
+        if self.vat[:len(country_code)] != country_code:
+            self.vat = country_code + self.vat
 
     @api.multi
     def open_partner(self):

--- a/project-addons/vt_flask_middleware/config.py
+++ b/project-addons/vt_flask_middleware/config.py
@@ -16,7 +16,8 @@ class Config(object):
                 'autorollback': True,
                 'stale_timeout': 600}
 
-    NOTIFY_URL = "https://d2aszo0r8k.execute-api.eu-west-1.amazonaws.com/Prod/web/syncdata"
+    NOTIFY_URL = "https://d2aszo0r8k.execute-api.eu-west-1.amazonaws.com/prod/web/syncdata"
     NOTIFY_USER = os.environ.get('NOTIFY_USER')
     NOTIFY_PASSWORD = os.environ.get('NOTIFY_PASSWORD')
     NOTIFY_HEADER = ""
+    NOTIFY_COUNTRY = ""  # ES, IT, ... depending on the odoo instance

--- a/project-addons/vt_flask_middleware/sync_log.py
+++ b/project-addons/vt_flask_middleware/sync_log.py
@@ -30,9 +30,11 @@ class SyncLog(BaseModel):
         url = app.config['NOTIFY_URL']
         header = app.config['NOTIFY_HEADER']
         headers = {'x-api-key': header}
+        country_code = app.config['NOTIFY_COUNTRY']
 
         signature = _get_signature()
         data = {'signature': signature,
+                'country_code': country_code,
                 'data': [{'model': self.model,
                           'operation': self.operation,
                           'odoo_id': self.odoo_id}]}
@@ -61,11 +63,14 @@ class SyncLog(BaseModel):
         url = app.config['NOTIFY_URL']
         header = app.config['NOTIFY_HEADER']
         headers = {'x-api-key': header}
+        country_code = app.config['NOTIFY_COUNTRY']
+
         signature = _get_signature()
         to_sync = True
         sync = False
         res = False
         data = {'signature': signature,
+                'country_code': country_code,
                 'data': []}
         for record in objs:
             data['data'].append({'model': record.model,


### PR DESCRIPTION
- [IMP]vt_flask_middleware: añadido parámetro para identificar la instancia de odoo que envía la notificación
- [IMP]custom_partner: forzar el código del país en el vat para mejorar la búsqueda en web

Aquí he cambiado la url del endpoint de producción que es la que habría que dejar para flask normal. Ahora te paso por email el endpoint de test que habría que poner en el flask de italia.
Junto con el nuevo endpoint hay que cambiar el api-key que va en el header de la notificación, te la pasaré como la otra vez.
El nuevo parámetro que pasamos sería "ES" o "IT" segun el flask que sea, no se si esto se podría poner en alguna variable de entorno o algo así. De momento he dejado la variable vacía para poner en cada caso el que toque.



