### PR TITLE
Guardar pedido y comercial en reservas y check de no rappel

### DIFF
--- a/project-addons/rappel_custom/models/__init__.py
+++ b/project-addons/rappel_custom/models/__init__.py
@@ -4,3 +4,4 @@ from . import rappel
 from . import rappel_calculated
 from . import rappel_current_info
 from . import res_partner_rappel_rel
+from . import sale

--- a/project-addons/rappel_custom/models/sale.py
+++ b/project-addons/rappel_custom/models/sale.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = 'sale.order.line'
+
+    no_rappel = fields.Boolean(states={'draft': [('readonly', False)], 'reserve': [('readonly', False)]})

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -176,6 +176,13 @@ class SaleOrderLine(models.Model):
                 reserve.unlink()
         return super().unlink()
 
+    @api.multi
+    def _prepare_stock_reservation(self, date_validity=False, note=False):
+        res = super()._prepare_stock_reservation(date_validity=date_validity, note=note)
+        res['sale_id'] = self.order_id.id
+        res['user_id'] = self.order_id.user_id.id
+        return res
+
     def stock_reserve(self):
         if self.env.context.get('later', False):
             return True
@@ -193,4 +200,6 @@ class SaleOrderLine(models.Model):
                 vals = line._prepare_stock_reservation()
                 reservation = self.env['stock.reservation'].create(vals)
                 reservation.reserve()
+                reservation.write({'sale_line_id': line.id})
+                reservation.move_id.write({'origin': line.order_id.name})
         return True


### PR DESCRIPTION
- [FIX]reserve_without_save_sale: recogido pedido y comercial en los movimientos de reservas
- [FIX]rappel_custom: poder editar el check de no rappel en pedido

