### PR TITLE
Varias mejoras en la gestión de reservas al cambiar unidades en el pedido

### DIFF
--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -117,9 +117,9 @@ class StockReservation(models.Model):
             current_sale_line_id = reserve.sale_line_id.id
             res = super(StockReservation, reserve).reserve()
             reserve.refresh()
-            reserve.write({"sale_line_id": current_sale_line_id})
             moves |= res
             for move in res:
+                move.sale_line_id = current_sale_line_id
                 reservation = self.env['stock.reservation'].search(
                     [('move_id', '=', move.id)])
                 if not reservation:

--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -117,6 +117,7 @@ class StockReservation(models.Model):
             current_sale_line_id = reserve.sale_line_id.id
             res = super(StockReservation, reserve).reserve()
             reserve.refresh()
+            reserve.write({"sale_line_id": current_sale_line_id})
             moves |= res
             for move in res:
                 reservation = self.env['stock.reservation'].search(

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -85,7 +85,7 @@ class SaleOrderLine(models.Model):
         lines_released = self.env['sale.order.line']
         if not self.env.context.get('later', False):
             for line in self:
-                if len(line.reservation_ids) > 1:
+                if len(line.reservation_ids) > 1 or line.product_id.bom_ids:
                     line.reservation_ids.release()
                     lines_released += line
             super()._update_reservation_price_qty()

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -83,12 +83,14 @@ class SaleOrderLine(models.Model):
     @api.multi
     def _update_reservation_price_qty(self):
         lines_released = self.env['sale.order.line']
-        for line in self:
-            if len(line.reservation_ids) > 1:
-                line.reservation_ids.release()
-                lines_released += line
-        super()._update_reservation_price_qty()
-        lines_released.stock_reserve()
+        if not self.env.context.get('later', False):
+            for line in self:
+                if len(line.reservation_ids) > 1:
+                    line.reservation_ids.release()
+                    lines_released += line
+            super()._update_reservation_price_qty()
+        if lines_released:
+            lines_released.stock_reserve()
 
 
 class SaleOrder(models.Model):

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -80,6 +80,16 @@ class SaleOrderLine(models.Model):
                     return {'warning': warning_mess}
         return {}
 
+    @api.multi
+    def _update_reservation_price_qty(self):
+        lines_released = self.env['sale.order.line']
+        for line in self:
+            if len(line.reservation_ids) > 1:
+                line.reservation_ids.release()
+                lines_released += line
+        super()._update_reservation_price_qty()
+        lines_released.stock_reserve()
+
 
 class SaleOrder(models.Model):
 

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -154,6 +154,8 @@ class StockMove(models.Model):
             responsible = None
             if move.picking_id:
                 responsible = move.picking_id.commercial.id
+            elif move.sale_id:
+                responsible = move.sale_id.user_id.id
             elif move.origin:
                 responsible = move.env['sale.order'].search(
                     [('name', '=', move.origin)]).user_id.id
@@ -237,10 +239,10 @@ class StockMove(models.Model):
     @api.multi
     def _compute_parent_partner(self):
         for move in self:
-            move.parent_partner=move.sale_line_id.order_id.partner_id if move.sale_line_id else move.partner_id
-    parent_partner = fields.Many2one('res.partner',compute="_compute_parent_partner",string="Partner")
+            move.parent_partner = move.sale_line_id.order_id.partner_id if move.sale_line_id else move.partner_id
+    parent_partner = fields.Many2one('res.partner', compute="_compute_parent_partner", string="Partner")
 
-    purchase_order_id = fields.Many2one('purchase.order',related='purchase_line_id.order_id')
+    purchase_order_id = fields.Many2one('purchase.order', related='purchase_line_id.order_id')
 
 
 class StockReturnPicking(models.TransientModel):


### PR DESCRIPTION
- [FIX]sale_custom: se libera la reserva y se vuelve a recuperar de forma automática al cambiar la cantidad de un pack multiproducto
- [FIX]sale_custom: arreglado problema al poner menos cantidad de producto
- [FIX]reserve_without_save_sale,stock_custom: recuperamos la información de las reservas que se pierden al reservar con el candado
- [FIX]reserve_without_save_sale: escribimos directamente en el movimiento para que no de error en los pack
- [FIX]sale_custom: se libera la reserva al modificar la cantidad de un pack para que se reserve con la cantidad correcta después




