### PR TITLE
Pequeño arreglo de categorias de producto en flask

### DIFF
--- a/project-addons/flask_middleware_connector/models/product/exporter.py
+++ b/project-addons/flask_middleware_connector/models/product/exporter.py
@@ -90,7 +90,7 @@ class ProductCategoryExporter(Component):
     _usage = 'record.exporter'
 
     def update(self, binding, mode):
-        vals = {"name": binding.name,
+        vals = {"name": binding.with_context({'lang': 'es_ES'}).name,
                 "parent_id": binding.parent_id.id,
                 "odoo_id": binding.id}
         if mode == "insert":


### PR DESCRIPTION
- [IMP]flask_middleware_connector: añadido context para pasar siempre el valor en español de la categoría de producto

