### PR TITLE
[Important] mejora en tiempo de borrado de sale_order_line

### DIFF
--- a/project-addons/picking_invoice_pending/models/sale.py
+++ b/project-addons/picking_invoice_pending/models/sale.py
@@ -1,24 +1,27 @@
 from odoo import models, fields, api, _
 
+
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
+
     @api.multi
     def action_invoice_create(self):
-        lines=self.env['sale.order.line']
+        lines = self.env['sale.order.line']
         for order in self:
-            promo_lines= order.mapped('order_line').filtered(lambda x: x.original_line_id_promo)
+            promo_lines = order.mapped('order_line').filtered(lambda x: x.original_line_id_promo)
             for line in promo_lines:
-                #For example in 4x3 promo, line.promo_qty_split is equals to 4
-                #because this field show us the minimun qty of product for which the promo is applied
-                qty_to_invoice=(line.original_line_id_promo.qty_invoiced +
-                                line.original_line_id_promo.qty_to_invoice)//line.promo_qty_split - line.qty_invoiced
-                line.qty_to_invoice=qty_to_invoice
-                if qty_to_invoice==0:
-                    lines+=line
-        res= super(SaleOrder, self).action_invoice_create()
+                original_line_id_promo = self.env['sale.order.line'].browse(line.original_line_id_promo)
+                # For example in 4x3 promo, line.promo_qty_split is equals to 4
+                # because this field show us the minimum qty of product for which the promo is applied
+                qty_to_invoice = (original_line_id_promo.qty_invoiced +
+                                  original_line_id_promo.qty_to_invoice)//line.promo_qty_split - line.qty_invoiced
+                line.qty_to_invoice = qty_to_invoice
+                if qty_to_invoice == 0:
+                    lines += line
+        res = super(SaleOrder, self).action_invoice_create()
         for line in lines:
-            if line.product_uom_qty!=line.qty_invoiced:
-                line.qty_to_invoice=line.product_uom_qty-line.qty_invoiced
+            if line.product_uom_qty != line.qty_invoiced:
+                line.qty_to_invoice = line.product_uom_qty-line.qty_invoiced
         return res
 
 

--- a/project-addons/picking_invoice_pending/models/sale.py
+++ b/project-addons/picking_invoice_pending/models/sale.py
@@ -13,11 +13,12 @@ class SaleOrder(models.Model):
                 original_line_id_promo = self.env['sale.order.line'].browse(line.original_line_id_promo)
                 # For example in 4x3 promo, line.promo_qty_split is equals to 4
                 # because this field show us the minimum qty of product for which the promo is applied
-                qty_to_invoice = (original_line_id_promo.qty_invoiced +
-                                  original_line_id_promo.qty_to_invoice)//line.promo_qty_split - line.qty_invoiced
-                line.qty_to_invoice = qty_to_invoice
-                if qty_to_invoice == 0:
-                    lines += line
+                if original_line_id_promo:
+                    qty_to_invoice = (original_line_id_promo.qty_invoiced +
+                                      original_line_id_promo.qty_to_invoice)//line.promo_qty_split - line.qty_invoiced
+                    line.qty_to_invoice = qty_to_invoice
+                    if qty_to_invoice == 0:
+                        lines += line
         res = super(SaleOrder, self).action_invoice_create()
         for line in lines:
             if line.product_uom_qty != line.qty_invoiced:

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -309,7 +309,7 @@ class PromotionsRulesActions(models.Model):
         return order_line.write(vals)
 
     def create_y_line_axb(self, order, order_line, quantity):
-        product_id=order_line.product_id
+        product_id = order_line.product_id
         vals = {
             'order_id': order.id,
             'sequence': order_line.sequence,

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -21,7 +21,7 @@ class SaleOrderLine(models.Model):
     product_tags = fields.Char(compute="_compute_product_tags", string='Tags')
     web_discount = fields.Boolean()
     accumulated_promo = fields.Boolean(default=False)
-    original_line_id_promo = fields.Many2one('sale.order.line', "Original line", ondelete='cascade')
+    original_line_id_promo = fields.Many2one('sale.order.line', "Original line")
     promo_qty_split = fields.Integer(help="It is the minimum quantity of product for which this promo is applied")
     old_discount = fields.Float(copy=False)
     old_price = fields.Float(copy=False)

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -21,7 +21,7 @@ class SaleOrderLine(models.Model):
     product_tags = fields.Char(compute="_compute_product_tags", string='Tags')
     web_discount = fields.Boolean()
     accumulated_promo = fields.Boolean(default=False)
-    original_line_id_promo = fields.Many2one('sale.order.line', "Original line")
+    original_line_id_promo = fields.Integer("Original line")
     promo_qty_split = fields.Integer(help="It is the minimum quantity of product for which this promo is applied")
     old_discount = fields.Float(copy=False)
     old_price = fields.Float(copy=False)


### PR DESCRIPTION
Este cambio es debido a que hemos metido varias promociones de las que añaden líneas al pedido y al recalcular las promociones tarda muchísimo en borrar las líneas de promo. Sabemos que rompemos la gracia de una base de datos relacional, pero el ahorro en tiempo a la hora de hacer un delete parece considerable.