### PR TITLE
Aviso peso DHL y ondelete líneas personalización

### DIFF
--- a/project-addons/kitchen/models/kitchen_customization.py
+++ b/project-addons/kitchen/models/kitchen_customization.py
@@ -251,7 +251,7 @@ class KitchenCustomizationLine(models.Model):
     product_qty = fields.Float(required=1)
     customization_id = fields.Many2one('kitchen.customization', ondelete='cascade', index=True,
                                        copy=False)
-    sale_line_id = fields.Many2one('sale.order.line')
+    sale_line_id = fields.Many2one('sale.order.line', ondelete='cascade')
     state = fields.Selection([
         ('draft', 'New'),
         ('waiting','Waiting Availability'),

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -293,7 +293,7 @@ class SaleOrder(models.Model):
         return True
 
     def check_weight(self,onchange=False):
-        dhl_flight = self.transporter_id.name == "DHL" and self.service_id.name == "UE Aéreo (U)"
+        dhl_flight = self.transporter_id.name == "DHL" and self.service_id.by_air
         canary = self.partner_shipping_id and \
                  not self.env.context.get("bypass_canary_max_weight", False) and \
                  self.partner_shipping_id.state_id.id in (

--- a/project-addons/transportation/i18n/es.po
+++ b/project-addons/transportation/i18n/es.po
@@ -372,3 +372,8 @@ msgstr "Envío"
 #: model:ir.model.fields,field_description:transportation.field_sale_order_delivery_type
 msgid "Delivery type"
 msgstr "Tipo de envío"
+
+#. module: transportation
+#: model:ir.model.fields,field_description:transportation.field_transportation_service_by_air
+msgid "By Air"
+msgstr "Aéreo"

--- a/project-addons/transportation/i18n/it.po
+++ b/project-addons/transportation/i18n/it.po
@@ -373,3 +373,8 @@ msgstr "Invio"
 #: model:ir.model.fields,field_description:transportation.field_sale_order_delivery_type
 msgid "Delivery type"
 msgstr "Tipo de invio"
+
+#. module: transportation
+#: model:ir.model.fields,field_description:transportation.field_transportation_service_by_air
+msgid "By Air"
+msgstr "Aerea"

--- a/project-addons/transportation/models/transportation.py
+++ b/project-addons/transportation/models/transportation.py
@@ -44,3 +44,4 @@ class TransportService(models.Model):
                                        'service_id',
                                        'transporter_id',
                                        'Transporters')
+    by_air = fields.Boolean()

--- a/project-addons/transportation/views/transportation_view.xml
+++ b/project-addons/transportation/views/transportation_view.xml
@@ -71,6 +71,7 @@
             <field name="arch" type="xml">
                 <tree string="Transportation services">
                     <field name="name"/>
+                    <field name="by_air"/>
                 </tree>
             </field>
         </record>
@@ -83,6 +84,7 @@
                     <sheet>
                         <group>
                             <field name="name"/>
+                            <field name="by_air"/>
                             <field name="transporter_ids">
                                 <tree string="Transporter">
                                     <field name="name"/>


### PR DESCRIPTION
 - [IMP] transportation: añadido campo que determina si un servicio de transporte es aéreo
-  [IMP] sale_custom: bloquear pedido para todos los servicios de DHl que sean aéreos
- [FIX] kitchen: borrar líneas de la personalización al borrarlas del pedido




