### PR TITLE
[Important] Fix EDI - Error de lectura de ficheros de años pasados

### DIFF
--- a/project-addons/edi_edifact/models/account.py
+++ b/project-addons/edi_edifact/models/account.py
@@ -8,6 +8,8 @@ class AccountInvoice(models.Model):
 
     _inherit = 'account.invoice'
 
+    edi_partner = fields.Boolean(related="partner_id.edi_enabled", readonly=True)
+
     @api.multi
     def send_via_edi(self):
         for invoice in self:

--- a/project-addons/edi_edifact/models/edi_message.py
+++ b/project-addons/edi_edifact/models/edi_message.py
@@ -328,20 +328,17 @@ class EdifFile(models.Model):
 
         # Read the files
         files = []
-        lines = []
         latest_date = False
-        ftp.dir("", lines.append)  # Read every line in the folder
         date_reading = fields.Datetime.now()
         latest_date_str = self.search([], limit=1, order='read_date desc').read_date
 
-        for line in lines:  # Get the latest files only
-            pieces = line.split(maxsplit=9)
-            datetime_str = pieces[5] + " " + pieces[6] + " " + pieces[7]
+        for line in ftp.mlsd(ftp_folder):  # Get the latest files only
+            datetime_str = line[1].get("modify")
             line_datetime = parser.parse(datetime_str)
             if latest_date_str:
                 latest_date = parser.parse(latest_date_str)
-            if line_datetime > latest_date:
-                files.append(pieces[8])
+            if line_datetime > latest_date and line[0] not in ['.', '..']:
+                files.append(line[0])
 
         for file in files:
             vals = {

--- a/project-addons/edi_edifact/views/account_invoice_views.xml
+++ b/project-addons/edi_edifact/views/account_invoice_views.xml
@@ -5,8 +5,12 @@
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_form" />
         <field name="arch" type="xml">
+            <field name="move_id" position="before">
+                <field name="edi_partner" invisible="1"/>
+            </field>
             <button name="action_invoice_draft" position="after">
-                <button type="object" string="Send to EDI" name="send_via_edi"/>
+                <button type="object" string="Send to EDI" name="send_via_edi"
+                        attrs="{'invisible': [('edi_partner','=',False)]}"/>
             </button>
         </field>
     </record>


### PR DESCRIPTION
- [FIX]edi_edifact: cambiado método de lectura de ficheros para poder recuperar el año en la fecha de modificación
- [IMP]edi_edifact: añadida visibilidad al botón de enviar factura
