### PR TITLE
[ODOO IT] Generador de reglas de abastecimiento en Italia

### DIFF
--- a/project-addons/product_stock_unsafety/models/stock_warehouse_orderpoint.py
+++ b/project-addons/product_stock_unsafety/models/stock_warehouse_orderpoint.py
@@ -7,5 +7,4 @@ class StockWarehouseOrderpoint(models.Model):
     _inherit = 'stock.warehouse.orderpoint'
 
     min_days_id = fields.Many2one('minimum.day',
-                                  'Stock Mínimum Days',
-                                  required=True)
+                                  'Stock Mínimum Days')

--- a/project-addons/stock_orderpoint_generator_custom/__init__.py
+++ b/project-addons/stock_orderpoint_generator_custom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/stock_orderpoint_generator_custom/__manifest__.py
+++ b/project-addons/stock_orderpoint_generator_custom/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Order point generator custom',
+    'summary': 'Mass configuration of stock order points custom',
+    'version': '11.0.2.0.0',
+    'author': "Visiotech",
+    'category': 'Warehouse',
+    'website': '',
+    'depends': ['stock','stock_orderpoint_generator'],
+    'data': ['views/orderpoint_template_views.xml'
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/project-addons/stock_orderpoint_generator_custom/i18n/es.po
+++ b/project-addons/stock_orderpoint_generator_custom/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_orderpoint_generator_custom
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-29 14:26+0000\n"
+"PO-Revision-Date: 2021-11-29 14:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_orderpoint_generator_custom
+#: model:ir.model.fields,field_description:stock_orderpoint_generator_custom.field_stock_warehouse_orderpoint_template_all_products
+msgid "All Products"
+msgstr "Aplicar a todos los productos"

--- a/project-addons/stock_orderpoint_generator_custom/i18n/it.po
+++ b/project-addons/stock_orderpoint_generator_custom/i18n/it.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_orderpoint_generator_custom
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-29 14:26+0000\n"
+"PO-Revision-Date: 2021-11-29 14:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_orderpoint_generator_custom
+#: model:ir.model.fields,field_description:stock_orderpoint_generator_custom.field_stock_warehouse_orderpoint_template_all_products
+msgid "All Products"
+msgstr "Applica a tutti i prodotti"

--- a/project-addons/stock_orderpoint_generator_custom/models/__init__.py
+++ b/project-addons/stock_orderpoint_generator_custom/models/__init__.py
@@ -1,0 +1,3 @@
+from . import procurement
+from . import orderpoint_template
+from . import product

--- a/project-addons/stock_orderpoint_generator_custom/models/orderpoint_template.py
+++ b/project-addons/stock_orderpoint_generator_custom/models/orderpoint_template.py
@@ -1,0 +1,5 @@
+from odoo import fields, models, api
+
+class OrderpointTemplate(models.Model):
+    _inherit = 'stock.warehouse.orderpoint.template'
+    all_products = fields.Boolean()

--- a/project-addons/stock_orderpoint_generator_custom/models/procurement.py
+++ b/project-addons/stock_orderpoint_generator_custom/models/procurement.py
@@ -1,0 +1,19 @@
+from odoo import models, api
+
+class ProcurementGroup(models.Model):
+    _inherit = 'procurement.group'
+
+    @api.model
+    def _procure_orderpoint_confirm(self, use_new_cursor=False, company_id=False):
+        context = dict(self.env.context, remove_reserves=True)
+        return super(ProcurementGroup, self.with_context(context))._procure_orderpoint_confirm(use_new_cursor,
+                                                                                               company_id)
+
+    @api.model
+    def run(self, product_id, product_qty, product_uom, location_id, name, origin, values):
+        if self._context.get('remove_reserves', False):
+            product_qty -= product_id.reservation_count
+            if product_qty <= 0:
+                return False
+        return super(ProcurementGroup, self).run(product_id, product_qty, product_uom, location_id, name, origin,
+                                                 values)

--- a/project-addons/stock_orderpoint_generator_custom/models/product.py
+++ b/project-addons/stock_orderpoint_generator_custom/models/product.py
@@ -1,0 +1,12 @@
+from odoo import models, api
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def create(self, vals):
+        res = super(ProductProduct, self).create(vals)
+        orderpoints = self.env['stock.warehouse.orderpoint.template'].search([('all_products','=',True),('auto_generate','=',True)])
+        orderpoints.write({'auto_product_ids':[(4,res.id)]})
+        return res
+

--- a/project-addons/stock_orderpoint_generator_custom/views/orderpoint_template_views.xml
+++ b/project-addons/stock_orderpoint_generator_custom/views/orderpoint_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warehouse_orderpoint_template_add_all_products_form" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.template.add_all_products_form</field>
+        <field name="model">stock.warehouse.orderpoint.template</field>
+        <field name="inherit_id" ref="stock_orderpoint_generator.view_warehouse_orderpoint_template_form" />
+        <field name="arch" type="xml">
+            <field name="auto_generate" position="after">
+                <field name="all_products" attrs="{'invisible':[('auto_generate', '=', False)]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Buenas tardes @omar7r , hemos estado probando el módulo que nos comentaste para las reservas en Odoo It. Este nuevo módulo contiene algunas modificaciones que hemos considerado que teniamos que hacer para el correcto funcionamiento, por lo que habría que instalar el módulo stock_orderpoint_generator y el nuevo módulo que está incluido en este PR (stock_orderpoint_generator_custom). De la configuración ya nos encargamos nosotros una vez lo hayas mergeado.
Muchas gracias

- [IMP] stock_orderpoint_generator_custom: Añadido nuevo módulo
- [FIX] product_stock_unsafety: quitamos obligatoriedad de campo