### PR TITLE
Cambios en albaranes parcialmente disponibles

### DIFF
--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -217,6 +217,7 @@ class StockPicking(models.Model):
                 bck = self._create_backorder_incidences(new_moves)
                 bck.write({'move_type': 'one'})
                 self.action_assign()
+                pick.move_lines.write({'state': 'assigned'})
             self.message_post(body=_("User %s accepted confirmed qties.") %
                               self.env.user.name)
 


### PR DESCRIPTION
[IMP] location_moves: Forzar el parcializado de albaranes internos que estén parcialmente disponibles.
[FIX] picking_incidences: Al parcializar, forzar el estado de los movimientos a "assigned" del albarán que tiene todo reservado