### PR TITLE
Prevención de facturas de compra como out_invoice

### DIFF
--- a/project-addons/custom_emails_company/models/invoice.py
+++ b/project-addons/custom_emails_company/models/invoice.py
@@ -10,6 +10,9 @@ class AccountInvoice(models.Model):
         layout = \
             'account.mail_template_data_notification_email_account_invoice'
         for invoice in self:
+            if invoice.type == 'out_invoice' and invoice.journal_id.type == 'purchase':
+                # To prevent possible errors
+                invoice.type = 'in_invoice'
             if not invoice.not_send_email and invoice.type in ('out_invoice', 'out_refund'):
                 try:
                     template = invoice.env.\


### PR DESCRIPTION
[FIX] custom_emails_company: pequeño parche para que no se creen facturas de compra como facturas de venta