### PR TITLE
Eliminadas reservas al vuelo

### DIFF
--- a/project-addons/reserve_without_save_sale/__init__.py
+++ b/project-addons/reserve_without_save_sale/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from . import controllers
 from . import models
 from . import wizard

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -52,7 +52,7 @@ class SaleOrder(models.Model):
                      if line[2] and line[2].get('product_uom_qty') and line[0] == 1]  # 1 = write, 0 = create
             if lines:
                 self.env['sale.order.line'].browse(lines).\
-                    filtered(lambda r: r.product_id and r.product_id.type != 'service'
+                    filtered(lambda r: r.product_id and r.product_id.type == 'product'
                                        and r.promotion_line is not True).\
                     stock_reserve()
         return res
@@ -95,7 +95,7 @@ class SaleOrderLine(models.Model):
     def _compute_is_stock_reservation(self):
         for line in self:
             reservable = False
-            if not (line.state not in ('draft', 'reserve') or line._get_procure_method() == 'make_to_order' or not line.product_id or line.product_id.type == 'service'):
+            if not (line.state not in ('draft', 'reserve') or line._get_procure_method() == 'make_to_order' or not line.product_id or line.product_id.type != 'product'):
                 reservable = True
             line.is_stock_reservable = reservable
 
@@ -106,7 +106,7 @@ class SaleOrderLine(models.Model):
     @api.model
     def create(self, vals):
         res = super().create(vals)
-        if res.product_id and res.product_id.type != 'service' \
+        if res.product_id and res.product_id.type == 'product' \
                 and res.promotion_line is not True and res.order_id.state == 'reserve':
             res.stock_reserve()
         return res

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -46,7 +46,6 @@ class SaleOrder(models.Model):
     @api.multi
     def write(self, vals):
         res = super().write(vals)
-        print(vals)
         if vals.get('order_line', False):
             lines = [line[1] for line in vals['order_line']
                      if line[2] and line[2].get('product_uom_qty') and line[0] == 1]  # 1 = write, 0 = create

--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -7,6 +7,7 @@ import logging
 
 _logger = logging.getLogger(__name__)
 
+
 class StockReservation(models.Model):
 
     _name = 'stock.reservation'
@@ -42,20 +43,6 @@ class StockReservation(models.Model):
         res.move_id.user_id = res.user_id
         if vals.get('sequence') and res.move_id:
             res.move_id.sequence = vals['sequence']
-        if vals.get('unique_js_id', False) and \
-                not vals.get('sale_line_id', False):
-            with registry(self.env.cr.dbname).cursor() as new_cr:
-                new_env = api.Environment(new_cr, self.env.uid,
-                                          self.env.context)
-
-                new_env.cr.execute("select id from sale_order_line where "
-                                   "unique_js_id = '%s'" % vals['unique_js_id']
-                                   )
-
-                lines = new_env.cr.fetchone()
-                if lines:
-                    self.with_env(new_env).write({'sale_line_id': lines[0]})
-                new_env.cr.commit()
         return res
 
     def write(self, vals):

--- a/project-addons/reserve_without_save_sale/views/sale.xml
+++ b/project-addons/reserve_without_save_sale/views/sale.xml
@@ -5,14 +5,6 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/form/group/group/field[@name='product_id']" position="after">
-                <field name="unique_js_id" invisible="0"/>
-                <field name="temp_unique_js_id" invisible="0"/>
-            </xpath>
-            <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']" position="after">
-                <field name="unique_js_id" invisible="1"/>
-                <field name="temp_unique_js_id" invisible="1"/>
-            </xpath>
             <xpath expr="//button[@name='action_confirm'][1]" position="attributes">
                 <attribute name="attrs"></attribute>
                 <attribute name="invisible">True</attribute>
@@ -76,12 +68,6 @@
             </field>
         </field>
     </record>
-
-    <template id="assets_backend" name="sales_team assets" inherit_id="web.assets_backend">
-            <xpath expr="." position="inside">
-                <script type="text/javascript" src="/reserve_without_save_sale/static/src/js/sale_order_line.js"></script>
-            </xpath>
-    </template>
 
     <record id="view_order_form_visibility_reserve_button" model="ir.ui.view">
         <field name="name">sale.order.form.reserve.button</field>


### PR DESCRIPTION
-  [IMP]reserve_without_save_sale: eliminada la posibilidad de reservar mientras se edita el pedido, ahora se reserva solamente al crear y al guardar.
- [FIX]reserve_without_save_sale: ahora tampoco reserva consumibles
- [FIX]reserve_without_save_sale: eliminado print de debug