### PR TITLE
Restricción de la visibilidad de las reglas comerciales

### DIFF
--- a/project-addons/custom_partner/__manifest__.py
+++ b/project-addons/custom_partner/__manifest__.py
@@ -29,7 +29,7 @@
                 'base_partner_sequence', 'stock', 'account_credit_control',
                 'purchase', 'prospective_customer', 'account_due_list',
                 'customer_lost', 'sale_margin_percentage', 'contacts',
-                'mail_tracking', 'crm_phone_validation'],
+                'mail_tracking', 'crm_phone_validation', 'commercial_rules'],
     "data": ["views/partner_view.xml",
              "views/sale_view.xml",
              "security/ir.model.access.csv",

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -578,4 +578,15 @@
             parent="crm.crm_menu_config"
             sequence="6"/>
 
+        <record id="button_view_promotions_add_groups_view" model="ir.ui.view">
+            <field name="name">res.partner.form.commercial.rules.group</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="commercial_rules.view_partner_form_commercial_rules" />
+            <field name="arch" type="xml">
+                <button name="buttom_view_promotions" position="attributes">
+                    <attribute name="groups">base.group_system</attribute>
+                </button>
+            </field>
+        </record>
+
 </odoo>

--- a/project-addons/sale_promotions_extend/views/rule.xml
+++ b/project-addons/sale_promotions_extend/views/rule.xml
@@ -15,5 +15,5 @@
     </record>
 
     <menuitem id="commercial_rules.promos" action="commercial_rules.act_commercial_rules"
-        parent="sale.menu_sale_config" sequence="4"/>
+        parent="sale.menu_sale_config" groups="base.group_system" sequence="4"/>
 </odoo>


### PR DESCRIPTION
- [FIX] sale_promotions_extend: restringida la visibilidad del menu reglas comerciales
- [FIX] custom_partner: restringida la visibilidad el botón reglas comerciales en la ficha de cliente



