### PR TITLE
Desabilitar botones de acción y corregido error en rappels

### DIFF
--- a/project-addons/disable_action_buttons/__manifest__.py
+++ b/project-addons/disable_action_buttons/__manifest__.py
@@ -11,7 +11,8 @@
     ],
     "depends": [
         "web",
-        "stock_custom"
+        "stock_custom",
+        "web_export_view"
     ],
     "auto_install": False,
     "installable": True,

--- a/project-addons/disable_action_buttons/static/src/js/sidebar.js
+++ b/project-addons/disable_action_buttons/static/src/js/sidebar.js
@@ -10,7 +10,7 @@ Sidebar.include({
 
     _redraw: function () {
         var self=this;
-        this.$el.html(QWeb.render('Sidebar', {widget: this}));
+        this._super.apply(this, arguments);
         self.getSession().user_has_group('stock_custom.group_comercial_ext').then(function(has_group) {
             var cont=0;
             self.$('.o_dropdown').each(function () {
@@ -19,9 +19,17 @@ Sidebar.include({
                 }
                 cont++;
             });
-            self.$("[title]").tooltip({
-                delay: { show: 500, hide: 0}
-            });
+            if (has_group && self.getParent().renderer.viewType === 'list'){
+                self.getSession().user_has_group('web_export_view.group_disallow_export_view_data_excel').then(function(has_group_xml){
+                    if (!has_group_xml){
+                        self.$el.find('.o_dropdown')
+                                .first().append(QWeb.render(
+                                    'WebExportTreeViewXls', {widget: self}));
+                            self.$el.find('.export_treeview_xls').on('click',
+                                self.on_sidebar_export_treeview_xls);
+                    }
+                });
+            }
         });
     },
 

--- a/project-addons/rappel_custom/models/rappel_current_info.py
+++ b/project-addons/rappel_custom/models/rappel_current_info.py
@@ -38,8 +38,8 @@ class RappelCurrentInfo(models.Model):
 
                         if rappel_timing.advice_timing == 'variable':
 
-                            timing = (date_end - date_start).days * \
-                                rappel_timing.timing / 100
+                            timing = round((date_end - date_start).days * \
+                                rappel_timing.timing / 100)
                             timing2 = (today - date_start).days
 
                             if timing == timing2:


### PR DESCRIPTION
- [FIX] disable_action_buttons: Ahora aparece el botón de exportar a Excel 
- [FIX] rappel_custom: Arreglado error que hacía que no se enviaran los e-mails de los rappels correctamente.

