### PR TITLE
Cambios SIMs

### DIFF
--- a/project-addons/sim_manager/__manifest__.py
+++ b/project-addons/sim_manager/__manifest__.py
@@ -6,7 +6,7 @@
     'author': 'Visiotech',
     'depends': ['mrp', 'barcode_action', 'crm_claim_rma', 'stock_custom', 'flask_middleware_connector'],
     'data': ['views/sim_view.xml', 'views/partner_view.xml', 'views/email_template.xml',
-             'security/ir.model.access.csv', 'data/parameters.xml', 'data/cron.xml'],
+             'security/ir.model.access.csv', 'data/parameters.xml', 'data/cron.xml', 'data/email_template.xml'],
     'installable': True,
     'auto_install': False,
 }

--- a/project-addons/sim_manager/data/email_template.xml
+++ b/project-addons/sim_manager/data/email_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="email_template_sim_bank_account_error" model="mail.template">
+            <field name="name">Bank Account Error</field>
+            <field name="email_from">odoo_team@visiotechsecurity.com</field>
+            <field name="subject">[Odoo] Missing Bank Account on SIM invoice</field>
+            <field name="email_to">contabilidad@visiotechsecurity.com</field>
+            <field name="model_id" ref="sim_manager.model_sim_package"/>
+            <field name="auto_delete" eval="False"/>
+            <field name="body_html"><![CDATA[
+                ${ctx.get('message_warn','') | safe}
+             ]]>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -198,3 +198,14 @@ msgstr "Algunas de estas tarjetas SIM %s del albarán %s no se encuentran en el 
 #, python-format
 msgid "You must specify the serial number of the serial products"
 msgstr "Debes especificar el número de serie de los productos con tracking"
+
+#. module: sim_manager
+#: model:mail.template,subject:sim_manager.email_template_sim_bank_account_error
+msgid "[Odoo] Missing Bank Account on SIM invoice"
+msgstr "[Odoo] Faltan cuentas bancarias en facturas SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/res_partner.py:86
+#, python-format
+msgid "Partner %s has not a valid mandate or account. Invoice %s has not been changed. \n"
+msgstr "El cliente %s no tiene cuenta o un mandato válido. La factura %s no se ha cambiado. \n"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -205,7 +205,7 @@ msgid "[Odoo] Missing Bank Account on SIM invoice"
 msgstr "[Odoo] Faltan cuentas bancarias en facturas SIM"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/res_partner.py:86
+#: code:addons/sim_manager/models/res_partner.py:82
 #, python-format
 msgid "Partner %s has not a valid mandate or account. Invoice %s has not been changed. \n"
 msgstr "El cliente %s no tiene cuenta o un mandato válido. La factura %s no se ha cambiado. \n"

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, _
 from odoo.addons.component.core import Component
 import requests
 import json
@@ -13,6 +13,7 @@ class ResPartner(models.Model):
     def invoice_sim_packages(self, month=None):
         # Call web to get the data
         error = ''
+        mail_bank_error_message = ''
         web_invoice_endpoint = self.env['ir.config_parameter'].sudo().get_param('web.sim.invoice.endpoint')
         api_key = self.env['ir.config_parameter'].sudo().get_param('web.sim.invoice.endpoint.key')
         c_code = self.env['ir.config_parameter'].sudo().get_param('country_code')
@@ -46,6 +47,7 @@ class ResPartner(models.Model):
                                     'company_id': 1, 'not_send_email': True}
                         invoice = self.env['account.invoice'].create(inv_data)
                         invoice._onchange_partner_id()
+
                         line_data = {'sequence': 1, 'product_id': product_sim.id, 'name': product_sim.default_code,
                                      'quantity': round(partner_data['sims'], 2), 'discount': 0, 'uom_id': 1, 'price_unit': price_unit,
                                      'account_id': line_account.id, 'invoice_id': invoice.id}
@@ -71,11 +73,32 @@ class ResPartner(models.Model):
                             line_voz.price_unit = 0.15
                         invoice.compute_taxes()
                         invoice.action_invoice_open()
+
+                        if partner.property_payment_term_id.name in ('Prepago', 'Pago inmediato'):
+                            if partner.valid_mandate_id and partner.valid_mandate_id.partner_bank_id:
+                                rd_payment = self.env['account.payment.mode'].search([('name', '=', 'Recibo domiciliado')])
+                                invoice.write({'payment_mode_id': rd_payment.id})
+                            else:
+                                mail_bank_error_message += _('Partner %s has not a valid mandate or account. Invoice %s has not been changed. \n') \
+                                                          % (partner.name, invoice.number)
                     else:
                         error += 'Partner id %s not found ' % partner_data['odooId']
         else:
             error += 'Response %s with error: %s' % (response.status_code, response.text)
         print(error)
+
+        # Send mail to accounting if there is partners without bank account
+        if mail_bank_error_message:
+            mail_pool = self.env['mail.mail']
+            context = self._context.copy()
+            context.pop('default_state', False)
+            context['message_warn'] = mail_bank_error_message
+            template_id = self.env.ref('sim_manager.email_template_sim_bank_account_error')
+            if template_id:
+                mail_id = template_id.with_context(context).send_mail(self.id)
+                if mail_id:
+                    mail_id_check = mail_pool.browse(mail_id)
+                    mail_id_check.with_context(context).send()
 
 
 class PartnerListener(Component):

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -75,7 +75,8 @@ class ResPartner(models.Model):
                         invoice.action_invoice_open()
 
                         if partner.property_payment_term_id.name in ('Prepago', 'Pago inmediato'):
-                            if partner.valid_mandate_id and partner.valid_mandate_id.partner_bank_id:
+                            valid_mandate = self.env['account.banking.mandate'].search_count([('partner_id', '=', partner.id), ('state', '=', 'valid')])
+                            if valid_mandate > 0:
                                 rd_payment = self.env['account.payment.mode'].search([('name', '=', 'Recibo domiciliado')])
                                 invoice.write({'payment_mode_id': rd_payment.id})
                             else:

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -122,8 +122,8 @@ class SimPackage(models.Model):
         for package in self:
             data = {
                 "origin": c_code.lower(),
-                "odoo_id": package.partner_id.id,
-                "partner_name": package.partner_id.name,
+                "odoo_id": package.partner_id.id or 0,
+                "partner_name": package.partner_id.name or '',
                 "mode": mode,
                 "codes": [sim.code for sim in package.serial_ids],
             }

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -50,7 +50,7 @@
             <form string="SIM packages">
                 <header>
                     <button name="%(sim_manager.action_sim_export_wizard)d" string="Sync web" type="action"
-                            groups="base.group_system"/>
+                            groups="mrp.group_mrp_user"/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
- [IMP]sim_manager: las facturas de clientes prepago se ponen a recibo domiciliado. Email de contabilidad. Se notifica entero y vacío en el return.
- [FIX]sim_manager: cambiada la línea de traducción
- [IMP]sim_manager: grupo menos restrictivo al boton de sincronizar
- [IMP]sim_manager: cambiado tipo de comprobación de mandatos para que vaya más rapido