### PR TITLE
Exclusión de los productos asociados para el cálculo del margen en el descuento prepago

### DIFF
--- a/project-addons/prepaid_order_discount/models/sale.py
+++ b/project-addons/prepaid_order_discount/models/sale.py
@@ -117,7 +117,7 @@ class SaleOrder(models.Model):
             sale_price = 0.0
             purchase_price = 0.0
             for line in sale.order_line:
-                if not line.deposit and line.product_id.categ_id.id not in shipping_cost_categ.ids:
+                if not line.deposit and line.product_id.categ_id.id not in shipping_cost_categ.ids and not line.original_line_id:
                     if line.price_unit > 0:
                         margin_rappel += line.margin_rappel or 0.0
                     else:


### PR DESCRIPTION
- [FIX] prepaid_order_discount: Exclusión de los productos asociados para el cálculo del margen en el descuento prepago