### PR TITLE
Errores reembolsos Amazon y no copiar asin_code al duplicar producto

### DIFF
--- a/project-addons/amazon_connector/models/product.py
+++ b/project-addons/amazon_connector/models/product.py
@@ -4,4 +4,4 @@ from odoo import models, fields, api
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
-    asin_code = fields.Char("Amazon ASIN")
+    asin_code = fields.Char("Amazon ASIN", copy=False)


### PR DESCRIPTION
- [FIX] amazon_connector: corregido errores en reembolsos y no copiar asin_code al duplicar producto