### PR TITLE
Cambios en RMA

### DIFF
--- a/project-addons/crm_claim_rma/models/stock.py
+++ b/project-addons/crm_claim_rma/models/stock.py
@@ -48,13 +48,14 @@ class StockMove(models.Model):
                 claim_line_obj = move.claim_line_id
                 qty = claim_line_obj.product_returned_quantity
                 loc_lost = self.env.ref('crm_rma_advance_location.stock_location_carrier_loss')
+                loc_cust = self.env.ref('stock.stock_location_customers')
                 claim_obj = claim_line_obj.claim_id
                 if claim_line_obj.equivalent_product_id:
                     rma_cost = claim_obj.rma_cost
                     if move.location_dest_id == loc_lost:
                         standard_price = claim_line_obj.product_id.standard_price
                         rma_cost += (move.picking_type_code == u'incoming') and (standard_price * qty) or 0.0
-                    else:
+                    elif move.location_dest_id == loc_cust:
                         standard_price = claim_line_obj.equivalent_product_id.standard_price
                         rma_cost += (move.picking_type_code == u'outgoing') and (standard_price * qty) or 0.0
                     claim_obj.rma_cost = rma_cost

--- a/project-addons/vt_imp_performance/models/mail_thread.py
+++ b/project-addons/vt_imp_performance/models/mail_thread.py
@@ -9,7 +9,7 @@ class MailThread(models.AbstractModel):
     def create(self, values):
         """Eliminamos el log de documento creado y cambios en campos"""
         ctx = dict(self.env.context)
-        if self._name != 'sale.order':
+        if self._name not in ('sale.order', 'crm.claim'):
             ctx.update({'mail_create_nolog': True,
                         'mail_notrack': True})
         res = super(MailThread, self.with_context(ctx)).create(values)
@@ -19,7 +19,7 @@ class MailThread(models.AbstractModel):
     def write(self, values):
         """Eliminamos el log de cambios en campos"""
         ctx = dict(self.env.context)
-        if self._name != 'sale.order':
+        if self._name not in ('sale.order', 'crm.claim'):
             ctx.update({'mail_notrack': True})
         return super(MailThread, self.
                      with_context(ctx)).write(values)


### PR DESCRIPTION
- [FIX]crm_claim_rma: se tiene en cuenta solamente los movimientos de salida a clientes
- [IMP]vt_imp_performance: recuperada la mensajería en el modelo de reclamación


