### PR TITLE
Visibilidad Ubicación Origen y destino en albaranes de entrada y salida y reserva automática al crear albaran de salida a mano

### DIFF
--- a/project-addons/picking_incidences/views/picking_view.xml
+++ b/project-addons/picking_incidences/views/picking_view.xml
@@ -13,6 +13,9 @@
             <xpath expr="//field[@name='location_id']" position="attributes">
                 <attribute name="attrs">{'invisible': False}</attribute>
             </xpath>
+            <xpath expr="//field[@name='location_dest_id']" position="attributes">
+                <attribute name="attrs">{'invisible': False}</attribute>
+            </xpath>
             <field name="origin" position="after">
                 <field name="with_incidences"/>
                 <field name="block_picking" readonly="1"/>

--- a/project-addons/picking_incidences/views/picking_view.xml
+++ b/project-addons/picking_incidences/views/picking_view.xml
@@ -10,8 +10,8 @@
                 <button name="action_copy_reserv_qty" attrs="{'invisible': ['|','|',('state', 'not in', ['confirmed','partially_available']),('with_incidences','=',True),('move_type', '!=' , 'direct')]}" string="Copy reserved qty. to confirmed qty." groups="base.group_user" type="object"/>
                 <button name="action_accept_confirmed_qty" attrs="{'invisible': ['|','|',('state', 'not in', ['confirmed','partially_available']),('with_incidences','=',True),('move_type', '!=' , 'direct')]}" string="Confirm assignation" groups="base.group_user" type="object" confirm="Are you sure? Backorder will be created with remaining quantities"/>
             </button>
-            <xpath expr="//field[@name='location_id']" position="after">
-                    <field name="location_dest_id" visible="1"/>
+            <xpath expr="//field[@name='location_id']" position="attributes">
+                <attribute name="attrs">{'invisible': False}</attribute>
             </xpath>
             <field name="origin" position="after">
                 <field name="with_incidences"/>

--- a/project-addons/purchase_picking/models/stock.py
+++ b/project-addons/purchase_picking/models/stock.py
@@ -129,6 +129,13 @@ class StockPicking(models.Model):
                     res.append(move.container_id.id)
             picking.container_ids = res
 
+    @api.onchange("location_id","location_dest_id")
+    def onchange_locations(self):
+        for picking in self:
+            for move in picking.move_lines:
+                move.location_id=picking.location_id
+                move.location_dest_id = picking.location_dest_id
+
 
 class StockMove(models.Model):
 

--- a/project-addons/stock_custom/models/stock.py
+++ b/project-addons/stock_custom/models/stock.py
@@ -104,6 +104,15 @@ class StockPicking(models.Model):
                 picking_template.with_context(lang=picking.partner_id.commercial_partner_id.lang).send_mail(picking.id)
         return result
 
+    @api.multi
+    def action_confirm(self):
+        res = super(StockPicking, self).action_confirm()
+        self.filtered(lambda picking: picking.picking_type_code == 'outgoing' and picking.location_id.usage=='internal' and picking.state == 'confirmed') \
+                .mapped('move_lines')._action_assign()
+        return res
+
+
+
 
 class StockMoveLine(models.Model):
 


### PR DESCRIPTION
-  [IMP] picking_incidences: corregido duplicación de ubicación destino, y mostrar la de origen en albaranes de entrada
-  [IMP] purchase_picking: cuando cambia la ubicación del albarán cambia la de los movimientos
-  [IMP] picking_incidences,stock_custom: Eliminada restricción de visibilidad de ubicación origen y destino y reserva automática al crear un albarán de salida a mano.




