### PR TITLE
[HOTFIX] Devoluciones y Escaneo de SIM

### DIFF
--- a/project-addons/sim_manager/__manifest__.py
+++ b/project-addons/sim_manager/__manifest__.py
@@ -4,7 +4,7 @@
     'summary': '',
     'description': '',
     'author': 'Visiotech',
-    'depends': ['mrp', 'barcode_action'],
+    'depends': ['mrp', 'barcode_action', 'crm_claim_rma', 'stock_custom'],
     'data': ['views/sim_view.xml', 'views/partner_view.xml', 'views/email_template.xml',
              'security/ir.model.access.csv', 'data/parameters.xml', 'data/cron.xml'],
     'installable': True,

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -192,3 +192,9 @@ msgstr "Tipo"
 #, python-format
 msgid "Some of these SIM cards %s of the picking %s have not been found in the system."
 msgstr "Algunas de estas tarjetas SIM %s del albarán %s no se encuentran en el sistema."
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:20
+#, python-format
+msgid "You must specify the serial number of the serial products"
+msgstr "Debes especificar el número de serie de los productos con tracking"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -181,3 +181,9 @@ msgstr "Tipo"
 #, python-format
 msgid "Some of these SIM cards %s of the picking %s have not been found in the system"
 msgstr "Alcuni di queste SIM card %s della bolla %s non esistono nel sistema."
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:20
+#, python-format
+msgid "You must specify the serial number of the serial products"
+msgstr "Devi specificare il numero serie dei prodotti con traking"

--- a/project-addons/sim_manager/models/__init__.py
+++ b/project-addons/sim_manager/models/__init__.py
@@ -1,3 +1,5 @@
 from . import sim
 from . import res_partner
 from . import stock
+from . import claim
+

--- a/project-addons/sim_manager/models/claim.py
+++ b/project-addons/sim_manager/models/claim.py
@@ -1,0 +1,22 @@
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+
+class ClaimMakePicking(models.TransientModel):
+
+    _inherit = "claim_make_picking.wizard"
+
+    @api.multi
+    def create_move(self, claim_line, p_type, picking_id, claim, note, write_field):
+        super().create_move(claim_line, p_type, picking_id, claim, note, write_field)
+        claim_line_id = claim_line.id
+        move = picking_id.move_lines.filtered(lambda l: l.claim_line_id.id == claim_line_id)
+        move.write({'lots_text': claim_line.prodlot_id})
+
+    @api.multi
+    def action_create_picking(self):
+        for wizard_claim_line in self.claim_line_ids:
+            if wizard_claim_line.product_id.track_serial and not wizard_claim_line.prodlot_id:
+                raise UserError(_("You must specify the serial number of the serial products"))
+        res = super(ClaimMakePicking, self).action_create_picking()
+        return res

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -60,7 +60,7 @@ class SimPackage(models.Model):
         logger.info("Imported SIM %s" % barcode)
         max_cards = int(self.env['ir.config_parameter'].sudo().get_param('package.sim.card.max'))
 
-        created_code = self.env['sim.package'].search([], order="code desc", limit=1)
+        created_code = self
         if len(created_code.serial_ids) < max_cards:
             sim_serial = self.env['sim.serial'].create({'code': barcode, 'package_id': created_code.id})
             if sim_serial:

--- a/project-addons/sim_manager/security/ir.model.access.csv
+++ b/project-addons/sim_manager/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sim_package,access_sim_package,model_sim_package,base.group_user,1,1,1,1
 access_sim_serial,access_sim_serial,model_sim_serial,base.group_user,1,1,1,1
+access_sim_type,access_sim_type,model_sim_type,base.group_user,1,1,1,1

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -51,6 +51,7 @@
                <filter string="ES" domain="[('code','not like','EU'),('code','not like','VIP')]"/>
                <filter string="EU" domain="[('code','like','EU')]"/>
                <filter string="VIP" domain="[('code','like','VIP')]"/>
+               <separator/>
                <filter string="Sold" domain="[('state','=','sold')]"/>
                <filter string="Available" domain="[('state','=','available')]"/>
                <field name="code" string="Paquete"/>


### PR DESCRIPTION
- [IMP]sim_manager: obligatorio meter el numero de serie de productos seriables en RMA y añadida logica para devolver paquetes sim
- [FIX]sim_manager: cambiamos la busqueda por el propio self donde viene ya el último objeto creado, al hacer la busqueda encontraba el penultimo y no el ultimo