### PR TITLE
Ajustes en modulo de gestion de SIM

### DIFF
--- a/project-addons/sim_manager/__manifest__.py
+++ b/project-addons/sim_manager/__manifest__.py
@@ -5,7 +5,7 @@
     'description': '',
     'author': 'Visiotech',
     'depends': ['mrp', 'barcode_action'],
-    'data': ['views/sim_view.xml', 'views/partner_view.xml',
+    'data': ['views/sim_view.xml', 'views/partner_view.xml', 'views/email_template.xml',
              'security/ir.model.access.csv', 'data/parameters.xml'],
     'installable': True,
     'auto_install': False,

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -28,6 +28,7 @@ msgstr "Tarjetas"
 
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
 msgid "Code"
 msgstr "Código"
 
@@ -157,3 +158,31 @@ msgstr "Paquete %s terminado. Escanea el siguiente para continuar"
 #, python-format
 msgid "Scan the #%s serial for %s"
 msgstr "Escanea el #%s ID para el %s"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
+msgid "Manage the SIM Types"
+msgstr "Gestionar tipos de SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_product_id
+msgid "Product"
+msgstr "Producto"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_type_form
+msgid "SIM Type"
+msgstr "Tipo SIM"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_type_config
+#: model:ir.ui.menu,name:sim_manager.menu_sim_type_config
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_type
+msgid "SIM Types"
+msgstr "Tipos de SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
+msgid "Type"
+msgstr "Tipo"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -186,3 +186,9 @@ msgstr "Tipos de SIM"
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
 msgid "Type"
 msgstr "Tipo"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/stock.py:27
+#, python-format
+msgid "Some of these SIM cards %s of the picking %s have not been found in the system."
+msgstr "Algunas de estas tarjetas SIM %s del albarán %s no se encuentran en el sistema."

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -27,6 +27,7 @@ msgstr "Carte"
 
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
 msgid "Code"
 msgstr "Codice"
 
@@ -145,3 +146,32 @@ msgstr "Pachetto %s finito. Scansiona il sucesivo per continuare"
 #, python-format
 msgid "Scan the #%s serial for %s"
 msgstr "Scasiona il #%s ID per il %s"
+
+
+#. module: sim_manager
+#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
+msgid "Manage the SIM Types"
+msgstr "Gestire tipi de SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_product_id
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_type_form
+msgid "SIM Type"
+msgstr "Tipo SIM"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_type_config
+#: model:ir.ui.menu,name:sim_manager.menu_sim_type_config
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_type
+msgid "SIM Types"
+msgstr "Tipi de SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
+msgid "Type"
+msgstr "Tipo"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -175,3 +175,9 @@ msgstr "Tipi de SIM"
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
 msgid "Type"
 msgstr "Tipo"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/stock.py:27
+#, python-format
+msgid "Some of these SIM cards %s of the picking %s have not been found in the system"
+msgstr "Alcuni di queste SIM card %s della bolla %s non esistono nel sistema."

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -136,3 +136,13 @@ class SimSerial(models.Model):
 
     code = fields.Char(string='Serial')
     package_id = fields.Many2one('sim.package', string='Package')
+
+
+class SimType(models.Model):
+    _name = 'sim.type'
+    _description = 'simType'
+    _rec_name = 'type'
+
+    product_id = fields.Many2one('product.product')
+    type = fields.Char('Type')
+    code = fields.Char('Code')

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -133,6 +133,7 @@ class SimPackage(models.Model):
 class SimSerial(models.Model):
     _name = 'sim.serial'
     _description = 'simSerial'
+    _rec_name = 'code'
 
     code = fields.Char(string='Serial')
     package_id = fields.Many2one('sim.package', string='Package')

--- a/project-addons/sim_manager/models/stock.py
+++ b/project-addons/sim_manager/models/stock.py
@@ -16,8 +16,9 @@ class StockMove(models.Model):
                         pkg.write({'partner_id': self.partner_id.commercial_partner_id.id,
                                    'move_id': self.id,
                                    'state': 'sold'})
-                        if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name:
-                            sim_packages.with_delay(priority=10).notify_sale_web('sold')
+                        if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name \
+                                and 'VIP' not in pkg.code:  # TODO: manejar con los tipos
+                            pkg.with_delay(priority=10).notify_sale_web('sold')
                 else:
                     # Notify warehouse something missing
                     mail_pool = self.env['mail.mail']
@@ -39,11 +40,13 @@ class StockMove(models.Model):
                 for pkg_code in vals.get('lots_text', '').split(', '):
                     sim_packages = self.env['sim.package'].search([('code', '=', pkg_code)])
                     if sim_packages:
-                        sim_packages.write({'partner_id': None,
-                                            'move_id': None,
-                                            'state': 'available'})
-                        if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name:
-                            sim_packages.with_delay(priority=10).notify_sale_web('return')
+                        for pkg in sim_packages:
+                            pkg.write({'partner_id': None,
+                                       'move_id': None,
+                                       'state': 'available'})
+                            if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name \
+                                    and 'VIP' not in pkg.code:  # TODO: manejar con los tipos
+                                pkg.with_delay(priority=10).notify_sale_web('sold')
         return res
 
 

--- a/project-addons/sim_manager/models/stock.py
+++ b/project-addons/sim_manager/models/stock.py
@@ -16,7 +16,7 @@ class StockMove(models.Model):
                         pkg.write({'partner_id': self.partner_id.commercial_partner_id.id,
                                    'move_id': self.id,
                                    'state': 'sold'})
-                        if self.partner_id.commercial_partner_id.web:
+                        if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name:
                             sim_packages.with_delay(priority=10).notify_sale_web('sold')
                 else:
                     # Notify warehouse something missing
@@ -42,7 +42,7 @@ class StockMove(models.Model):
                         sim_packages.write({'partner_id': None,
                                             'move_id': None,
                                             'state': 'available'})
-                        if self.partner_id.commercial_partner_id.web:
+                        if 'VISIOTECH' not in self.partner_id.commercial_partner_id.name:
                             sim_packages.with_delay(priority=10).notify_sale_web('return')
         return res
 

--- a/project-addons/sim_manager/models/stock.py
+++ b/project-addons/sim_manager/models/stock.py
@@ -1,4 +1,4 @@
-from odoo import models, api
+from odoo import models, api, _
 
 
 class StockMove(models.Model):
@@ -9,14 +9,32 @@ class StockMove(models.Model):
         res = super().write(vals)
         if 'lots_text' in vals:
             if self.picking_id.picking_type_id.code == 'outgoing':
-                sim_packages = self.env['sim.package'].search([('code', 'in', vals.get('lots_text', '').split(', '))])
-                if sim_packages:
+                sims = vals.get('lots_text', '').split(', ')
+                sim_packages = self.env['sim.package'].search([('code', 'in', sims)])
+                if sim_packages and len(sim_packages) == len(sims):
                     for pkg in sim_packages:
                         pkg.write({'partner_id': self.partner_id.commercial_partner_id.id,
                                    'move_id': self.id,
                                    'state': 'sold'})
                         if self.partner_id.commercial_partner_id.web:
                             sim_packages.with_delay(priority=10).notify_sale_web('sold')
+                else:
+                    # Notify warehouse something missing
+                    mail_pool = self.env['mail.mail']
+                    context = self._context.copy()
+                    context.pop('default_state', False)
+                    context['message_warn'] = \
+                        _('Some of these SIM cards %s of the picking %s have not been found in the system.') % \
+                        (vals.get('lots_text', ''), self.picking_id.name)
+
+                    template_id = self.env.ref('sim_manager.email_template_sim_error')
+
+                    if template_id:
+                        mail_id = template_id.with_context(context).send_mail(self.id)
+                        if mail_id:
+                            mail_id_check = mail_pool.browse(mail_id)
+                            mail_id_check.with_context(context).send()
+
             elif self.picking_id.picking_type_id.code == 'incoming':
                 for pkg_code in vals.get('lots_text', '').split(', '):
                     sim_packages = self.env['sim.package'].search([('code', '=', pkg_code)])

--- a/project-addons/sim_manager/views/email_template.xml
+++ b/project-addons/sim_manager/views/email_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="email_template_sim_error" model="mail.template">
+            <field name="name">SIM Error</field>
+            <field name="email_from">odoo_team@visiotechsecurity.com</field>
+            <field name="subject">[Odoo] SIM card not found</field>
+            <field name="email_to">jlmoralejo@visiotechsecurity.com</field>
+            <field name="model_id" ref="stock.model_stock_move"/>
+            <field name="auto_delete" eval="False"/>
+            <field name="body_html"><![CDATA[
+                <p>${ctx.get('message_warn','')}</p>
+             ]]>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -54,6 +54,8 @@
                <filter string="Sold" domain="[('state','=','sold')]"/>
                <filter string="Available" domain="[('state','=','available')]"/>
                <field name="code" string="Paquete"/>
+               <field name="serial_ids" string="Tarjetas"/>
+               <field name="partner_id" string="Cliente"/>
            </search>
         </field>
     </record>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -121,6 +121,36 @@
         </field>
     </record>
 
+    <record id="view_sim_type" model="ir.ui.view">
+        <field name="name">sim.type.view</field>
+        <field name="model">sim.type</field>
+        <field name="arch" type="xml">
+            <tree string="SIM Types">
+                <field name="type"/>
+                <field name="code"/>
+                <field name="product_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_sim_type_form" model="ir.ui.view">
+        <field name="name">sim.type.form</field>
+        <field name="model">sim.type</field>
+        <field name="arch" type="xml">
+            <form string="SIM Type">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="type"/>
+                            <field name="code"/>
+                            <field name="product_id"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
     <record id="action_sim_package_creator" model="ir.actions.act_window">
         <field name="name">Create SIM package</field>
         <field name="type">ir.actions.act_window</field>
@@ -139,9 +169,20 @@
         <field name="search_view_id" ref="view_sim_package_filter"/>
     </record>
 
+    <record id="action_sim_type_config" model="ir.actions.act_window">
+        <field name="name">SIM Types</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sim.type</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_type">form</field>
+        <field name="help">Manage the SIM Types</field>
+    </record>
+
     <menuitem id="menu_sim_package" action="action_sim_package" parent="mrp.menu_mrp_bom" sequence="40"/>
     <menuitem id="menu_sim_package_creator" action="action_sim_package_creator" name="Scan SIMs"
             parent="mrp.menu_mrp_manufacturing" sequence="50"/>
     <menuitem id="menu_sim_report" action="action_sim_package_report" name="SIM Tags"
               parent="mrp.menu_mrp_reporting" sequence="50"/>
+    <menuitem id="menu_sim_type_config" action="action_sim_type_config" name="SIM Types"
+              parent="mrp.menu_mrp_configuration" sequence="40"/>
 </odoo>

--- a/project-addons/sim_manager/wizard/sim_creator_wizard.py
+++ b/project-addons/sim_manager/wizard/sim_creator_wizard.py
@@ -7,11 +7,7 @@ class SimPackageCreateWizard(models.TransientModel):
 
     _name = "sim.package.create.wizard"
 
-    type_sim = fields.Selection(string='Type',
-                                selection=[('M2M_CARD', 'ES'),
-                                           ('M2M_CARD_EU', 'EU'),
-                                           ('M2M_CARD_VIP', 'VIP')],
-                                required=True)
+    type_sim = fields.Many2one('sim.type', string='Type', required=True)
 
     new_code = fields.Char(string='New package', compute='_get_new_code', store=True)
 
@@ -20,17 +16,17 @@ class SimPackageCreateWizard(models.TransientModel):
         if not self.type_sim:
             self.new_code = ''
         else:
-            if self.type_sim == 'M2M_CARD':
-                last_code = self.env['sim.package'].search([('code', 'ilike', self.type_sim),
+            if self.type_sim.type == 'ES':
+                last_code = self.env['sim.package'].search([('code', 'ilike', self.type_sim.code),
                                                             ('code', 'not like', 'EU'),
                                                             ('code', 'not like', 'VIP')], order="code desc", limit=1)
             else:
-                last_code = self.env['sim.package'].search([('code', 'ilike', self.type_sim)],
+                last_code = self.env['sim.package'].search([('code', 'ilike', self.type_sim.code)],
                                                            order="code desc", limit=1)
             if last_code:
-                self.new_code = self.type_sim + '_' + str(int(last_code.code.split('_')[-1])+1).zfill(6)
+                self.new_code = self.type_sim.code + '_' + str(int(last_code.code.split('_')[-1])+1).zfill(6)
             else:
-                self.new_code = self.type_sim + '_000001'
+                self.new_code = self.type_sim.code + '_000001'
 
     def create_package(self):
         context = self._context.copy()


### PR DESCRIPTION
- [IMP]sim_manager: tipos de sim configurables y envío solo de clientes web
- [IMP]sim_manager: añadido filtro para tarjetas
- [IMP]sim_manager: email de aviso para almacen 
- [IMP]sim_manager: se mandan clientes web pero no clientes internos
- [IMP]sim_manager: quitamos la notificacion de las tarjetas VIP

