### PR TITLE
Cliente en pdf albaranes y reducción tiempo de carga stock catalog

### DIFF
--- a/project-addons/custom_report_link/views/custom_layout.xml
+++ b/project-addons/custom_report_link/views/custom_layout.xml
@@ -1249,14 +1249,6 @@ BIC: CAIXESBBXXX
                     <div t-field="o.partner_id"
                          t-options="{'widget': 'contact', 'fields': ['address', 'name', 'phone', 'fax', 'email']}"/>
                 </div>
-                <div class="col-xs-4"
-                     t-if="o.move_lines and o.move_lines[0].partner_id and o.move_lines[0].partner_id.id != o.partner_id.id">
-                    <span>
-                        <strong>Delivery Address:</strong>
-                    </span>
-                    <div t-field="o.move_lines[0].partner_id"
-                         t-options="{'widget': 'contact', 'fields': ['address', 'name', 'phone', 'fax', 'email'], 'no_marker': true}"/>
-                </div>
                 <div t-if="o.picking_type_id.code != 'internal' and (not o.move_lines or not o.move_lines[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
                     <span>
                         <strong>Warehouse Address:</strong>
@@ -1716,14 +1708,6 @@ SWIFT/BIC: BESCPTPL
                     </span>
                     <div t-field="o.partner_id"
                          t-field-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;, &quot;fax&quot;, &quot;email&quot;]}"/>
-                </div>
-                <div class="col-xs-4"
-                     t-if="o.move_lines and o.move_lines[0].partner_id and o.move_lines[0].partner_id.id != o.partner_id.id">
-                    <span>
-                        <strong>Delivery Address:</strong>
-                    </span>
-                    <div t-field="o.move_lines[0].partner_id"
-                         t-field-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;, &quot;fax&quot;, &quot;email&quot;], &quot;no_marker&quot;: true}"/>
                 </div>
                 <div t-if="o.picking_type_id.code != 'internal' and (not o.move_lines or not o.move_lines[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
                     <span>

--- a/project-addons/product_stock_unsafety/models/product.py
+++ b/project-addons/product_stock_unsafety/models/product.py
@@ -165,4 +165,4 @@ class ProductProduct(models.Model):
         'Next incoming date', compute='_get_next_incoming_date')
     min_suggested_qty = fields.Integer(
         'Min qty suggested', compute='_get_min_suggested_qty')
-    seller_id = fields.Many2one('res.partner', related='seller_ids.name', string='Main Supplier')
+    seller_id = fields.Many2one('res.partner', related='seller_ids.name', store=True, string='Main Supplier')

--- a/project-addons/stock_custom/views/product_view.xml
+++ b/project-addons/stock_custom/views/product_view.xml
@@ -109,7 +109,7 @@
                 <attribute name="filter_domain"></attribute>
             </field>
             <filter name="services" position="after">
-                <filter string="Main supplier not contains outlet" name="main_supplier_outlet" domain="[('seller_id','not ilike','outlet')]"/>
+                <filter string="Main supplier not contains outlet" name="main_supplier_outlet" domain="[('seller_id.name','not ilike','outlet')]"/>
                 <filter string="New Category" name="categ_new" domain="[('categ_id.name','like','NUEVOS')]"/>
                 <filter string="One month ago" name="one_month_ago" domain="[('date_first_incoming','>=',(datetime.datetime.now() - datetime.timedelta(days=31)).strftime('%Y-%m-%d'))]"/>
             </filter>


### PR DESCRIPTION
Se almacena el campo seller_id porque tarda muchísimo en cargar la vista, y no pueden exportar la vista, por lo que almacenando el campo, se ha conseguido reducir bastante el tiempo de carga.

-  [REM] custom_report_link : ahora siempre se muestra en el pdf el cliente del albarán
-  [FIX] product_stock_unsafety: almacenado campo seller_id para reducir tiempo de carga
-  [FIX] stock_custom: cambiado filtro proveedor principal no contiene outlet



