### PR TITLE
Vale-ahorro de producto vinculado a empresa matriz

### DIFF
--- a/project-addons/rappel_custom/models/rappel.py
+++ b/project-addons/rappel_custom/models/rappel.py
@@ -97,7 +97,7 @@ class Rappel(models.Model):
                 # Rappel que depende de la compra de un producto concreto
                 partner_product = self.env['account.invoice.line'].search([
                     ('product_id', '=', product_rappel.id),
-                    ('invoice_id.state', 'in', ['open', 'paid'])]).mapped('invoice_id.partner_id.id')
+                    ('invoice_id.state', 'in', ['open', 'paid'])]).mapped('invoice_id.commercial_partner_id.id')
                 partner_filter.extend(["('id', 'in', partner_product)"])
 
             if partner_filter:


### PR DESCRIPTION
[FIX] rappel_custom: Vincular los vale-ahorro ligados a un producto a la empresa matriz en vez de al contacto de facturación.