### PR TITLE
[HOTFIX] Recuperar función antigua de lectura PEC

### DIFF
--- a/project-addons/scripts/mail_thread_pec.diff
+++ b/project-addons/scripts/mail_thread_pec.diff
@@ -1,0 +1,182 @@
+diff --git a/l10n_it_fatturapa_pec/models/mail_thread.py b/l10n_it_fatturapa_pec/models/mail_thread.py
+index b56c6b6..f747e0b 100644
+--- a/l10n_it_fatturapa_pec/models/mail_thread.py
++++ b/l10n_it_fatturapa_pec/models/mail_thread.py
+@@ -44,18 +44,66 @@ class MailThread(models.AbstractModel):
+             message.get('Reply-To', ''),
+             message.get('From', ''),
+             message.get('Return-Path', '')]
+-        ):
++               ):
+             _logger.info("Processing FatturaPA PEC with Message-Id: "
+                          "{}".format(message.get('Message-Id')))
++
++            fatturapa_regex = re.compile(FATTURAPA_IN_REGEX)
+             fatturapa_attachments = [x for x in message_dict['attachments']
+                                      if fatturapa_regex.match(x.fname)]
++            response_regex = re.compile(RESPONSE_MAIL_REGEX)
+             response_attachments = [x for x in message_dict['attachments']
+                                     if response_regex.match(x.fname)]
+             if response_attachments and fatturapa_attachments:
+-                return self.manage_pec_fe_attachments(
+-                    message, message_dict, response_attachments)
++                # this is an electronic invoice
++                if len(response_attachments) > 1:
++                    _logger.info(
++                        'More than 1 message found in mail of incoming '
++                        'invoice')
++                message_dict['model'] = 'fatturapa.attachment.in'
++                message_dict['record_name'] = message_dict['subject']
++                message_dict['res_id'] = 0
++                attachment_ids = self._message_post_process_attachments(
++                    message_dict['attachments'], [], message_dict)
++                for attachment in self.env['ir.attachment'].browse(
++                    [att_id for m, att_id in attachment_ids]):
++                    if fatturapa_regex.match(attachment.name):
++                        self.create_fatturapa_attachment_in(attachment)
++
++                message_dict['attachment_ids'] = attachment_ids
++                self.clean_message_dict(message_dict)
++
++                # model and res_id are only needed by
++                # _message_post_process_attachments: we don't attach to
++                del message_dict['model']
++                del message_dict['res_id']
++
++                # message_create_from_mail_mail to avoid to notify message
++                # (see mail.message.create)
++                self.env['mail.message'].with_context(
++                    message_create_from_mail_mail=True).create(message_dict)
++                _logger.info('Routing FatturaPA PEC E-Mail with Message-Id: {}'
++                             .format(message.get('Message-Id')))
++                return []
++
+             else:
+-                return self.manage_pec_sdi_notification(message, message_dict)
++                # this is an SDI notification
++                message_dict = self.env['fatturapa.attachment.out'] \
++                    .parse_pec_response(message_dict)
++
++                message_dict['record_name'] = message_dict['subject']
++                attachment_ids = self._message_post_process_attachments(
++                    message_dict['attachments'], [], message_dict)
++                message_dict['attachment_ids'] = attachment_ids
++                self.clean_message_dict(message_dict)
++
++                # message_create_from_mail_mail to avoid to notify message
++                # (see mail.message.create)
++                self.env['mail.message'].with_context(
++                    message_create_from_mail_mail=True).create(message_dict)
++                _logger.info('Routing FatturaPA PEC E-Mail with Message-Id: {}'
++                             .format(message.get('Message-Id')))
++                return []
+ 
+         elif self._context.get('fetchmail_server_id', False):
+             # This is not an email coming from SDI
+@@ -64,18 +112,53 @@ class MailThread(models.AbstractModel):
+             if fetchmail_server.is_fatturapa_pec:
+                 att = self.find_attachment_by_subject(message_dict['subject'])
+                 if att:
+-                    return self.manage_pec_sdi_response(att, message_dict)
+-                raise UserError(_(
+-                    "PEC message \"%s\" has been read "
+-                    "but not processed, as not related to an "
+-                    "e-invoice.\n"
+-                    "Please check PEC mailbox %s, at server %s,"
+-                    " with user %s."
+-                ) % (
+-                    message_dict['subject'],
+-                    fetchmail_server.name, fetchmail_server.server,
+-                    fetchmail_server.user
+-                ))
++                    # This a PEC response (CONSEGNA o ACCETTAZIONE)
++                    # related to a message sent to SDI by us
++                    message_dict['model'] = 'fatturapa.attachment.out'
++                    message_dict['res_id'] = att.id
++                    self.clean_message_dict(message_dict)
++                    self.env['mail.message'].with_context(
++                        message_create_from_mail_mail=True).create(
++                        message_dict)
++                else:
++                    _logger.info(
++                        'Can\'t route PEC E-Mail with Message-Id: {}'.format(
++                            message.get('Message-Id'))
++                    )
++                    if fetchmail_server.e_inv_notify_partner_ids:
++                        self.env['mail.mail'].create({
++                            'subject': _(
++                                "PEC message [%s] not processed"
++                            ) % message.get('Subject'),
++                            'body_html': _(
++                                "<p>"
++                                "PEC message with Message-Id %s has been read "
++                                "but not processed, as not related to an "
++                                "e-invoice.</p>"
++                                "<p>Please check PEC mailbox %s, at server %s,"
++                                " with user %s</p>"
++                            ) % (
++                                             message.get('Message-Id'),
++                                             fetchmail_server.name, fetchmail_server.server,
++                                             fetchmail_server.user
++                                         ),
++                            'recipient_ids': [(
++                                6, 0,
++                                fetchmail_server.e_inv_notify_partner_ids.ids
++                            )]
++                        })
++                        _logger.info(
++                            'Notifying partners %s about message with '
++                            'Message-Id: %s' % (
++                                fetchmail_server.e_inv_notify_partner_ids.ids,
++                                message.get('Message-Id')))
++                    else:
++                        _logger.error(
++                            'Can\'t notify anyone about not processed '
++                            'PEC E-Mail with Message-Id: {}'.format(
++                                message.get('Message-Id')))
++                return []
++
+         return super(MailThread, self).message_route(
+             message, message_dict, model=model, thread_id=thread_id,
+             custom_values=custom_values)
+@@ -167,21 +250,13 @@ class MailThread(models.AbstractModel):
+                 return fatturapa_attachment_out
+         return attachment_out_model.browse()
+ 
+-    def create_fatturapa_attachment_in(self, attachment, message_dict=None):
++    def create_fatturapa_attachment_in(self, attachment):
+         decoded = base64.b64decode(attachment.datas)
++        fatturapa_regex = re.compile(FATTURAPA_IN_REGEX)
+         fatturapa_attachment_in = self.env['fatturapa.attachment.in']
+         fetchmail_server_id = self.env.context.get('fetchmail_server_id')
+-        received_date = False
+-        if message_dict is not None and 'date' in message_dict:
+-            received_date = message_dict['date']
+         company_id = False
+         e_invoice_user_id = False
+-        # The incoming supplier e-bill doesn't carry which company
+-        # we must use to create the given fatturapa.attachment.in record,
+-        # so we expect fetchmail_server_id coming in the context
+-        # see fetchmail.py.
+-        # With this information we search which SDI is actually using it,
+-        # finally the SDI contain both company and user we would need to use
+         if fetchmail_server_id:
+             sdi_chan = self.env['sdi.channel'].search([
+                 ('fetch_pec_server_id', '=', fetchmail_server_id)], limit=1)
+@@ -208,9 +283,8 @@ class MailThread(models.AbstractModel):
+                             fatturapa_attachment_in.create({
+                                 'name': file_name,
+                                 'datas_fname': file_name,
+-                                'datas': base64.encodestring(inv_file.read()),
++                                'datas': base64.encodebytes()(inv_file.read()),
+                                 'company_id': company_id,
+-                                'e_invoice_received_date': received_date,
+                             })
+         else:
+             fatturapa_atts = fatturapa_attachment_in.search(
+@@ -223,5 +297,4 @@ class MailThread(models.AbstractModel):
+                 fatturapa_attachment_in.create({
+                     'ir_attachment_id': attachment.id,
+                     'company_id': company_id,
+-                    'e_invoice_received_date': received_date,
+                 })


### PR DESCRIPTION
En la actualización que introdujimos el otro día, han cambiado la función que lee la bandeja de entrada del PEC, ahora, cuando encuentra un correo que no es lo que espera, lanza una excepción. Esto hace que se nos envíen cada 5 minutos un correo de aviso  porque parece ser que lee una y otra vez los mismos correos y además cada vez que hace eso, inactiva el servidor de entrada del PEC. En el script recuperamos la función antigua hasta que lo arreglen.
Hay una issue abierta de otro usuario en el repo de la oca de italia, pero no se si llegará a buen puerto.