### PR TITLE
Días de pago en pedidos prepago

### DIFF
--- a/project-addons/prepaid_order_discount/models/__init__.py
+++ b/project-addons/prepaid_order_discount/models/__init__.py
@@ -16,3 +16,4 @@
 ##############################################################################
 from . import sale
 from . import rules
+from . import invoice

--- a/project-addons/prepaid_order_discount/models/invoice.py
+++ b/project-addons/prepaid_order_discount/models/invoice.py
@@ -1,0 +1,12 @@
+from odoo import models, api
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.onchange('payment_term_id', 'date_invoice', 'value_date')
+    def _onchange_payment_term_date_invoice(self):
+        super()._onchange_payment_term_date_invoice()
+        if self.sale_order_ids and len(self.sale_order_ids) == 1:
+            if self.sale_order_ids.prepaid_option:
+                self.date_due = self.date_invoice


### PR DESCRIPTION
-  [IMP]prepaid_order_discount: si el pedido es prepago, se ignoran los días de pago configurados en el cliente

