### PR TITLE
Al devolver albarán, no copiar campo "Albarán procesado por vstock"

### DIFF
--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -266,3 +266,10 @@ class StockPicking(models.Model):
 
         return True
 
+
+class ReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    def create_returns(self):
+        super(ReturnPicking, self).create_returns()
+        self.picking_id.block_picking = False


### PR DESCRIPTION
- [IMP] Devolver albarán no copia el campo block_picking