### PR TITLE
Añadidos campos a la vista en órdenes de compra y opción prepago en mensajería

### DIFF
--- a/project-addons/prepaid_order_discount/i18n/es.po
+++ b/project-addons/prepaid_order_discount/i18n/es.po
@@ -74,3 +74,9 @@ msgstr "El margen del pedido está por debajo de los límites para aplicar el de
 msgid "Prepaid discount line has not been created"
 msgstr "No se ha creado línea de descuento por prepago"
 
+#. module: prepaid_order_discount
+#: code:addons/prepaid_order_discount/models/sale.py:143
+#, python-format
+msgid "Prepaid option checked by Web Team"
+msgstr "Opción prepago marcado por el Equipo Web"
+

--- a/project-addons/prepaid_order_discount/models/sale.py
+++ b/project-addons/prepaid_order_discount/models/sale.py
@@ -134,3 +134,11 @@ class SaleOrder(models.Model):
                     return round((margin_rappel * 100) / purchase_price, 2)
                 else:
                     return round((margin_rappel * 100) / sale_price, 2)
+
+    @api.model
+    def create(self, vals):
+        res = super(SaleOrder, self).create(vals)
+        if vals.get('prepaid_option', False) and self.env.user.login == self.env['ir.config_parameter'].sudo().get_param(
+                'web.user.buyer'):
+            res.message_post(body=_("Prepaid option checked by Web Team"))
+        return res

--- a/project-addons/separate_purchase_orders/views/purchase_view.xml
+++ b/project-addons/separate_purchase_orders/views/purchase_view.xml
@@ -94,6 +94,8 @@
                             <group class="oe_subtotal_footer oe_right">
                                 <field name="amount_untaxed" widget="monetary"
                                        options="{'currency_field': 'currency_id'}"/>
+                                <field name="total_no_disc" widget="monetary"/>
+                                <field name="total_disc" widget="monetary"/>
                                 <field name="amount_tax" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                 <div class="oe_subtotal_footer_separator oe_inline">
                                     <label for="amount_total"/>


### PR DESCRIPTION
- [IMP] prepaid_order_discount: opción prepago reflejada en mensajeria.
-  [IMP] separate_purchase_orders: Añadidos campos total sin descuento  y total descuento a las órdenes de compra