### PR TITLE
Corrección en la ordenación albaranes para asignar reserva

### DIFF
--- a/project-addons/custom_account/security/ir.model.access.csv
+++ b/project-addons/custom_account/security/ir.model.access.csv
@@ -5,3 +5,4 @@
 "base.access_ir_exports_line_group_system","ir_exports_line group_system","base.model_ir_exports_line","base.group_user",1,1,1,0
 "access_ir_exports_group_system_manager","ir_exports group_system","base.model_ir_exports","base.group_system",1,1,1,1
 "access_ir_exports_line_group_system_manager","ir_exports_line group_system","base.model_ir_exports_line","base.group_system",1,1,1,1
+"access_account_invoice_contact_report","account.invoice.contact.report","model_account_invoice_contact_report","base.group_user",1,1,1,0

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -191,7 +191,7 @@ class StockMove(models.Model):
                           ('product_id', '=', move.product_id.id)]
                 confirmed_ids = self.\
                     search(domain, limit=None,
-                           order="has_reservations,sequence,picking_id,id")
+                           order="has_reservations,sequence,date_expected,id")
                 if confirmed_ids:
                     confirmed_ids._action_assign()
         return res


### PR DESCRIPTION
- [FIX] custom_account: Añadida configuración de seguridad para el análisis de facturas por contacto
- [FIX] stock_custom: Cambio en el criterio de ordenación de los stock.move pendientes para asignar reservas, ya que antes se hacía a la inversa
