### PR TITLE
Facturar descuentos lo último

### DIFF
--- a/project-addons/order_invoice_policy/models/sale_order.py
+++ b/project-addons/order_invoice_policy/models/sale_order.py
@@ -40,8 +40,8 @@ class SaleOrder(models.Model):
                 invoice_status = 'invoiced'
             elif any(line.invoice_status == 'to invoice'
                      for line in order.order_line.filtered(lambda p: p.product_id.type in ['product', 'consu'])) or \
-                    all(line.invoice_status == 'to invoice' and line.product_id.type == 'service'
-                        for line in order.order_line):
+                    all(line.invoice_status == 'to invoice' and line.product_id.type == 'service' for line in order.order_line) or \
+                    all(line.invoice_status == 'to invoice' for line in order.order_line.filtered(lambda p: p.invoice_status != 'invoiced')):
                 invoice_status = 'to_invoice'
             elif all(line.invoice_status in ('invoiced', 'cancel', 'upselling') for line in order.order_line):
                 invoice_status = 'invoiced'

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -29,7 +29,7 @@ class SaleOrderLine(models.Model):
     def invoice_line_create(self, invoice_id, qty):
         lines = self.env['sale.order.line']
         for line in self:
-            if line.promotion_line:
+            if line.price_unit < 0:
                 order = line.order_id
                 total_to_invoice_dict = self._context.get('total_to_invoice', False)
                 total_to_invoice = 0
@@ -51,7 +51,7 @@ class SaleOrderLine(models.Model):
     @api.multi
     def _prepare_invoice_line(self, qty):
         if all(oline.product_id.type == 'service' for oline in self.order_id.order_line.filtered(lambda l: l.invoice_status == 'to invoice')) \
-                and self.product_id.id == self.env.ref('commercial_rules.product_discount').id:
+                and self.price_unit < 0:
             # This case is for creating a refund with the last discount on the order and positive quantities
             vals = super(SaleOrderLine, self)._prepare_invoice_line(qty)
             vals['price_unit'] = -vals['price_unit']


### PR DESCRIPTION
- [FIX]sale_promotions_extend: evitamos facturar el descuento hasta el final y cuando se facture, se genera una rectificativa con cantidades positivas
- [FIX]order_invoice_policy: se pone el estado Para facturar cuando solo quedan servicios pendientes
- [FIX]sale_promotions_extend: en una línea de descuento, cuando se crea una rectificativa con ella, hay que sumar a la cantidad facturada, no restar
- [IMP]sale_promotions_extend: cambiamos el producto descuento por que el precio sea negativo, así incluimos otros productos que usan que también son descuentos