### PR TITLE
Arreglo de albaranes procesados por cron de compras

### DIFF
--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -59,9 +59,12 @@ class PurchaseOrder(models.Model):
     def _check_picking_to_process(self):
         pickings_to_stock = self.env['stock.picking'].search([('picking_type_id', '=',
                                                                self.env.ref('stock.picking_type_in').id),
+                                                              ('location_id', '=',
+                                                               self.env.ref('automatize_edi_it.stock_location_vendor_deposit').id),
+                                                              ('location_dest_id', '=',
+                                                               self.env.ref('stock.stock_location_stock').id),
                                                               ('state', 'in',
-                                                               ("assigned", "confirmed", "partially_available")),
-                                                              ('claim_id', '=', False)])
+                                                               ("assigned", "confirmed", "partially_available"))])
         pickings_to_stock._process_picking()
 
     @api.model

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -60,7 +60,8 @@ class PurchaseOrder(models.Model):
         pickings_to_stock = self.env['stock.picking'].search([('picking_type_id', '=',
                                                                self.env.ref('stock.picking_type_in').id),
                                                               ('state', 'in',
-                                                               ("assigned", "confirmed", "partially_available"))])
+                                                               ("assigned", "confirmed", "partially_available")),
+                                                              ('claim_id', '=', False)])
         pickings_to_stock._process_picking()
 
     @api.model
@@ -70,13 +71,13 @@ class PurchaseOrder(models.Model):
                                  ('state', '=', 'draft')])
         for order in purchases:
             order.with_context(bypass_override=True).button_confirm()
-            action = order.attach_ubl_xml_file_button()
+            '''action = order.attach_ubl_xml_file_button()
             attachment = self.env['ir.attachment'].browse(action['res_id'])
             output_folder = self.env['base.io.folder'].\
                 search([('direction', '=', 'export')], limit=1)
             if not output_folder:
                 raise exceptions.UserError(_("Please create an export folder"))
-            output_folder.export_file(attachment.datas, attachment.name)
+            output_folder.export_file(attachment.datas, attachment.name)'''
             order.picking_ids._process_picking()
         self._check_picking_to_process()
 

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -71,13 +71,13 @@ class PurchaseOrder(models.Model):
                                  ('state', '=', 'draft')])
         for order in purchases:
             order.with_context(bypass_override=True).button_confirm()
-            '''action = order.attach_ubl_xml_file_button()
+            action = order.attach_ubl_xml_file_button()
             attachment = self.env['ir.attachment'].browse(action['res_id'])
             output_folder = self.env['base.io.folder'].\
                 search([('direction', '=', 'export')], limit=1)
             if not output_folder:
                 raise exceptions.UserError(_("Please create an export folder"))
-            output_folder.export_file(attachment.datas, attachment.name)'''
+            output_folder.export_file(attachment.datas, attachment.name)
             order.picking_ids._process_picking()
         self._check_picking_to_process()
 


### PR DESCRIPTION
- [FIX]automatize_edi_it: no se tienen en cuenta los albaranes que vienen de RMA para que no los confirme
- [FIX]automatize_edi_it: descomentado exportacion de fichero 
- [FIX]automatize_edi_it: se tienen en cuenta solo albaranes de Deposito a stock

