### PR TITLE
[ITALIA] Plantillas reglas abastecimiento solo en almacenables

### DIFF
--- a/project-addons/stock_orderpoint_generator_custom/models/product.py
+++ b/project-addons/stock_orderpoint_generator_custom/models/product.py
@@ -6,7 +6,8 @@ class ProductProduct(models.Model):
     @api.model
     def create(self, vals):
         res = super(ProductProduct, self).create(vals)
-        orderpoints = self.env['stock.warehouse.orderpoint.template'].search([('all_products','=',True),('auto_generate','=',True)])
-        orderpoints.write({'auto_product_ids':[(4,res.id)]})
+        if 'type' in vals and vals['type']=='product':
+            orderpoints = self.env['stock.warehouse.orderpoint.template'].search([('all_products','=',True),('auto_generate','=',True)])
+            orderpoints.write({'auto_product_ids':[(4,res.id)]})
         return res
 


### PR DESCRIPTION
-[FIX] stock_orderpoint_generator_custom: Ahora solo se añaden a las plantillas de reglas de abastecimiento los productos que sean almacenables