### PR TITLE
Visibilidad botón reservas en líneas de pedido

### DIFF
--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -71,8 +71,9 @@ class SaleOrderLine(models.Model):
                                 related='product_id.reservation_count',
                                 digits=dp.get_precision('Product Unit \
                                                   of Measure'))
-    hide_reserve_buttons = fields.Boolean("Hide reserve buttons", compute='_compute_hide_reserve_buttons',
-                                          readonly=True, default=True)
+    hide_reserve_buttons = fields.Boolean("Hide reserve buttons",
+                                          compute='_compute_hide_reserve_buttons',
+                                          readonly=True)
 
     @api.multi
     @api.depends('state', 'product_id', 'reservation_ids')
@@ -204,9 +205,14 @@ class SaleOrderLine(models.Model):
         return True
 
     @api.multi
+    @api.depends('order_id.partner_id')
     def _compute_hide_reserve_buttons(self):
+        import ipdb
+        ipdb.set_trace()
         for line in self:
             if line.order_id.partner_id.user_id.id == line.env.user.id \
                     or line.env.user.has_group('base.group_system'):
                 line.hide_reserve_buttons = False
+            else:
+                line.hide_reserve_buttons = True
 

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -71,7 +71,8 @@ class SaleOrderLine(models.Model):
                                 related='product_id.reservation_count',
                                 digits=dp.get_precision('Product Unit \
                                                   of Measure'))
-
+    hide_reserve_buttons = fields.Boolean("Hide reserve buttons", compute='_compute_hide_reserve_buttons',
+                                          readonly=True, default=True)
 
     @api.multi
     @api.depends('state', 'product_id', 'reservation_ids')
@@ -201,3 +202,11 @@ class SaleOrderLine(models.Model):
                     reservation.write({'sale_line_id': line.id})
                     reservation.write({'origin': line.order_id.name})
         return True
+
+    @api.multi
+    def _compute_hide_reserve_buttons(self):
+        for line in self:
+            if line.order_id.partner_id.user_id.id == line.env.user.id \
+                    or line.env.user.has_group('base.group_system'):
+                line.hide_reserve_buttons = False
+

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -207,8 +207,6 @@ class SaleOrderLine(models.Model):
     @api.multi
     @api.depends('order_id.partner_id')
     def _compute_hide_reserve_buttons(self):
-        import ipdb
-        ipdb.set_trace()
         for line in self:
             if line.order_id.partner_id.user_id.id == line.env.user.id \
                     or line.env.user.has_group('base.group_system'):

--- a/project-addons/reserve_without_save_sale/views/sale.xml
+++ b/project-addons/reserve_without_save_sale/views/sale.xml
@@ -88,11 +88,14 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="stock_reserve_sale.view_order_form_reserve"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree/field[@name='price_subtotal']" position="after">
+                    <field name="hide_reserve_buttons" invisible="1"/>
+            </xpath>
             <xpath expr="//field[@name='order_line']/tree//button[@name='%(stock_reserve_sale.action_sale_stock_reserve)d']" position="attributes">
-                <attribute name="groups">base.group_system</attribute>
+                <attribute name="attrs">{'invisible': ['|', ('reservation_ids', '!=', []),  ('hide_reserve_buttons', '=', True)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//button[@name='release_stock_reservation']" position="attributes">
-                <attribute name="groups">base.group_system</attribute>
+                <attribute name="attrs">{'invisible': ['|', ('reservation_ids', '=', []), ('hide_reserve_buttons', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>

--- a/project-addons/reserve_without_save_sale/views/sale.xml
+++ b/project-addons/reserve_without_save_sale/views/sale.xml
@@ -92,7 +92,7 @@
                     <field name="hide_reserve_buttons" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//button[@name='%(stock_reserve_sale.action_sale_stock_reserve)d']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('reservation_ids', '!=', []),  ('hide_reserve_buttons', '=', True)]}</attribute>
+                <attribute name="attrs">{'invisible': ['|', '|', ('reservation_ids', '!=', []), ('is_stock_reservable', '=', False), ('hide_reserve_buttons', '=', True)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//button[@name='release_stock_reservation']" position="attributes">
                 <attribute name="attrs">{'invisible': ['|', ('reservation_ids', '=', []), ('hide_reserve_buttons', '=', True)]}</attribute>


### PR DESCRIPTION
- [IMP] reserve_without_save_sale: Permitir reservar o deshacer reservas en líneas de pedido si se trata de un cliente del usuario logueado o si éste pertenece a group_system
- [FIX] reserve_without_save_sale: Correción visibilidad botones reserva (gastos de envío y default del campo para ocultarlos)