### PR TITLE
[HOTFIX] Modelo 347

### DIFF
--- a/project-addons/patches/mod347.diff
+++ b/project-addons/patches/mod347.diff
@@ -1,5 +1,5 @@
 diff --git a/l10n_es_aeat_mod347/models/mod347.py b/l10n_es_aeat_mod347/models/mod347.py
-index e3dc2d8..d6a198c 100644
+index e3dc2d8..d5dda76 100644
 --- a/l10n_es_aeat_mod347/models/mod347.py
 +++ b/l10n_es_aeat_mod347/models/mod347.py
 @@ -15,6 +15,8 @@ from datetime import datetime
@@ -31,58 +31,103 @@ index e3dc2d8..d6a198c 100644
          ]
 
      @api.model
-@@ -212,19 +214,24 @@ class L10nEsAeatMod347Report(models.Model):
+@@ -207,50 +209,61 @@ class L10nEsAeatMod347Report(models.Model):
+                 'partner_country_code': country_code,
+             }
+
++    def _get_partners_ids(self):
++        query = " SELECT DISTINCT partner_id FROM account_move_line " \
++                "WHERE date BETWEEN '%s' AND '%s' AND tax_line_id IS NOT NULL " % (self.date_start, self.date_end)
++        self._cr.execute(query)
++        ids = self._cr.dictfetchall()
++        return [p['partner_id'] for p in ids]
++
+     def _create_partner_records(self, key, map_ref, partner_record=None):
+         partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
          partner_obj = self.env['res.partner']
          map_line = self.env.ref(map_ref)
          taxes = self._get_taxes(map_line)
 -        domain = self._account_move_line_domain(taxes)
 +        domain = self._account_move_line_domain()
++        partner_ids = self._get_partners_ids()
          if partner_record:
-             domain += [('partner_id', '=', partner_record.partner_id.id)]
+-            domain += [('partner_id', '=', partner_record.partner_id.id)]
 -        groups = self.env['account.move.line'].read_group(
 -            domain,
 -            ['partner_id', 'balance'],
 -            ['partner_id'],
 -        )
-+
-+        moves = self.env['account.move.line'].search(domain)
-+        lines = moves.filtered(lambda m: m.tax_ids & taxes or m.tax_line_id in taxes)
-+        lines = lines.sorted(key=lambda ml: ml.partner_id.id)
-+        groups = []
-+        for key_p, items in itertools.groupby(lines, lambda l: l.partner_id.id):
-+            balance = 0
-+            for item in list(items):
-+                balance += item.balance
-+            groups.append({'partner_id': key_p, 'balance': balance})
-         filtered_groups = list(filter(
-             lambda d: abs(d['balance']) > self.operations_limit, groups)
-         )
-         for group in filtered_groups:
+-        filtered_groups = list(filter(
+-            lambda d: abs(d['balance']) > self.operations_limit, groups)
+-        )
+-        for group in filtered_groups:
 -            partner = partner_obj.browse(group['partner_id'][0])
-+            partner = partner_obj.browse(group['partner_id'])
-             vals = {
-                 'report_id': self.id,
-                 'partner_id': partner.id,
-@@ -233,14 +240,16 @@ class L10nEsAeatMod347Report(models.Model):
-                 'amount': (-1 if key == 'B' else 1) * group['balance'],
-             }
-             vals.update(self._get_partner_347_identification(partner))
+-            vals = {
+-                'report_id': self.id,
+-                'partner_id': partner.id,
+-                'representative_vat': '',
+-                'operation_key': key,
+-                'amount': (-1 if key == 'B' else 1) * group['balance'],
+-            }
+-            vals.update(self._get_partner_347_identification(partner))
 -            move_groups = self.env['account.move.line'].read_group(
 -                group['__domain'],
 -                ['move_id', 'balance'],
 -                ['move_id'],
 -            )
-+            move_groups = []
-+            for key_m, items in itertools.groupby(lines.filtered(lambda li: li.partner_id.id == partner.id),
-+                                                  lambda l: l.move_id.id):
-+                balance = 0
-+                for item in list(items):
-+                    balance += item.balance
-+                move_groups.append({'move_id': key_m, 'balance': balance})
-             vals['move_record_ids'] = [
-                 (0, 0, {
+-            vals['move_record_ids'] = [
+-                (0, 0, {
 -                    'move_id': move_group['move_id'][0],
-+                    'move_id': move_group['move_id'],
-                     'amount': abs(move_group['balance']),
-                 }) for move_group in move_groups
-             ]
+-                    'amount': abs(move_group['balance']),
+-                }) for move_group in move_groups
+-            ]
+-            if partner_record:
+-                vals['move_record_ids'][0:0] = [
+-                    (2, x) for x in partner_record.move_record_ids.ids
+-                ]
+-                partner_record.write(vals)
+-            else:
+-                partner_record_obj.create(vals)
++            partners = partner_obj.search([('id', '=', partner_record.partner_id.id)])
++        else:
++            partners = partner_obj.browse(partner_ids)
++
++        for partner in partners:
++            domain_partner = domain + [('partner_id', '=', partner.id)]
++            moves = self.env['account.move.line'].search(domain_partner)
++            lines = moves.filtered(lambda m: m.tax_ids & taxes or m.tax_line_id in taxes)
++            if lines:
++                balance = sum(lines.mapped('balance'))
++
++                if abs(balance) > self.operations_limit:
++                    vals = {
++                        'report_id': self.id,
++                        'partner_id': partner.id,
++                        'representative_vat': '',
++                        'operation_key': key,
++                        'amount': (-1 if key == 'B' else 1) * balance,
++                    }
++                    vals.update(self._get_partner_347_identification(partner))
++
++                    move_groups = []
++                    for key_m, items in itertools.groupby(lines, lambda l: l.move_id.id):
++                        balance = 0
++                        for item in list(items):
++                            balance += item.balance
++                        move_groups.append({'move_id': key_m, 'balance': balance})
++                    vals['move_record_ids'] = [
++                        (0, 0, {
++                            'move_id': move_group['move_id'],
++                            'amount': abs(move_group['balance']),
++                        }) for move_group in move_groups
++                    ]
++                    if partner_record:
++                        vals['move_record_ids'][0:0] = [
++                            (2, x) for x in partner_record.move_record_ids.ids
++                        ]
++                        partner_record.write(vals)
++                    else:
++                        partner_record_obj.create(vals)
+
+     def _create_cash_moves(self):
+         partner_obj = self.env['res.partner']


### PR DESCRIPTION
Hemos optado por rehacer la función de otra manera, en vez de recorrer todos los apuntes del año, recorremos clientes y buscamos los apuntes de cada cliente. Esto es más lento, ya que hace muchas más búsquedas en la base de datos pero no debería tener ningún problema de memoria porque manejamos sets de registros más pequeños. Hemos conseguido sacar el informe de 2019 en unas dos horas.