### PR TITLE
[Important] Arreglo para comunicación de deuda en odoo Italia

### DIFF
--- a/project-addons/account_move_line_followup/models/credit_control_policy.py
+++ b/project-addons/account_move_line_followup/models/credit_control_policy.py
@@ -202,8 +202,12 @@ class CreditCommunication(models.Model):
                 strbegin = "<TD>"
                 strend = "</TD>"
                 date = aml['date_maturity'] or aml['date']
+                if not aml.ref:
+                    move_ref = aml.invoice_id and aml.invoice_id.number or ''
+                else:
+                    move_ref = aml.ref
                 followup_table += "<TR>" + strbegin + datetime.datetime.strptime(aml['date'], '%Y-%m-%d').strftime('%d/%m/%Y') + strend + \
-                                  strbegin + (aml['ref'] or '') + strend + \
+                                  strbegin + move_ref + strend + \
                                   strbegin + str(datetime.datetime.strptime(date, '%Y-%m-%d').strftime('%d/%m/%Y')) + strend + strbegin + \
                                   str(aml['amount_residual']) + strend + "</TR>"
 


### PR DESCRIPTION
[FIX] account_move_line_followup: Pequeña corrección para que no aparezca la referencia vacía en el comunicado de deuda que se va a enviar desde odoo Italia