### PR TITLE
[HOTFIX] Corregido error que saltaba al facturar

### DIFF
--- a/project-addons/picking_invoice_pending/models/sale.py
+++ b/project-addons/picking_invoice_pending/models/sale.py
@@ -6,7 +6,7 @@ class SaleOrder(models.Model):
     def action_invoice_create(self):
         lines=self.env['sale.order.line']
         for order in self:
-            promo_lines= order.mapped('order_line').filtered(lambda x: x.original_line_id)
+            promo_lines= order.mapped('order_line').filtered(lambda x: x.original_line_id_promo)
             for line in promo_lines:
                 #For example in 4x3 promo, line.promo_qty_split is equals to 4
                 #because this field show us the minimun qty of product for which the promo is applied

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -295,7 +295,7 @@ class PromotionsRulesActions(models.Model):
             'promotion_line': True,
             'product_uom_qty': quantity,
             'product_uom': product_id.uom_id.id,
-            'original_line_id': order_line.id,
+            'original_line_id_promo': order_line.id,
             'promo_qty_split': eval(self.arguments.split(",")[0])
 
         }

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -21,7 +21,7 @@ class SaleOrderLine(models.Model):
     product_tags = fields.Char(compute="_compute_product_tags", string='Tags')
     web_discount = fields.Boolean()
     accumulated_promo = fields.Boolean(default=False)
-    original_line_id = fields.Many2one('sale.order.line', "Original line", ondelete='cascade')
+    original_line_id_promo = fields.Many2one('sale.order.line', "Original line", ondelete='cascade')
     promo_qty_split = fields.Integer(help="It is the minimum quantity of product for which this promo is applied")
 
 


### PR DESCRIPTION
-  [HOTFIX] picing_invoice_pending,sale_promotions_extend : Corregido error que hacía que no se pudieran facturar productos con productos asociados

