### PR TITLE
Correcciones en el descuento por prepago

### DIFF
--- a/project-addons/flask_middleware_connector/models/res_partner/common.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/common.py
@@ -250,8 +250,7 @@ class ResPartner(models.Model):
         # 7 días y Pago inmediato)
         prepaid_ids = []
         prepaid_terms = self.env['account.payment.term'].with_context(lang='en_US').search(
-            ["|", "|", "|", "|", ("name", "=", "1 day"), ("name", "=", "3 days"),
-             ("name", "=", "5 days"), ("name", "=", "7 days"), ('name', 'ilike', 'Prepaid')])
+            [("name", "in", ("1 day","3 days","5 days","7 days","Prepaid"))])
         prepaid_ids.extend(prepaid_terms.ids)
         prepaid_ids.extend([self.env.ref('account.account_payment_term_immediate').id])
         for partner in self:

--- a/project-addons/flask_middleware_connector/models/res_partner/common.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/common.py
@@ -246,10 +246,13 @@ class ResPartner(models.Model):
 
     @api.multi
     def prepaid_payment_term(self):
-        # Obtener ids de plazo de pago que requieran prepagar (Prepago y Pago inmediato)
+        # Obtener ids de plazo de pago que requieran prepagar (Prepago, 1 días, 3 días, 5 días,
+        # 7 días y Pago inmediato)
         prepaid_ids = []
-        prepaid_ids.extend([self.env['account.payment.term'].
-                           with_context(lang='en_US').search([('name', 'ilike', 'Prepaid')]).id])
+        prepaid_terms = self.env['account.payment.term'].with_context(lang='en_US').search(
+            ["|", "|", "|", "|", ("name", "=", "1 day"), ("name", "=", "3 days"),
+             ("name", "=", "5 days"), ("name", "=", "7 days"), ('name', 'ilike', 'Prepaid')])
+        prepaid_ids.extend(prepaid_terms.ids)
         prepaid_ids.extend([self.env.ref('account.account_payment_term_immediate').id])
         for partner in self:
             # Si el plazo de pago del cliente coincide con alguno de esos ids, devolver True

