### PR TITLE
Cron fichedo de compras

### DIFF
--- a/project-addons/cron_stock_catalog/__init__.py
+++ b/project-addons/cron_stock_catalog/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/cron_stock_catalog/__manifest__.py
+++ b/project-addons/cron_stock_catalog/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "Cron Stock Catalog",
+    "description": "Cron to send the stock catalog every day to purchase department",
+    "version": "0.1",
+    "data": [
+        "data/ir_cron.xml",
+        "views/email_template.xml",
+    ],
+    "depends": [
+    ],
+
+    "auto_install": False,
+    "installable": True,
+}

--- a/project-addons/cron_stock_catalog/data/ir_cron.xml
+++ b/project-addons/cron_stock_catalog/data/ir_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record forcecreate="True" id="ir_cron_stock_catalog" model="ir.cron">
+            <field name="name">Purchase Stock Catalog</field>
+            <field name="active" eval="True" />
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field eval="False" name="doall" />
+            <field name="model_id" ref="model_product_product"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_stock_catalog()</field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/cron_stock_catalog/data/ir_cron.xml
+++ b/project-addons/cron_stock_catalog/data/ir_cron.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record forcecreate="True" id="ir_cron_stock_catalog" model="ir.cron">
             <field name="name">Purchase Stock Catalog</field>
-            <field name="active" eval="True" />
+            <field name="active" eval="False" />
             <field name="user_id" ref="base.user_root"/>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>

--- a/project-addons/cron_stock_catalog/models/__init__.py
+++ b/project-addons/cron_stock_catalog/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -1,0 +1,79 @@
+from odoo import api, fields, models, _, exceptions
+import csv
+import io
+import base64
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def cron_stock_catalog(self):
+        headers = ["ID", "Proveedor principal", "Referencia interna", "Fabricando", "Entrante", "Stock cocina",
+                   "Stock real", "Stock disponible", "Ventas en los últimos 60 días con stock",
+                   "Cant. pedido más grande", "Días de stock restantes", "Stock en playa", "Stock alm. externo",
+                   "Media de margen de últimas ventas", "Cost Price", "Último precio de compra",
+                   "Última fecha de compra", "Reemplazado por", "Estado"]
+
+        domain = [('custom', '=', False), ('type', '!=', 'service'), ('seller_id.name', 'not ilike', 'outlet')]
+        fields = ["id", "seller_id", "code", "qty_in_production", "incoming_qty", "qty_available_wo_wh",
+                  "qty_available", "virtual_stock_conservative", "last_sixty_days_sales", "biggest_sale_qty",
+                  "remaining_days_sale", "qty_available_input_loc", "qty_available_external", "average_margin",
+                  "standard_price", "last_purchase_price", "last_purchase_date", "replacement_id", "state"]
+        rows = []
+
+        products = self.env['product.product'].search_read(domain, fields, limit=2)
+        for product in products:
+            product_fields = []
+            for field in fields:
+                if field == 'seller_id':
+                    product_fields.append(product[field][1])
+                else:
+                    if product[field] is False:
+                        product_fields.append("")
+                    else:
+                        product_fields.append(product[field])
+            rows.append(product_fields)
+
+        # Create the csv
+        s = io.StringIO()
+        csv.writer(s).writerow(headers)
+        csv.writer(s).writerows(rows)
+        s.seek(0)
+        buf = io.BytesIO()
+        buf.write(s.getvalue().encode())
+        buf.seek(0)
+        buf.name = 'stock_catalog.csv'
+
+        self.send_stock_email(buf)
+
+
+    @api.multi
+    def send_stock_email(self, file):
+        attach = None
+        if file:
+            attach = self.env['ir.attachment'].create({
+                'name': "stock_diary",
+                'res_model': 'res.users',
+                'res_field': False,
+                'res_id': 1,
+                'type': 'binary',
+                'datas': base64.b64encode(file.read()),
+                'datas_fname': "stock_catalog.csv",
+
+            })
+        mail_pool = self.env['mail.mail']
+        context = self._context.copy()
+        context['base_url'] = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        context['attachment'] = attach.id
+        context.pop('default_state', False)
+
+        template_id = self.env.ref('cron_stock_catalog.email_template_purchase_stock_catalog')
+
+        if template_id:
+            mail_id = template_id.with_context(context).send_mail(self.id)
+            if mail_id:
+                mail_id_check = mail_pool.browse(mail_id)
+                mail_id_check.attachment_ids = [(6, 0, [attach.id])]
+                mail_id_check.with_context(context).send()
+
+        return True

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -9,10 +9,10 @@ class ProductProduct(models.Model):
 
     def cron_stock_catalog(self):
         headers = ["ID", "Proveedor principal", "Referencia interna", "Fabricando", "Entrante", "Stock cocina",
-                   "Stock real", "Stock disponible", "Ventas en los últimos 60 días con stock",
-                   "Cant. pedido más grande", "Días de stock restantes", "Stock en playa", "Stock alm. externo",
-                   "Media de margen de últimas ventas", "Cost Price", "Último precio de compra",
-                   "Última fecha de compra", "Reemplazado por", "Estado"]
+                   "Stock real", "Stock disponible", "Ventas en los últimos 60 dias con stock",
+                   "Cant. pedido mas grande", "Dias de stock restantes", "Stock en playa", "Stock alm. externo",
+                   "Media de margen de ultimas ventas", "Cost Price", "Ultimo precio de compra",
+                   "Ultima fecha de compra", "Reemplazado por", "Estado"]
 
         domain = [('custom', '=', False), ('type', '!=', 'service'), ('seller_id.name', 'not ilike', 'outlet')]
         fields = ["id", "seller_id", "code", "qty_in_production", "incoming_qty", "qty_available_wo_wh",

--- a/project-addons/cron_stock_catalog/views/email_template.xml
+++ b/project-addons/cron_stock_catalog/views/email_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="email_template_purchase_stock_catalog" model="mail.template">
+        <field name="name">Purchase Stock Catalog</field>
+        <field name="email_from">odoo_team@visiotechsecurity.com</field>
+        <field name="subject">Listado Stock Diario</field>
+        <field name="email_to">purchasing.spain@visiotechsecurity.com</field>
+        <field name="model_id" ref="base.model_res_users"/>
+        <field name="auto_delete" eval="False"/>
+        <field name="body_html"><![CDATA[
+            <p>Hello</p>
+            <p>Here is the Stock Catalog for today</p>
+            ]]>
+         </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- [IMP]cron_stock_catalog: cron para enviar fichero de compras
- [IMP]cron_catalog_update: desactivado cron para que no se ejecute la primera vez y poder activarlo a mano
- [IMP]cron_stock_catalog: eliminadas tildes de los títulos

Es un poco chapucero el método de generación y envío del fichero pero parece funcionar, si ves cualquier cosa rara me dices.