### PR TITLE
Sincronización fechas fiabilidad media

### DIFF
--- a/project-addons/flask_middleware_connector/models/product/common.py
+++ b/project-addons/flask_middleware_connector/models/product/common.py
@@ -166,10 +166,10 @@ class ProductProduct(models.Model):
     def compute_date_next_incoming(self):
         moves = self.env['stock.move'].search(
             [('product_id', '=', self.id), ('purchase_line_id', '!=', False), ('state', 'not in', ['cancel','done']),
-             ('location_dest_id.usage', 'like', 'internal'),('picking_id','!=',False)],
-            limit=1, order="date_expected asc")
+             ('location_dest_id.usage', 'like', 'internal'),'|',('picking_id','!=',False),('container_id','!=',False)]).sorted(
+            key=lambda m: m.date_expected and m.date_reliability)
         if moves:
-            return moves.date_expected
+            return moves[0].date_expected
         return (datetime.datetime.now() - datetime.timedelta(days=365)).strftime("%Y-%m-%d %H:%M:%S")
 
 


### PR DESCRIPTION
- [FIX] flask_middleware_connector: las fechas de próxima recepción ahora tienen en cuenta las fechas con fiabilidad media