### PR TITLE
Campos en solo lectura en pedidos y comprobación DHL aéreo al modificar cantidades

### DIFF
--- a/project-addons/sale_delivery_type/views/sale_view.xml
+++ b/project-addons/sale_delivery_type/views/sale_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <field name="pricelist_id" position="after">
-                    <field name="delivery_type" widget='selection'/>
+                    <field name="delivery_type" widget='selection' attrs="{'readonly': [('state', 'not in', ['draft', 'sent', 'reserve'])]}"/>
                 </field>
                 <field name="partner_id" position="attributes">
                     <attribute name="context">{'search_default_customer':1, 'show_address': 0}</attribute>

--- a/project-addons/transportation/views/sale_view.xml
+++ b/project-addons/transportation/views/sale_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <field name="pricelist_id" position="after">
                     <field name="transporter_id" attrs="{'readonly': [('state', 'not in', ['draft', 'sent', 'reserve'])]}"/>
-                    <field name="service_id"/>
+                    <field name="service_id" attrs="{'readonly': [('state', 'not in', ['draft', 'sent', 'reserve'])]}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
- [IMP] sale_custom: Añadido que al modificar cantidades cuando el pedido está tramitado, se compruebe si se pasa de peso si es DHL aéreo
-  [FIX] sale_delivery_type: Añadido que el delivery_type sea solo de lectura cuando se tramita un pedido
-  [FIX] transportation: Añadido que el campo service_id sea solo de lectura cuando un pedido ya está tramitado





