### PR TITLE
Mejora cálculo Libro de IVA

### DIFF
--- a/project-addons/l10n_es_vat_book_imp/__init__.py
+++ b/project-addons/l10n_es_vat_book_imp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/l10n_es_vat_book_imp/__manifest__.py
+++ b/project-addons/l10n_es_vat_book_imp/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'VAT Book Improvements',
+    'summary': 'VAT Book Improvements',
+    'author': 'Visiotech',
+    'website': '',
+    'category': 'Accounting',
+    'version': '11.0',
+    'depends': [
+        'l10n_es_vat_book',
+    ],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/project-addons/l10n_es_vat_book_imp/models/__init__.py
+++ b/project-addons/l10n_es_vat_book_imp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_es_vat_book

--- a/project-addons/l10n_es_vat_book_imp/models/l10n_es_vat_book.py
+++ b/project-addons/l10n_es_vat_book_imp/models/l10n_es_vat_book.py
@@ -15,11 +15,11 @@ class L10nEsVatBook(models.Model):
                 WHERE
                     ((aml.date >= '%s') and (aml.date <= '%s'))
                     and ((amlatr.account_tax_id in %s) or (aml.tax_line_id in %s))
-                    and aml.company_id = 1
+                    and aml.company_id = %s
                 ORDER BY
                     aml.date desc,
                     aml.id desc
-        """) % (self.date_start, self.date_end, tuple(taxes.ids), tuple(taxes.ids))
+        """) % (self.date_start, self.date_end, tuple(taxes.ids), tuple(taxes.ids), self.env.user.company_id.id)
         self.env.cr.execute(sql)
         lines = self.env.cr.fetchall()
         lines = self.env['account.move.line'].browse([x[0] for x in lines])

--- a/project-addons/l10n_es_vat_book_imp/models/l10n_es_vat_book.py
+++ b/project-addons/l10n_es_vat_book_imp/models/l10n_es_vat_book.py
@@ -1,0 +1,26 @@
+from odoo import models
+
+
+class L10nEsVatBook(models.Model):
+    _inherit = 'l10n.es.vat.book'
+
+    def _get_account_move_lines(self, taxes):
+        sql = (
+            """ SELECT
+                    DISTINCT aml.id, aml.date
+                FROM
+                    account_move_line aml
+                LEFT JOIN
+                    account_move_line_account_tax_rel amlatr ON amlatr.account_move_line_id = aml.id
+                WHERE
+                    ((aml.date >= '%s') and (aml.date <= '%s'))
+                    and ((amlatr.account_tax_id in %s) or (aml.tax_line_id in %s))
+                    and aml.company_id = 1
+                ORDER BY
+                    aml.date desc,
+                    aml.id desc
+        """) % (self.date_start, self.date_end, tuple(taxes.ids), tuple(taxes.ids))
+        self.env.cr.execute(sql)
+        lines = self.env.cr.fetchall()
+        lines = self.env['account.move.line'].browse([x[0] for x in lines])
+        return lines


### PR DESCRIPTION
- [IMP]l10n_es_vat_book_imp: mejora de velocidad en el cálculo del libro de IVA
- [FIX]l10n_es_vat_book_imp: compañía parametrizada

Igual te parece extraño este cambio, pero es la única solución que hemos encontrado para acelerar un poco el cálculo del libro de  IVA. El search que hay en esa función en el módulo original puede tardar varias horas en ejecutarse, la query que genera es super ineficiente con una subselect de millones de registros. Hemos sustituido el search por una query parecida pero haciendo join y ahora el libro se calcula en menos de un minuto. Con el módulo original ha llegado a tardar más de 4 horas, eso cuando no tiraba abajo odoo. No se si con el ORM habría alguna forma de mejorar el search, pero yo creo que en este caso merece la pena el cambio solo por el ahorro de tiempo que supone.