### PR TITLE
Arreglos en el seguimiento de la deuda y bloqueo de ventas

### DIFF
--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -212,7 +212,7 @@ class CreditCommunication(models.Model):
     @api.multi
     def get_followup_table_html_not_due(self):
         today = fields.Date.from_string(fields.Date.today()).strftime("%Y-%m-%d")
-        aml_ids = self.move_line_ids
+        aml_ids = self.move_line_ids.filtered(lambda l: l.invoice_id.state != 'paid')
         aml_not_due = aml_ids.filtered(lambda l: today < l.date_maturity)
         followup_table, total = self.get_followup_table_html_base(aml_not_due)
         if followup_table:
@@ -225,7 +225,7 @@ class CreditCommunication(models.Model):
     @api.multi
     def get_followup_table_html_due(self):
         today = fields.Date.from_string(fields.Date.today()).strftime("%Y-%m-%d")
-        aml_ids = self.move_line_ids
+        aml_ids = self.move_line_ids.filtered(lambda l: l.invoice_id.state != 'paid')
         aml_due = aml_ids.filtered(lambda l: today >= l.date_maturity)
         followup_table, total = self.get_followup_table_html_base(aml_due)
         if followup_table:

--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -197,14 +197,15 @@ class CreditCommunication(models.Model):
                   </tr>
                   '''
             for aml in moves:
-                total += aml['balance']
+                # total += aml['balance']
+                total += aml['amount_residual']
                 strbegin = "<TD>"
                 strend = "</TD>"
                 date = aml['date_maturity'] or aml['date']
                 followup_table += "<TR>" + strbegin + datetime.datetime.strptime(aml['date'], '%Y-%m-%d').strftime('%d/%m/%Y') + strend + \
                                   strbegin + (aml['ref'] or '') + strend + \
                                   strbegin + str(datetime.datetime.strptime(date, '%Y-%m-%d').strftime('%d/%m/%Y')) + strend + strbegin + \
-                                  str(aml['balance']) + strend + "</TR>"
+                                  str(aml['amount_residual']) + strend + "</TR>"
 
         return followup_table, total
 

--- a/project-addons/block_invoices/i18n/es.po
+++ b/project-addons/block_invoices/i18n/es.po
@@ -38,10 +38,11 @@ msgid "Customer %s blocked by lack of payment. Check the maturity dates of their
 msgstr "Cliente %s bloqueado por impagos. Compruebe la fecha de vencimiento de sus efectos contables."
 
 #. module: block_invoices
-#: code:addons/block_invoices/account_invoice.py:48
-#: code:addons/block_invoices/account_invoice.py:73
+#: code:addons/block_invoices/account_invoice.py:27
+#: code:addons/block_invoices/account_invoice.py:40
 #: code:addons/block_invoices/sale_make_invoice.py:49
-#: code:addons/block_invoices/sale_order.py:50
+#: code:addons/block_invoices/sale_order.py:39
+#: code:addons/block_invoices/sale_order.py:52
 #: code:addons/block_invoices/stock_invoice_onshipping.py:47
 #, python-format
 msgid "Customer blocked by lack of payment. Check the maturity dates of their account move lines."

--- a/project-addons/block_invoices/models/res_partner.py
+++ b/project-addons/block_invoices/models/res_partner.py
@@ -40,7 +40,8 @@ class ResPartner(models.Model):
         move_lines = self.env['account.move.line'].search(
             [('account_id', 'in', cust_account._ids),
              ('date_maturity', '<', limit_customer_date),
-             ('full_reconcile_id', '=', False)])
+             ('full_reconcile_id', '=', False),
+             ('invoice_id.state', '!=', 'paid')])  # <- to avoid partial reconciles
         if len(move_lines) > 0:
             for move_line in move_lines:
                 if move_line.partner_id.id not in visited_partner_ids:
@@ -70,7 +71,8 @@ class ResPartner(models.Model):
                  '|', ('date_maturity', '<', limit_customer_date),
                  ('date_maturity', '=', False),
                  ('full_reconcile_id', '=', False),
-                 ('partner_id', '=', partner.id)])
+                 ('partner_id', '=', partner.id),
+                 ('invoice_id.state', '!=', 'paid')])  # <- to avoid partial reconciles
             balance = 0
             for line in move_lines:
                 balance += line.credit


### PR DESCRIPTION

- [FIX]account_move_line_followup: cambiado balance por amount_residual para que se muestren bien los pagos parciales
- [FIX]flask_middleware_connector: exportar todos los datos del cliente en el wizard
- [FIX]block_invoices: no tener en cuenta las líneas correspondientes a facturas ya pagadas, normalmente con conciliación parcial
- [FIX]block_invoices: arregladas traducciones
- [FIX]account_move_line: se ha tenido en cuenta las pagadas tambien a la hora de generar la tabla





