### PR TITLE
Error al cancelar albaranes desde el PO

### DIFF
--- a/project-addons/custom_account/models/purchase.py
+++ b/project-addons/custom_account/models/purchase.py
@@ -17,6 +17,7 @@ class PurchaseOrder(models.Model):
                                 'some receptions have already been done.') %
                               (purchase.name))
             else:
+                purchase.picking_ids.action_cancel()
                 purchase.order_line.mapped('move_ids').\
                     write({'state': 'cancel'})
         super().button_cancel()

--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -116,6 +116,8 @@ class StockPicking(models.Model):
                         move._do_unreserve()
                     move.state = "draft"
                     move.picking_id = False
+                pick.state = "cancel"
+
         return super(StockPicking, self).action_cancel()
 
     @api.multi


### PR DESCRIPTION
-  [FIX] purchase_picking: cambiar estado a cancelado al cancelar un albarán de entrada
-  [FIX] custom_account: eliminar asientos asociados a los albaranes de entrada al cancelar un pedido de compra



