### PR TITLE
Evitar duplicidad stock.move compras

### DIFF
--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -124,8 +124,10 @@ class StockPicking(models.Model):
             if not move.qty_ready:
                 new_moves.append(move.id)
             elif float_compare(remaining_qty, 0, precision_rounding=precision) > 0 and \
-                 float_compare(remaining_qty, move.product_qty, precision_rounding=precision) < 0:
-                new_move = move._split(remaining_qty)
+                    float_compare(remaining_qty, move.product_qty, precision_rounding=precision) < 0:
+                move_ctx = move._context.copy()
+                move_ctx.update(accept_ready_qty=True)
+                new_move = move.with_context(move_ctx)._split(remaining_qty)
                 new_moves.append(new_move)
         if new_moves:
             new_moves = self.env['stock.move'].browse(new_moves)

--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -145,7 +145,11 @@ class StockMove(models.Model):
     @api.multi
     def write(self, vals):
         for move in self:
-            if 'product_uom_qty' in vals and self.purchase_line_id and self.picking_id and 'origin' not in vals:
+            if 'product_uom_qty' in vals \
+                    and self.purchase_line_id \
+                    and self.picking_id \
+                    and 'origin' not in vals\
+                    and not move._context.get('accept_ready_qty'):
                 if move.product_uom_qty > vals['product_uom_qty'] > 0:
                     move.copy({'picking_id': False, 'product_uom_qty': move.product_uom_qty - vals['product_uom_qty']})
                 elif vals['product_uom_qty'] > move.product_uom_qty:


### PR DESCRIPTION
[FIX] purchase_picking,picking_incidences: Evitar que se duplique movimiento en borrador al aceptar cantidades preparadas en un albarán de entrada.