### PR TITLE
Nuevos campos en sincro IT-ES

### DIFF
--- a/project-addons/automatize_edi_it/i18n/es.po
+++ b/project-addons/automatize_edi_it/i18n/es.po
@@ -41,3 +41,13 @@ msgstr "A facturar Completo"
 #: model:ir.ui.view,arch_db:automatize_edi_it.view_purchase_order_filter_inherit_search
 msgid "To Invoice Incomplete"
 msgstr "A facturar Incompleto"
+
+#. module: automatize_edi_it
+#: model:ir.model.fields,field_description:automatize_edi_it.field_purchase_order_es_sale_order
+msgid "Amount To Invoice Es"
+msgstr "Venta ES"
+
+#. module: automatize_edi_it
+#: model:ir.model.fields,field_description:automatize_edi_it.field_purchase_order_amount_to_invoice_it
+msgid "To Invoice"
+msgstr "A facturar"

--- a/project-addons/automatize_edi_it/i18n/it.po
+++ b/project-addons/automatize_edi_it/i18n/it.po
@@ -41,3 +41,8 @@ msgstr "Attesa fattura Completo"
 #: model:ir.ui.view,arch_db:automatize_edi_it.view_purchase_order_filter_inherit_search
 msgid "To Invoice Incomplete"
 msgstr "Attesa fattura Incompleto"
+
+#. module: automatize_edi_it
+#: model:ir.model.fields,field_description:automatize_edi_it.field_purchase_order_es_sale_order
+msgid "Amount To Invoice Es"
+msgstr "Ordine ES"

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -42,11 +42,18 @@ class PurchaseOrder(models.Model):
     @api.multi
     def _get_to_invoice_diff(self):
         for order in self:
-            order.diff_to_invoice = order.amount_to_invoice_es - order.amount_total
+            order.diff_to_invoice = order.amount_to_invoice_es - order.amount_to_invoice_it
+
+    @api.multi
+    def _get_amt_to_invoice(self):
+        for order in self:
+            order.amount_to_invoice_it = sum([l.qty_received * l.price_unit for l in order.order_line])
 
     force_confirm = fields.Boolean()
     amount_to_invoice_es = fields.Monetary()
     diff_to_invoice = fields.Monetary(compute='_get_to_invoice_diff', store=True)
+    es_sale_order = fields.Char('ES Sale')
+    amount_to_invoice_it = fields.Monetary('To Invoice', compute='_get_amt_to_invoice', store=False)
 
     @api.model
     def _check_picking_to_process(self):
@@ -86,20 +93,22 @@ class PurchaseOrder(models.Model):
         odoo_es.login(server.server_db, server.login, server.password)
 
         amt_to_invoice = 0.0
+        es_sale = None
         order_es_id = odoo_es.env['sale.order'].search([('client_order_ref', '=', purchase_ref), ('partner_id', '=', 245247)])
         if order_es_id:
             order_es = odoo_es.env['sale.order'].browse(order_es_id)
+            es_sale = order_es.name
             if order_es.invoice_status == 'to invoice':
                 for line in order_es.order_line:
                     amt_to_invoice += line.qty_to_invoice * line.price_unit
-        return amt_to_invoice
+        return amt_to_invoice, es_sale
 
     def cron_check_qty_to_invoice_lx(self):
         purchases = self.search([('invoice_status', '=', 'to invoice')])
 
         for purchase in purchases:
             if purchase.amount_total != purchase.amount_to_invoice_es:
-                purchase.amount_to_invoice_es = self._get_qty_to_invoice_es(purchase.name)
+                purchase.amount_to_invoice_es, purchase.es_sale_order = self._get_qty_to_invoice_es(purchase.name)
 
 
 

--- a/project-addons/automatize_edi_it/views/purchase_view.xml
+++ b/project-addons/automatize_edi_it/views/purchase_view.xml
@@ -6,10 +6,12 @@
         <field name="inherit_id" ref="purchase.purchase_order_tree"/>
         <field name="arch" type="xml">
             <field name="amount_total" position="after">
+                <field name="amount_to_invoice_it"/>
                 <field name="amount_to_invoice_es"/>
+                <field name="es_sale_order"/>
             </field>
             <xpath expr="//tree" position="attributes">
-                <attribute name="decoration-danger">amount_total != amount_to_invoice_es</attribute>
+                <attribute name="decoration-danger">amount_to_invoice_it != amount_to_invoice_es</attribute>
             </xpath>
         </field>
     </record>

--- a/project-addons/picking_sync_it/__manifest__.py
+++ b/project-addons/picking_sync_it/__manifest__.py
@@ -5,7 +5,8 @@
     'author': 'Visiotech',
     'category': '',
     'depends': ['stock', 'base_synchro', 'picking_incidences', 'queue_job'],
-    'data': ["views/stock_picking_view.xml"],
+    'data': ["views/stock_picking_view.xml",
+             "views/email_template.xml"],
     'active': False,
     'installable': True,
 }

--- a/project-addons/picking_sync_it/models/stock.py
+++ b/project-addons/picking_sync_it/models/stock.py
@@ -49,3 +49,20 @@ class StockPicking(models.Model):
                     picking.with_incidences = True
                     picking.move_type = 'direct'
                     picking.action_accept_ready_qty()
+            elif picking.location_id.name == 'Tránsito Italia' and picking.state != 'assigned':
+                import ipdb
+                ipdb.set_trace()
+                mail_pool = self.env['mail.mail']
+                context = self._context.copy()
+                context.pop('default_state', False)
+                context['message_warn'] = 'Entrada %s recibida. Imposible notificar finalización. Revisar el pedido %s' \
+                                          % (self.name, order)
+
+                template_id = self.env.ref('picking_sync_it.email_template_sync_pick_error')
+
+                if template_id:
+                    mail_id = template_id.with_context(context).send_mail(self.id)
+                    if mail_id:
+                        mail_id_check = mail_pool.browse(mail_id)
+                        mail_id_check.with_context(context).send()
+

--- a/project-addons/picking_sync_it/models/stock.py
+++ b/project-addons/picking_sync_it/models/stock.py
@@ -50,8 +50,6 @@ class StockPicking(models.Model):
                     picking.move_type = 'direct'
                     picking.action_accept_ready_qty()
             elif picking.location_id.name == 'Tránsito Italia' and picking.state != 'assigned':
-                import ipdb
-                ipdb.set_trace()
                 mail_pool = self.env['mail.mail']
                 context = self._context.copy()
                 context.pop('default_state', False)

--- a/project-addons/picking_sync_it/views/email_template.xml
+++ b/project-addons/picking_sync_it/views/email_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="email_template_sync_pick_error" model="mail.template">
+            <field name="name">Sync Picking Error</field>
+            <field name="email_from">odoo_team@visiotechsecurity.com</field>
+            <field name="subject">[Odoo] Error al notificar entrada</field>
+            <field name="email_to">odoo_team@visiotechsecurity.com</field>
+            <field name="model_id" ref="stock.model_stock_picking"/>
+            <field name="auto_delete" eval="False"/>
+            <field name="body_html"><![CDATA[
+                <p>${ctx.get('message_warn','')}</p>
+             ]]>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
 - [IMP]automatize_edi_it: añadido campo de venta en españa y cantidad a  facturar en italia. Ahora se compara directamente ambas cantidades a facturar.
- [IMP]automatize_edi_it: movido login fuera del for para loguearse solo una vez y añadido logout
- [IMP]picking_sync_it: nuevo aviso por email cuando el albarán está sin reservar




