### PR TITLE
Bloqueo pedidos Magreb a partir de un límite

### DIFF
--- a/project-addons/block_invoices/data/parameters.xml
+++ b/project-addons/block_invoices/data/parameters.xml
@@ -4,4 +4,8 @@
         <field name="key">margin.lock.limit</field>
         <field name="value"></field>
     </record>
+    <record id="magreb_limit_without_block" model="ir.config_parameter">
+        <field name="key">magreb.limit.without.block</field>
+        <field name="value">2000</field>
+    </record>
 </odoo>

--- a/project-addons/block_invoices/models/sale_order.py
+++ b/project-addons/block_invoices/models/sale_order.py
@@ -46,6 +46,8 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
+        import ipdb
+        ipdb.set_trace()
         if not self.env.context.get('bypass_risk', False) or self.env.context.get('force_check', False):
             message = ''
             for partner in self.partner_id.get_partners_to_check():
@@ -62,7 +64,8 @@ class SaleOrder(models.Model):
                 if message:
                     raise exceptions.Warning(message)
 
-            if (self.team_id.name == 'Magreb' or self.partner_id.team_id.name == 'Magreb') \
+            if self.amount_total>=int(self.env['ir.config_parameter'].sudo().get_param('magreb.limit.without.block')) \
+                    and (self.team_id.name == 'Magreb' or self.partner_id.team_id.name == 'Magreb') \
                     and not self.allow_confirm_blocked_magreb:
                 message = _('Order blocked. Approve pending')
                 raise exceptions.Warning(message)

--- a/project-addons/block_invoices/models/sale_order.py
+++ b/project-addons/block_invoices/models/sale_order.py
@@ -46,8 +46,6 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
-        import ipdb
-        ipdb.set_trace()
         if not self.env.context.get('bypass_risk', False) or self.env.context.get('force_check', False):
             message = ''
             for partner in self.partner_id.get_partners_to_check():


### PR DESCRIPTION
-  [IMP] block_invoices: Ahora solo se bloquean pedidos de Magreb si el total del pedido es mayor a un parámetro
-  [REM] block_invoices: eliminado ipdb

