### PR TITLE
Notificar por email reservas liberadas

### DIFF
--- a/project-addons/reserve_without_save_sale/__manifest__.py
+++ b/project-addons/reserve_without_save_sale/__manifest__.py
@@ -12,6 +12,6 @@
                 'stock_reserve', 'stock_reserve_sale',
                 ], # TODO: sale_display_stock y sale_product_customize
     'data': ['views/sale.xml', 'views/stock_reserve.xml',
-             'data/cron.xml', 'data/parameters.xml'],
+             'data/cron.xml', 'data/parameters.xml', 'data/mail_template.xml'],
     'installable': True,
 }

--- a/project-addons/reserve_without_save_sale/data/mail_template.xml
+++ b/project-addons/reserve_without_save_sale/data/mail_template.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+        <record id="mail_template_release_reservations_user" model="mail.template">
+            <field name="name">Release Reservation - Send by Email</field>
+            <field name="email_from">${'odoo_team@visiotechsecurity.com'}</field>
+            <field name="email_to">${(object.email or '')|safe}</field>
+            <field name="subject">Orders with released reservation</field>
+            <field name="model_id" ref="base.model_res_users"/>
+            <field name="lang">${object.lang}</field>
+            <field name="auto_delete" eval="False"/>
+            <field name="body_html"><![CDATA[
+
+                    <p> The reservations of the following orders have been released:</p>
+                    <div style="margin: 20px;">
+                    % for line in ctx['values']:
+                        ${line} <br/>
+                    % endfor
+                    </div>
+
+                    ]]>
+            </field>
+        </record>
+</odoo>

--- a/project-addons/reserve_without_save_sale/i18n/es.po
+++ b/project-addons/reserve_without_save_sale/i18n/es.po
@@ -37,3 +37,33 @@ msgstr "Tramitado"
 #: model:ir.ui.view,arch_db:reserve_without_save_sale.view_stock_reservation_search_add_waiting
 msgid "Partially available"
 msgstr "Parcialmente disponible"
+
+#. module: reserve_without_save_sale
+#: model:mail.template,subject:reserve_without_save_sale.mail_template_release_reservations_user
+msgid "Orders with released reservation"
+msgstr "Pedidos con reservas liberadas"
+
+#. module: reserve_without_save_sale
+#: model:mail.template,body_html:reserve_without_save_sale.mail_template_release_reservations_user
+msgid "\n"
+"\n"
+"                    <p> The reservations of the following orders have been released:</p>\n"
+"                    <div style=\"margin: 20px;\">\n"
+"                    % for line in ctx['values']:\n"
+"                        ${line} <br/>\n"
+"                    % endfor\n"
+"                    </div>\n"
+"\n"
+"                    \n"
+"            "
+msgstr "\n"
+"\n"
+"                    <p> Se han liberado las reservas de los siguientes pedidos:</p>\n"
+"                    <div style=\"margin: 20px;\">\n"
+"                    % for line in ctx['values']:\n"
+"                        ${line} <br/>\n"
+"                    % endfor\n"
+"                    </div>\n"
+"\n"
+"                    \n"
+"            "

--- a/project-addons/reserve_without_save_sale/i18n/it.po
+++ b/project-addons/reserve_without_save_sale/i18n/it.po
@@ -37,3 +37,33 @@ msgstr "Processato"
 #: model:ir.ui.view,arch_db:reserve_without_save_sale.view_stock_reservation_search_add_waiting
 msgid "Partially available"
 msgstr "Parzialmente disponibile"
+
+#. module: reserve_without_save_sale
+#: model:mail.template,subject:reserve_without_save_sale.mail_template_release_reservations_user
+msgid "Orders with released reservation"
+msgstr "Ordini con prenotazioni rilasciate"
+
+#. module: reserve_without_save_sale
+#: model:mail.template,body_html:reserve_without_save_sale.mail_template_release_reservations_user
+msgid "\n"
+"\n"
+"                    <p> The reservations of the following orders have been released:</p>\n"
+"                    <div style=\"margin: 20px;\">\n"
+"                    % for line in ctx['values']:\n"
+"                        ${line} <br/>\n"
+"                    % endfor\n"
+"                    </div>\n"
+"\n"
+"                    \n"
+"            "
+msgstr "\n"
+"\n"
+"                    <p> Le prenotazioni dei seguenti ordini sono state rilasciate:</p>\n"
+"                    <div style=\"margin: 20px;\">\n"
+"                    % for line in ctx['values']:\n"
+"                        ${line} <br/>\n"
+"                    % endfor\n"
+"                    </div>\n"
+"\n"
+"                    \n"
+"            "


### PR DESCRIPTION
[IMP] reserve_without_save_sale: Incluir todos los estados en la liberación de reservas, incluso si el material no estaba disponible. Notificar por correo a los comerciales los pedidos cuyas reservas se han liberado.