### PR TITLE
Error envío mail en albaranes

### DIFF
--- a/project-addons/stock_custom/views/stock_view.xml
+++ b/project-addons/stock_custom/views/stock_view.xml
@@ -294,4 +294,14 @@
             </field>
         </field>
     </record>
+    <record id="view_carrier_racking_ref_no_readonly" model="ir.ui.view">
+            <field name="name">view.carrier.racking.ref.no.readonly</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form"/>
+            <field name="arch" type="xml">
+               <xpath expr="//page[@name='extra']/group/group[@name='carrier_data']/div/field[@name='carrier_tracking_ref']" position="replace">
+                    <field name="carrier_tracking_ref" class="oe_inline"/>
+                </xpath>
+            </field>
+        </record>
 </odoo>


### PR DESCRIPTION
- [FIX] stock_custom: corregido error que hacía que no se enviaran bien los emails al poner los datos de envío del albarán.