### PR TITLE
No copiar campo block_picking y correción informe amazon

### DIFF
--- a/project-addons/amazon_connector/models/amazon_settlement.py
+++ b/project-addons/amazon_connector/models/amazon_settlement.py
@@ -155,17 +155,22 @@ class AmazonSettlement(models.Model):
                                      'amount': float(transaction[4].text),
                                      'settlement_id': settlement.id}
                     else:
-                        cont = 1 if transaction[1].tag=='ShipmentID' else 0
+                        if transaction[1].tag == 'ShipmentID':
+                            cont = 1
+                        elif transaction[1].tag == 'PostedDate':
+                            cont = -1
+                        else:
+                            cont = 0
                         line_vals = {'type': transaction.tag,
                                      'transaction_type': transaction[0].text,
-                                     'transaction_name': transaction[cont+1].text,
-                                     'posted_date': transaction[cont+2].text,
+                                     'transaction_name': transaction[cont + 1].text if cont != -1 else False,
+                                     'posted_date': transaction[cont + 2].text,
                                      'currency_id': self.env[
                                          'res.currency'].search(
                                          [('name', '=',
-                                           transaction[cont+3].attrib.get(
+                                           transaction[cont + 3].attrib.get(
                                                'currency'))]).id,
-                                     'amount': float(transaction[cont+3].text),
+                                     'amount': float(transaction[cont + 3].text),
                                      'settlement_id': settlement.id}
                         if cont==1:
                             line_vals.update({'shipment_id':transaction[1].text})

--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -52,7 +52,7 @@ class StockPicking(models.Model):
 
     with_incidences = fields.Boolean('With incidences', readonly=True,
                                      copy=False)
-    block_picking = fields.Boolean('Albarán procesado Vstock')
+    block_picking = fields.Boolean('Albarán procesado Vstock', copy=False)
     partial_picking = fields.Boolean('Partial picking', default=False)
 
     state = fields.Selection(selection_add=[('partially_available', 'Partially Available')])


### PR DESCRIPTION
- [IMP] picking_incidences: no copiar campo block_picking
- [FIX] amazon_Settlement: corregido error lectura en algunos informes