### PR TITLE
[HOTFIX] Retraso de promociones

### DIFF
--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -633,3 +633,8 @@ msgstr "Descuento por el programa de puntos en una Marca"
 #, python-format
 msgid "Discount % on Brand accumulated (Price Unit)"
 msgstr "Descuento acumulado % en marca (Precio Unidad)"
+
+#. module: sale_promotions_extend
+#: model:ir.model.fields,field_description:sale_promotions_extend.field_promos_rules_apply_at_confirm
+msgid "Apply at confirm"
+msgstr "Aplicar al confirmar"

--- a/project-addons/sale_promotions_extend/i18n/it.po
+++ b/project-addons/sale_promotions_extend/i18n/it.po
@@ -627,3 +627,8 @@ msgstr "Prodotti gratuiti per unità"
 #, python-format
 msgid "Discount % on Brand accumulated (Price Unit)"
 msgstr "Sconto accumulato % sulla marca (Prezzo Unità)"
+
+#. module: sale_promotions_extend
+#: model:ir.model.fields,field_description:sale_promotions_extend.field_promos_rules_apply_at_confirm
+msgid "Apply at confirm"
+msgstr "Applicare al confermare"

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -429,7 +429,10 @@ class PromotionsRules(models.Model):
 
     special_promo = fields.Boolean("Special Promo")
 
-    line_description = fields.Char(translate=True,string="Desciption in lines",help="This field is shown in the description field of the invoice,picking and sale lines")
+    line_description = fields.Char(translate=True, string="Desciption in lines",
+                                   help="This field is shown in the description field of the invoice,picking and sale lines")
+
+    apply_at_confirm = fields.Boolean("Apply at confirm")
 
     @api.model
     def apply_special_promotions(self, order):
@@ -447,3 +450,12 @@ class PromotionsRules(models.Model):
                 if promotion_rule.stop_further:
                     return True
         return True
+
+    @api.model
+    def _get_promotions_domain(self, order):
+        if self.env.context.get('is_confirm', False):
+            return super()._get_promotions_domain(order)
+        else:
+            domain = super()._get_promotions_domain(order)
+            domain += [('apply_at_confirm', '=', False)]
+            return domain

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -1,6 +1,6 @@
 # © 2019 Comunitea
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class SaleOrderLine(models.Model):
@@ -92,3 +92,10 @@ class SaleOrder(models.Model):
                             'old_discount': 0.00,
                             'accumulated_promo': False})
         return res
+
+    @api.multi
+    def action_confirm(self):
+        ctx = dict(self._context)
+        ctx['is_confirm'] = True
+        order = self.with_context(ctx)
+        return super(SaleOrder, order).action_confirm()

--- a/project-addons/sale_promotions_extend/views/rule.xml
+++ b/project-addons/sale_promotions_extend/views/rule.xml
@@ -10,6 +10,7 @@
             </field>
             <field name="stop_further" position="after">
                 <field name="special_promo"/>
+                <field name="apply_at_confirm"/>
             </field>
         </field>
     </record>

--- a/project-addons/sale_promotions_extend/views/sale_view.xml
+++ b/project-addons/sale_promotions_extend/views/sale_view.xml
@@ -31,6 +31,15 @@
             <field name="company_id" position="after">
                 <field name="no_promos"/>
             </field>
+            <!-- TODO: Temporal -->
+            <field name="order_line" position="after">
+                <p style="color:red" attrs="{'invisible': ['|','|',('amount_untaxed','&lt;','500'),('state','in',('sale','done','cancel')),('no_promos','=',True)]}">
+                    Promo: Se añadirá un 50XMASK-HYGIENIC gratis al tramitar
+                </p>
+                <p style="color:red" attrs="{'invisible': ['|','|',('amount_untaxed','&lt;','1000'),('state','in',('sale', 'done', 'cancel')),('no_promos','=',True)]}">
+                    Promo: Se añadirá un UT300R + BATT-6LR61 gratis al tramitar
+                </p>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Hemos metido un parámetro para que las promociones que añadan líneas se ejecuten solo al tramitar.
Hemos añadido también unos mensajes en el pedido que son temporales hasta que demos con el problema y podamos volver a aplicarlas con normalidad.