### PR TITLE
Finalización de pedidos con solo servicios cuando se crea una factura

### DIFF
--- a/project-addons/custom_partner/models/sale.py
+++ b/project-addons/custom_partner/models/sale.py
@@ -102,11 +102,10 @@ class SaleOrder(models.Model):
     @api.multi
     def action_invoice_create(self):
         res = super(SaleOrder, self).action_invoice_create()
-        services_products = self.env['product.product'].search([('product_tmpl_id.type', '=', 'service')])
         orders_to_done = self.env['sale.order']
         for order in self:
-            if all(line.product_id.id in services_products.mapped('id') for line in order.order_line):
+            if not order.order_line.mapped('product_id').filtered(lambda x: x.type != 'service'):
                 orders_to_done += order
-            orders_to_done.write({'state': 'done'})
+        orders_to_done.write({'state': 'done'})
         return res
 

--- a/project-addons/custom_partner/models/sale.py
+++ b/project-addons/custom_partner/models/sale.py
@@ -99,3 +99,14 @@ class SaleOrder(models.Model):
 
         return True
 
+    @api.multi
+    def action_invoice_create(self):
+        res = super(SaleOrder, self).action_invoice_create()
+        services_products = self.env['product.product'].search([('product_tmpl_id.type', '=', 'service')])
+        orders_to_done = self.env['sale.order']
+        for order in self:
+            if all(line.product_id.id in services_products.mapped('id') for line in order.order_line):
+                orders_to_done += order
+            orders_to_done.write({'state': 'done'})
+        return res
+

--- a/project-addons/test_management/wizard/sale_make_invoice_advance.py
+++ b/project-addons/test_management/wizard/sale_make_invoice_advance.py
@@ -69,4 +69,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
                 invoice._onchange_invoice_line_ids()
             orders.write({'force_invoiced':  True})
+        services_products = self.env['product.product'].search([('product_tmpl_id.type', '=', 'service')])
+        orders_to_done = self.env['sale.order']
+        for order in sale_orders:
+            if all(line.product_id.id in services_products.mapped('id') for line in order.order_line):
+                orders_to_done += order
+        orders_to_done.write({'state': 'done'})
         return res

--- a/project-addons/test_management/wizard/sale_make_invoice_advance.py
+++ b/project-addons/test_management/wizard/sale_make_invoice_advance.py
@@ -69,10 +69,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
                 invoice._onchange_invoice_line_ids()
             orders.write({'force_invoiced':  True})
-        services_products = self.env['product.product'].search([('product_tmpl_id.type', '=', 'service')])
         orders_to_done = self.env['sale.order']
         for order in sale_orders:
-            if all(line.product_id.id in services_products.mapped('id') for line in order.order_line):
+            if not order.order_line.mapped('product_id').filtered(lambda x: x.type != 'service'):
                 orders_to_done += order
         orders_to_done.write({'state': 'done'})
         return res


### PR DESCRIPTION
- [IMP] custom_partner: ahora se finalizan los pedidos que solo tienen servicios cuando se ejecuta el cron.
- [IMP] test_management: Ahora se finalizan los pedidos al crear una factura cuando todos sus productos son servicios



