### PR TITLE
Correción en cron_update_date_followup

### DIFF
--- a/project-addons/account_move_line_followup/models/account_move_line.py
+++ b/project-addons/account_move_line_followup/models/account_move_line.py
@@ -41,7 +41,7 @@ class AccountMoveLine(models.Model):
                                                       ('parent_id', '=', False), ('child_ids', '!=', False)])
 
         # Searching all positive account move line with cyc notify date
-        aml_notify_date = self.search_read([('full_reconcile_id', '=', False),
+        aml_notify_date = self.search_read([('reconciled', '=', False),
                                             ('account_id', '=', 443),
                                             ('debit', '!=', 0),
                                             ('cyc_notify_date', '!=', False)],


### PR DESCRIPTION
-[FIX] account_move_line_followup: corregido error en el cron que hacía que cogiera algunos apuntes ya finalizados

Buenas tardes Omar, 
¿que te parece este cambio? 
El cambio viene motivado porque con el full_reconcile_id nos salen algunos apuntes antiguos que ya están finalizados.