--- a/project-addons/merge_sale_order/__manifest__.py
+++ b/project-addons/merge_sale_order/__manifest__.py
@@ -9,7 +9,8 @@
     'depends': [
         'sale_management',
         'sale',
-        'reserve_without_save_sale'
+        'reserve_without_save_sale',
+        'prepaid_order_discount'        
     ],
 
     'data': [

--- a/project-addons/merge_sale_order/i18n/es.po
+++ b/project-addons/merge_sale_order/i18n/es.po
@@ -23,28 +23,34 @@ msgid "Please select at least two sale orders"
 msgstr "Por favor, seleccione al menos dos pedidos"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:43
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:48
 #, python-format
 msgid "Please select Sale orders which are in Quotation or Reserve state"
 msgstr "Por favor, seleccione pedidos que estén en estado Presupuesto o Reservado"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:46
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:50
 #, python-format
 msgid "Please select Sale orders whose Customers are the same"
 msgstr "Por favor, seleccione pedidos de venta cuyos clientes sean el mismo"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:49
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:52
 #, python-format
 msgid "Please select Sale orders whose shipping addresses are the same"
 msgstr "Por favor, seleccione pedidos de venta cuyas direcciones de envío sean iguales"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:52
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:54
 #, python-format
 msgid "Please select Sale orders whose invoice addresses are the same"
 msgstr "Por favor, seleccione Pedidos de venta cuyas direcciones de facturación sean iguales"
+
+#. module: merge_sale_order
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:56
+#, python-format
+msgid "Please all selected orders must have the same prepaid option"
+msgstr "Por favor, todos los pedidos tienen que tener la misma opción prepago"
 
 #. module: merge_sale_order
 #: selection:merge.sale.order,merge_type:0

--- a/project-addons/merge_sale_order/i18n/it.po
+++ b/project-addons/merge_sale_order/i18n/it.po
@@ -23,28 +23,34 @@ msgid "Please select at least two sale orders"
 msgstr "Seleziona almeno due ordini di vendita"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:43
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:48
 #, python-format
 msgid "Please select Sale orders which are in Quotation or Reserve state"
 msgstr "Seleziona gli ordini in stato Preventivo o Riservato"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:46
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:50
 #, python-format
 msgid "Please select Sale orders whose Customers are the same"
 msgstr "Seleziona gli ordini di vendita i cui clienti sono uguali"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:49
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:52
 #, python-format
 msgid "Please select Sale orders whose shipping addresses are the same"
 msgstr "Seleziona gli ordini di vendita i cui indirizzi di spedizione sono gli stessi"
 
 #. module: merge_sale_order
-#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:52
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:54
 #, python-format
 msgid "Please select Sale orders whose invoice addresses are same"
 msgstr "Seleziona gli ordini di vendita i cui indirizzi di fatturazione sono gli stessi"
+
+#. module: merge_sale_order
+#: code:addons/merge_sale_order/wizard/merge_sale_order_wizard.py:56
+#, python-format
+msgid "Please all selected orders must have the same prepaid option"
+msgstr "Per favore, tutti gli ordini selezionati devono avere la stessa opzione prepagata"
 
 #. module: merge_sale_order
 #: selection:merge.sale.order,merge_type:0

--- a/project-addons/prepaid_order_discount/models/sale.py
+++ b/project-addons/prepaid_order_discount/models/sale.py
@@ -21,9 +21,13 @@ class SaleOrder(models.Model):
                     message = _("It's an order with prepaid option. "
                                 "Please, calculate the discount if partner has prepaid or cancel the prepaid option.")
                 else:
-                    last_product_order = sale.order_line.sorted(key=lambda l: l.sequence)[-1]
-                    if exist_prepaid_discount_line.id != last_product_order.id:
-                        message = _("Please, recalculate prepaid discount")
+                    order_lines_sorted_by_id = sale.order_line.sorted(key=lambda l: l.id)
+                    last_product_order = order_lines_sorted_by_id[-1]
+                    if exist_prepaid_discount_line.id < last_product_order.id:
+                        num_elements = len(order_lines_sorted_by_id) -1 - order_lines_sorted_by_id.mapped('id').index(
+                            exist_prepaid_discount_line.id)
+                        if last_product_order.product_id.categ_id.name != 'Portes' or num_elements > 1:
+                            message = _("Please, recalculate prepaid discount")
             if message:
                 raise exceptions.Warning(message)
         return super().action_confirm()

--- a/project-addons/prepaid_order_discount/views/sale_order_view.xml
+++ b/project-addons/prepaid_order_discount/views/sale_order_view.xml
@@ -30,5 +30,22 @@
             </field>
         </record>
 
+        <record id="view_sale_prepaid_discount_readonly" model="ir.ui.view">
+        <field name="name">sale.order.prepaid.discount</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree//field[@name='price_unit']" position="attributes">
+                <attribute name="attrs">{'readonly': [('product_id', '=', %(prepaid_order_discount.prepaid_discount_product)d)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='discount']" position="attributes">
+                <attribute name="attrs">{'readonly': [('product_id', '=', %(prepaid_order_discount.prepaid_discount_product)d)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree//field[@name='product_uom_qty']" position="attributes">
+                <attribute name="attrs">{'readonly': [('product_id', '=', %(prepaid_order_discount.prepaid_discount_product)d)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
     </data>
 </odoo>

--- a/project-addons/shipping_balance/__manifest__.py
+++ b/project-addons/shipping_balance/__manifest__.py
@@ -26,7 +26,7 @@
     'author': 'Comunitea Servicios Tecnologicos',
     'website': 'www.comunitea.com',
     "depends": ["base", "product", "mrp_repair", "sale", "account",
-                "stock_reserve_sale", "sale_customer_discount"],
+                "stock_reserve_sale", "sale_customer_discount", "prepaid_order_discount"],
 
     "data": ["views/shipping_balance_view.xml",
               "wizard/shipping_balance_wizard.xml",

--- a/project-addons/shipping_balance/models/sale_order.py
+++ b/project-addons/shipping_balance/models/sale_order.py
@@ -32,7 +32,9 @@ class SaleOrder(models.Model):
 
     @api.constrains('state', 'amount_untaxed')
     def _check_amount_on_state(self):
-        if self.amount_untaxed < 0 and not self.order_line.filtered('deposit'):
+        prepaid_discount_product_id=self.env.ref('prepaid_order_discount.prepaid_discount_product').id
+        if self.amount_untaxed < 0 and \
+                not self.order_line.filtered(lambda l: l.deposit or l.promotion_line or l.product_id.id==prepaid_discount_product_id):
             raise ValidationError("Total amount must be > 0")
 
     @api.multi


### PR DESCRIPTION
-  [FIX] prepaid_order_discount: Añadido que algunos campos de la línea generada sean readonly y arreglado comprobación al tramitar
-  [IMP] flask_middleware_connector: Ahora se considera pago prepago si iene también plazo de pago 1,3,5 o 7 días
-  [IMP] merge_sale_order: Adaptación al nuevo descuento por prepago
-  [FIX] shipping_balance: Añadido que la comprobación de la base imponible no tenga en cuenta las líneas de promo


