### PR TITLE
Aumento de velocidad en Reservas huérfanas

### DIFF
--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -158,13 +158,13 @@ class StockReservation(models.Model):
                                 ('move_id.state', 'not in', ['done',
                                                              'cancel'])])
         reserves_to_delete = self.env['stock.reservation']
-        for reserve in reserves:
-            check_other_reserves = self.\
-                search([('sale_line_id', '=', reserve.sale_line_id.id),
-                        ('partner_id', '!=', False),
-                        ('move_id.state', 'not in', ['done', 'cancel'])])
-            if check_other_reserves:
-                reserves_to_delete |= reserve
+        check_other_reserves = self.\
+            search([('sale_line_id', 'in', reserves.mapped('sale_line_id').mapped('id')),
+                    ('partner_id', '!=', False),
+                    ('move_id.state', 'not in', ['done', 'cancel'])])
+        if check_other_reserves:
+            reserves_to_delete |= reserves.\
+                filtered(lambda r: r.sale_line_id.id in check_other_reserves.mapped('sale_line_id').mapped('id'))
         if reserves_to_delete:
             reserves_to_delete.unlink()
 

--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -159,12 +159,12 @@ class StockReservation(models.Model):
                                                              'cancel'])])
         reserves_to_delete = self.env['stock.reservation']
         check_other_reserves = self.\
-            search([('sale_line_id', 'in', reserves.mapped('sale_line_id').mapped('id')),
+            search([('sale_line_id', 'in', reserves.mapped('sale_line_id').ids),
                     ('partner_id', '!=', False),
                     ('move_id.state', 'not in', ['done', 'cancel'])])
         if check_other_reserves:
             reserves_to_delete |= reserves.\
-                filtered(lambda r: r.sale_line_id.id in check_other_reserves.mapped('sale_line_id').mapped('id'))
+                filtered(lambda r: r.sale_line_id.id in check_other_reserves.mapped('sale_line_id').ids)
         if reserves_to_delete:
             reserves_to_delete.unlink()
 


### PR DESCRIPTION
- [IMP]reserve_without_save_sale: sustituido for para aumentar la velocidad en el cron de reservas huérfanas
- [IMP]reserve_without_save_sale: cambiado mapped por ids
