### PR TITLE
Aviso reservas pdf pedidos (fr)

### DIFF
--- a/project-addons/custom_report_link/i18n/fr.po
+++ b/project-addons/custom_report_link/i18n/fr.po
@@ -1083,3 +1083,7 @@ msgstr "report.custom_report_link.report_overcustom"
 #: model:ir.model,name:custom_report_link.model_report_custom_report_link_report_overduecustom
 msgid "report.custom_report_link.report_overduecustom"
 msgstr "report.custom_report_link.report_overduecustom"
+
+#: model:ir.ui.view,arch_db:custom_report_link.external_layout_custom_saleorder
+msgid "The products reservation is not guaranteed after 7 days from the date of this document."
+msgstr "Au-delà de 7 jours à compter de la date du présent document, la réservation des produits disponibles n´est plus garantie."

--- a/project-addons/custom_report_link/views/custom_layout.xml
+++ b/project-addons/custom_report_link/views/custom_layout.xml
@@ -177,6 +177,11 @@
                 </t>
             </t>
             <div class="row">
+                <span t-if="lang == 'fr_FR' and o.state == 'reserve'">
+                     <p class="text-center" style="font-size:12px; color:#6D6E70;">
+The products reservation is not guaranteed after 7 days from the date of this document.
+                     </p><br/>
+                </span>
                 <table class="table table-condensed">
                     <thead>
                         <tr style="font-size:12px; color:#da1f2e">


### PR DESCRIPTION
[IMP] custom_report_link: Añadir aviso en informe pedidos para comunicar a los clientes franceses que las reservas duran 7 días