### PR TITLE
Pequeños ajustes y arreglos

### DIFF
--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -589,16 +589,4 @@
             </field>
         </record>
 
-        <record id="form_view_readonly_group" model="ir.ui.view">
-            <field name="name">form.view.readonly.group</field>
-            <field name="model">res.partner</field>
-            <field name="groups_id" eval="[(6,0,[ref('stock_custom.group_comercial_ext')])]"/>
-            <field name="inherit_id" ref="product.view_partner_property_form"/>
-            <field name="arch" type="xml">
-                <field name="property_product_pricelist" position="attributes">
-                    <attribute name="readonly">True</attribute>
-                </field>
-            </field>
-        </record>
-
 </odoo>

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -401,7 +401,7 @@
                     <button class="oe_inline oe_stat_button" type="action" name="%(partner_graphic_sales_grouped)d"
                         string="Sales Graphic"
                         icon="fa-bar-chart"
-                        context="{'search_default_partner_id': active_id, 'group_by':'date_order'}"
+                        context="{'search_default_partner_id': active_id, 'search_default_sales_not_canceled':1, 'group_by':'date_order'}"
                         attrs="{'invisible': [('customer','=', False)]}"/>
                 </xpath>
             </field>
@@ -586,6 +586,18 @@
                 <button name="buttom_view_promotions" position="attributes">
                     <attribute name="groups">base.group_system</attribute>
                 </button>
+            </field>
+        </record>
+
+        <record id="form_view_readonly_group" model="ir.ui.view">
+            <field name="name">form.view.readonly.group</field>
+            <field name="model">res.partner</field>
+            <field name="groups_id" eval="[(6,0,[ref('stock_custom.group_comercial_ext')])]"/>
+            <field name="inherit_id" ref="product.view_partner_property_form"/>
+            <field name="arch" type="xml">
+                <field name="property_product_pricelist" position="attributes">
+                    <attribute name="readonly">True</attribute>
+                </field>
             </field>
         </record>
 

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -589,4 +589,16 @@
             </field>
         </record>
 
+        <record id="form_view_readonly_group" model="ir.ui.view">
+            <field name="name">form.view.readonly.group</field>
+            <field name="model">res.partner</field>
+            <field name="groups_id" eval="[(6,0,[ref('stock_custom.group_comercial_ext')])]"/>
+            <field name="inherit_id" ref="product.view_partner_property_form"/>
+            <field name="arch" type="xml">
+                <field name="property_product_pricelist" position="attributes">
+                    <attribute name="readonly">True</attribute>
+                </field>
+            </field>
+        </record>
+
 </odoo>

--- a/project-addons/custom_partner/views/sale_view.xml
+++ b/project-addons/custom_partner/views/sale_view.xml
@@ -43,6 +43,7 @@
                 </field>
                 <filter context="{'group_by':'date_order'}" position="after">
                     <filter string="Invoice type" domain="[]" context="{'group_by':'invoice_type_id'}"/>
+                    <filter string="Sales not canceled" name="sales_not_canceled" domain="[('state','!=','cancel')]"/>
                 </filter>
             </field>
         </record>

--- a/project-addons/customer_area/models/sale.py
+++ b/project-addons/customer_area/models/sale.py
@@ -32,4 +32,4 @@ class SaleOrder(models.Model):
     @api.multi
     def _get_area_id(self):
         for sale in self:
-            sale.area_id = self.partner_shipping_id.area_id.id or self.partner_id.area_id.id
+            sale.area_id = sale.partner_shipping_id.area_id.id or sale.partner_id.area_id.id

--- a/project-addons/customer_area/models/sale.py
+++ b/project-addons/customer_area/models/sale.py
@@ -18,12 +18,18 @@
 #
 ##############################################################################
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
-class sale_order(models.Model):
+class SaleOrder(models.Model):
 
     _inherit = 'sale.order'
 
     area_id = fields.Many2one('res.partner.area', string='Area', store=True,
-                              related='partner_id.area_id')
+                              compute='_get_area_id')
+
+    @api.depends('partner_shipping_id', 'partner_id')
+    @api.multi
+    def _get_area_id(self):
+        for sale in self:
+            sale.area_id = self.partner_shipping_id.area_id.id or self.partner_id.area_id.id

--- a/project-addons/customer_area/views/sale_view.xml
+++ b/project-addons/customer_area/views/sale_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <field name="partner_id" position="after">
-                    <field name="area_id" invisible="1"/>
+                    <field name="area_id" readonly="1"/>
                 </field>
             </field>
         </record>

--- a/project-addons/purchase_picking/models/purchase.py
+++ b/project-addons/purchase_picking/models/purchase.py
@@ -43,7 +43,8 @@ class PurchaseOrder(models.Model):
             res = []
             for line in order.order_line:
                 for move in line.move_ids:
-                    res.append(move.container_id.id)
+                    if move.state != 'cancel':
+                        res.append(move.container_id.id)
             order.container_ids = res
 
     @api.multi


### PR DESCRIPTION
- [IMP]custom_partner: añadido filtro de pedidos no cancelados al analisis de venta de cliente
- [IMP]customer_area: mostrada zona en pedido y ahora se coge primero del contacto envío
- [FIX]custom_partner: eliminado codigo de prueba 
- [IMP]custom_partner: restringido edición de externos a la tarifa
- [FIX]purchase_picking: no se tienen en cuenta movimientos cancelados
- [FIX]customer_area: cambiado self por sale 


