### PR TITLE
Se vuelve a aplicar varias promos cruzadas a la vez.

### DIFF
--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -377,8 +377,8 @@ class PromotionsRulesActions(models.Model):
                 price_subtotal += order_line.price_subtotal
         if price_subtotal == 0:
             return True
-        rule = rule_obj.search([('name', 'ilike', self.arguments)])
-        bags = bag_obj.search([('partner_id','=',order.partner_id.id),('point_rule_id','=',rule.id),('applied_state','=','no')])
+        rules = rule_obj.search([('name', 'in', eval(self.arguments))])
+        bags = bag_obj.search([('partner_id','=',order.partner_id.id),('point_rule_id','in',rules.ids),('applied_state','=','no')])
         points = sum([x.points for x in bags])
         if points <= 0:
             return True
@@ -389,9 +389,8 @@ class PromotionsRulesActions(models.Model):
         else:
             bags_to_change_status = self.env['res.partner.point.programme.bag']
             cont_point_applied = 0
-            if rule.integer_points:
-                price_subtotal = int(price_subtotal)
             for bag in bags:
+                rule = bag.point_rule_id
                 if price_subtotal<=cont_point_applied:
                     break
                 bag_points=bag.points


### PR DESCRIPTION
- [REV] sale_promotions_extend: se vulven a aplicar varias promos cruzadas a la vez
Hola Omar, hemos estado haciendo con el profile de Odoo una comparativa de tiempos, y prácticamente no sube nada entre ambos cambios, por lo que lo volvemos a subir.