### PR TITLE
Stock disponible sin playa, contenedor  en fechas de llegada y fecha de contenedores corregidas

### DIFF
--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -51,7 +51,7 @@ class StockContainer(models.Model):
         return True
 
     @api.multi
-    @api.depends('move_ids')
+    @api.depends('move_ids.picking_id.scheduled_date')
     def _get_date_expected(self):
         for container in self:
             min_date = False
@@ -86,7 +86,7 @@ class StockContainer(models.Model):
             container.user_id = responsible
 
     name = fields.Char("Container Ref.", required=True)
-    date_expected = fields.Date("Date expected", compute='_get_date_expected', inverse='_set_date_expected', readonly=False, required=False)
+    date_expected = fields.Date("Date expected", compute='_get_date_expected', inverse='_set_date_expected', store=True,readonly=False, required=False)
     move_ids = fields.One2many("stock.move", "container_id", "Moves",
                                readonly=True, copy=False)
     picking_ids = fields.One2many('stock.picking', compute='_get_picking_ids', string='Pickings', readonly=True)

--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -26,6 +26,15 @@ class StockContainer(models.Model):
     _name = 'stock.container'
 
     @api.multi
+    def write(self,vals):
+        res=super(StockContainer,self).write(vals)
+        if vals.get('date_expected'):
+            for container in self:
+                for move in container.move_ids:
+                    move.write({'date_expected': container.date_expected})
+        return res
+
+    @api.multi
     def _set_date_expected(self):
         picking_ids = []
         for container in self:

--- a/project-addons/sale_display_stock/models/sale.py
+++ b/project-addons/sale_display_stock/models/sale.py
@@ -26,7 +26,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     qty_available = fields.\
-        Float('Qty available', readonly=True,compute="_compute_qty_available",
+        Float('Qty available', readonly=True, compute="_compute_qty_available",
               digits=dp.get_precision('Product Unit of Measure'))
     qty_available_wo_wh = fields.\
         Float('Qty. on kitchen', readonly=True,
@@ -37,9 +37,10 @@ class SaleOrderLine(models.Model):
               digits=dp.get_precision('Product Unit of Measure'))
 
     @api.multi
+    @api.depends('product_id')
     def _compute_qty_available(self):
         for line in self:
-            line.qty_available=line.product_id.virtual_stock_conservative-line.product_id.qty_available_wo_wh
+            line.qty_available = line.product_id.virtual_stock_conservative - line.product_id.qty_available_input_loc
 
     @api.multi
     def _get_incoming_qty(self):

--- a/project-addons/sale_display_stock/models/sale.py
+++ b/project-addons/sale_display_stock/models/sale.py
@@ -26,8 +26,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     qty_available = fields.\
-        Float('Qty available', readonly=True,
-              related='product_id.virtual_stock_conservative',
+        Float('Qty available', readonly=True,compute="_compute_qty_available",
               digits=dp.get_precision('Product Unit of Measure'))
     qty_available_wo_wh = fields.\
         Float('Qty. on kitchen', readonly=True,
@@ -36,6 +35,11 @@ class SaleOrderLine(models.Model):
     incoming_qty = fields.\
         Float('Incoming qty.', readonly=True, compute='_get_incoming_qty',
               digits=dp.get_precision('Product Unit of Measure'))
+
+    @api.multi
+    def _compute_qty_available(self):
+        for line in self:
+            line.qty_available=line.product_id.virtual_stock_conservative-line.product_id.qty_available_wo_wh
 
     @api.multi
     def _get_incoming_qty(self):

--- a/project-addons/stock_custom/views/stock_view.xml
+++ b/project-addons/stock_custom/views/stock_view.xml
@@ -179,10 +179,9 @@
                 <field name="date"/>
                 <field name="reference"/>
                 <field name="product_id"/>
-                <field name="location_id"/>
-                <field name="location_dest_id"/>
                 <field name="picking_id"/>
                 <field name="picking_type_id"/>
+                <field name="container_id" groups="purchase.group_purchase_manager"/>
                 <field name="date_expected"/>
                 <field name="date_reliability"/>
                 <field name="state"/>


### PR DESCRIPTION
- [FIX] sale_display_stock: Ahora en las líneas de un pedido de venta, se muestra el stock disponible sin el stock que hay en cocina
- [IMP] stock_custom: Añadido campo del contenedor en la vista de Fechas de Llegada y eliminadas las ubicaciones.
-  [FIX] purchase_picking: Añadido que se arrastre la fecha del contenedor bien a los movimientos asociados.
- [FIX] purchase_picking: Corregido error fecha de contenedores
- [FIX] sale_display_stock:Arreglado error en el stock disponible





