### PR TITLE
Separar acción reservar del aplicar promociones

### DIFF
--- a/project-addons/reserve_without_save_sale/i18n/es.po
+++ b/project-addons/reserve_without_save_sale/i18n/es.po
@@ -43,6 +43,11 @@ msgstr "Parcialmente disponible"
 msgid "Orders with released reservation"
 msgstr "Pedidos con reservas liberadas"
 
+#. module: sale_line_add_auxiliar_field
+#: model:ir.ui.view,arch_db:reserve_without_save_sale.sale_line_add_auxiliar_field
+msgid "Reserve Stock"
+msgstr "Reservar stock"
+
 #. module: reserve_without_save_sale
 #: model:mail.template,body_html:reserve_without_save_sale.mail_template_release_reservations_user
 msgid "\n"

--- a/project-addons/reserve_without_save_sale/i18n/it.po
+++ b/project-addons/reserve_without_save_sale/i18n/it.po
@@ -43,6 +43,11 @@ msgstr "Parzialmente disponibile"
 msgid "Orders with released reservation"
 msgstr "Ordini con prenotazioni rilasciate"
 
+#. module: sale_line_add_auxiliar_field
+#: model:ir.ui.view,arch_db:reserve_without_save_sale.sale_line_add_auxiliar_field
+msgid "Reserve Stock"
+msgstr "Riservare stock"
+
 #. module: reserve_without_save_sale
 #: model:mail.template,body_html:reserve_without_save_sale.mail_template_release_reservations_user
 msgid "\n"

--- a/project-addons/reserve_without_save_sale/views/sale.xml
+++ b/project-addons/reserve_without_save_sale/views/sale.xml
@@ -34,7 +34,7 @@
                 <button name="order_reserve"
                     type="object"
                     string="Reserve Stock"
-                    states="draft,sent"
+                    states="draft,sent,reserve"
                     />
             </button>
             <button name="release_all_stock_reservation" position="replace"></button>

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -73,9 +73,6 @@ class SaleOrder(models.Model):
             self.env['promos.rules'].apply_special_promotions(self)
             res = False
 
-        if order.state == 'reserve':
-            order.order_reserve()
-
         taxes = order.order_line.filtered(
             lambda l: len(l.tax_id) > 0)[0].tax_id
         for line in order.order_line:


### PR DESCRIPTION
- [IMP] Separado el aplicar promociones con reservar y añadido el botón reservar
- [IMP] Añadida traducción