### PR TITLE
[IMPORTANT] Revertidos todos los cambios en el planificador desde  Mayo y añadidos logs

### DIFF
--- a/project-addons/location_moves/models/procurement.py
+++ b/project-addons/location_moves/models/procurement.py
@@ -19,6 +19,9 @@
 ##############################################################################
 
 from odoo import models, api
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 class ProcurementGroup(models.Model):
@@ -26,42 +29,32 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
+        _logger.info("STARTING CALL SUPER SCHEDULER")
         super()._run_scheduler_tasks(use_new_cursor=use_new_cursor,
                                      company_id=company_id)
+        _logger.info("SEARCHING FOR INTERNAL PICKINGS")
 
-        location_it = self.env['stock.location'].search(
-            [('name', '=', 'Depósito Visiotech Italia')])
+        pick_ids = self.env["stock.picking"]. \
+            search([("picking_type_id", "=",
+                     self.env.ref('stock.picking_type_internal').id),
+                    ("state", "in", ("assigned", "confirmed", "partially_available"))])
 
-        operation_it = self.env['stock.picking.type'].search([('name', '=', 'Albarán de salida desde depósito IT')])
-        operation_internal = self.env.ref('stock.picking_type_internal').id
-        pick_ids_assign = self.env["stock.picking"]. \
-            search(['&', ("state", "=", "assigned"), '|',
-                    ("picking_type_id", "=", operation_internal), '&',
-                    ("location_id", "=", location_it.id),
-                    ("picking_type_id", "=", operation_it.id)
-                    ])
+        _logger.info("TRANSFERRING READY INTERNAL PICKINGS")
 
-        pick_ids_confirmed_par = self.env["stock.picking"]. \
-            search(['&', ("state", "in", ("confirmed", "partially_available")), '|',
-                    ("picking_type_id", "=", operation_internal),
-                    '&', ("location_id", "=", location_it.id),
-                    ("picking_type_id", "=", operation_it.id)
-                    ])
-        max_commit_len = int(self.env['ir.config_parameter'].sudo().get_param('max_commit_len'))
-        len_pick_assign = len(pick_ids_assign)
-        for count, pick_assign in enumerate(pick_ids_assign):
+        for pick_assign in pick_ids.filtered(
+                lambda l: l.state == "assigned"):
             pick_assign.action_done()
-            if ((count + 1 >= max_commit_len and count + 1 % max_commit_len == 0) or count == len_pick_assign - 1) \
-                    and use_new_cursor:
-                self.env.cr.commit()
 
-        for count, pick_partially in enumerate(pick_ids_confirmed_par):
+        _logger.info("PROCESSING CONFIRMED AND PARTIALLY AVAILABLE PICKINGS")
+
+        for pick_partially in pick_ids.filtered(
+                lambda l: l.state in ("confirmed", "partially_available")):
             pick_partially.move_type = 'direct'
             if pick_partially.state == "partially_available":
                 pick_partially.action_copy_reserv_qty()
                 pick_partially.action_accept_confirmed_qty()
-            if count + 1 >= max_commit_len and count + 1 % max_commit_len == 0 and use_new_cursor:
-                self.env.cr.commit()
 
         if use_new_cursor:
             self.env.cr.commit()
+        _logger.info("DONE")
+


### PR DESCRIPTION
-  [REV] location_moves: revertidos cambios en el planificador y añadido logs

Hola Omar, si puedes, intenta subir los cambios esta noche. El planificador sigue sin funcionar bien y no llega a transferir ningún albarán. Hemos revertido todos los cambios que hemos hecho últimamente en el planificador y añadido unos logs para determinar donde se queda en cada ejecución, ya que no aparece ninguna long query en el pghero.
Gracias, un saludo.

