### PR TITLE
Adjuntar RMA a pedidos

### DIFF
--- a/project-addons/crm_claim_rma_custom/__manifest__.py
+++ b/project-addons/crm_claim_rma_custom/__manifest__.py
@@ -51,6 +51,7 @@
              'data/stage_data.xml',
              'views/res_users_view.xml',
              'data/email_layout.xml',
-             'views/res_partner_view.xml'],
+             'views/res_partner_view.xml',
+             'views/sale_view.xml'],
     "installable": True
 }

--- a/project-addons/crm_claim_rma_custom/data/stage_data.xml
+++ b/project-addons/crm_claim_rma_custom/data/stage_data.xml
@@ -5,4 +5,14 @@
         <field name="sequence">27</field>
         <field name="case_default" eval="True"/>
     </record>
+    <record model="crm.claim.stage" id="stage_claim_pending_rev">
+        <field name="name">Pendiente revisión</field>
+        <field name="sequence">28</field>
+        <field name="case_default" eval="True"/>
+    </record>
+    <record model="crm.claim.stage" id="stage_claim_attached">
+        <field name="name">Adjuntado</field>
+        <field name="sequence">29</field>
+        <field name="case_default" eval="True"/>
+    </record>
 </odoo>

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -629,8 +629,8 @@ msgstr "Depósito"
 #. module: crm_claim_rma_custom
 #: code:addons/crm_claim_rma_custom/models/sale_order.py:67
 #, python-format
-msgid " Add %s  Ub.: %s"
-msgstr " Añadir %s  Ub.: %s"
+msgid " Add %s  Ub.: %s (%s)"
+msgstr " Añadir %s  Ub.: %s (%s)"
 
 #. module: crm_claim_rma_custom
 #: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_choose

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -644,3 +644,13 @@ msgstr "Dir. Envío"
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
 msgid "Pending RMA"
 msgstr "RMAs pendientes"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
+msgid "Attach RMA"
+msgstr "Adjuntar RMA"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_crm_claim_att_order_id
+msgid "Attach Sale"
+msgstr "Pedido adjunto"

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -98,6 +98,8 @@ msgstr "No puede borrar una linea facturada."
 #. module: crm_claim_rma_custom
 #: model:ir.model.fields,field_description:crm_claim_rma_custom.field_claim_invoice_line_claim_id
 #: model:ir.model,name:crm_claim_rma_custom.model_crm_claim
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_claim_id
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_claim_id_ro
 msgid "Claim"
 msgstr "Reclamación"
 
@@ -253,6 +255,7 @@ msgstr "Gestionado en Odoo"
 
 #. module: crm_claim_rma_custom
 #: model:ir.model,name:crm_claim_rma_custom.model_res_partner
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_partner_id
 msgid "Partner"
 msgstr "Empresa"
 
@@ -602,6 +605,7 @@ msgstr "Crear abono"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.invoice_discount_wizard
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.view_pending_rma_filter
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -616,3 +620,27 @@ msgstr "Facturas con descuentos en CRM"
 #, python-format
 msgid "This orders have discounts. Do you want to proceed anyways?: %s"
 msgstr "Las siguientes facturas tienen descuentos. ¿Quieres continuar?: %s"
+
+#. module: crm_claim_rma_custom
+#: code:addons/crm_claim_rma_custom/models/sale_order.py:67
+#, python-format
+msgid " Add %s  Ub.: %s"
+msgstr " Añadir %s  Ub.: %s"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_choose
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.view_pending_rma_filter
+msgid "Add"
+msgstr "Añadir"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_partner_shipping_id
+msgid "Shipping"
+msgstr "Dir. Envío"
+
+#. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:crm_claim_rma_custom.action_show_pending_claims
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.view_pending_rma_filter
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
+msgid "Pending RMA"
+msgstr "RMAs pendientes"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -97,6 +97,8 @@ msgstr "Impossibile eliminare una linea già fatturata"
 #. module: crm_claim_rma_custom
 #: model:ir.model.fields,field_description:crm_claim_rma_custom.field_claim_invoice_line_claim_id
 #: model:ir.model,name:crm_claim_rma_custom.model_crm_claim
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_claim_id
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_claim_id_ro
 msgid "Claim"
 msgstr "Reclamazione"
 
@@ -257,6 +259,7 @@ msgstr "Gestione Odoo"
 
 #. module: crm_claim_rma_custom
 #: model:ir.model,name:crm_claim_rma_custom.model_res_partner
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_partner_id
 msgid "Partner"
 msgstr "Azienda"
 
@@ -517,3 +520,27 @@ msgstr "<p>Gentile cliente,</p> <p>La informiamo che abbiamo ricevuto i prodotti
 #: model:mail.template,subject:crm_claim_rma_custom.rma_received_template
 msgid "Visiotech - RMA received"
 msgstr "Visiotech - RMA ricevuto"
+
+#. module: crm_claim_rma_custom
+#: code:addons/crm_claim_rma_custom/models/sale_order.py:67
+#, python-format
+msgid " Add %s  Ub.: %s"
+msgstr " Aggiungere %s  Ub.: %s"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_choose
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.view_pending_rma_filter
+msgid "Add"
+msgstr "Aggiungere"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_partner_shipping_id
+msgid "Shipping"
+msgstr "Dir. Spedizione"
+
+#. module: crm_claim_rma_custom
+#: model:ir.actions.act_window,name:crm_claim_rma_custom.action_show_pending_claims
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.view_pending_rma_filter
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
+msgid "Pending RMA"
+msgstr "RMAs pendenti"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -544,3 +544,13 @@ msgstr "Dir. Spedizione"
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
 msgid "Pending RMA"
 msgstr "RMAs pendenti"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.sale_order_form_rma_button
+msgid "Attach RMA"
+msgstr "Aggiungere RMA"
+
+#. module: crm_claim_rma_custom
+#: model:ir.model.fields,field_description:crm_claim_rma_custom.field_crm_claim_att_order_id
+msgid "Attach Sale"
+msgstr "Ordine Aggiunto"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -529,8 +529,8 @@ msgstr "Depositi"
 #. module: crm_claim_rma_custom
 #: code:addons/crm_claim_rma_custom/models/sale_order.py:67
 #, python-format
-msgid " Add %s  Ub.: %s"
-msgstr " Aggiungere %s  Ub.: %s"
+msgid " Add %s  Ub.: %s (%s)"
+msgstr " Aggiungere %s  Ub.: %s (%s)"
 
 #. module: crm_claim_rma_custom
 #: model:ir.model.fields,field_description:crm_claim_rma_custom.field_sale_order_claim_wizard_line_choose

--- a/project-addons/crm_claim_rma_custom/models/__init__.py
+++ b/project-addons/crm_claim_rma_custom/models/__init__.py
@@ -4,3 +4,4 @@ from . import partner
 from . import mrp_repair
 from . import stock
 from . import res_users
+from . import sale_order

--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -67,6 +67,8 @@ class CrmClaimRma(models.Model):
     warehouse_date = fields.Date('Final Received Date')
     deposit_id = fields.Many2many('stock.picking', string='Deposit')
 
+    att_order_id = fields.Many2one('sale.order', string='Attach Sale')
+
     check_states = ['substate_received', 'substate_process', 'substate_due_receive']
 
     @api.multi

--- a/project-addons/crm_claim_rma_custom/models/sale_order.py
+++ b/project-addons/crm_claim_rma_custom/models/sale_order.py
@@ -65,7 +65,7 @@ class SaleOrderClaimWizard(models.TransientModel):
         state = self.env.ref('crm_claim_rma_custom.stage_claim_pending_rev')
         for rma in self.line_ids.filtered(lambda l: l.choose):
             notes = order.internal_notes or ''
-            order.internal_notes = notes + _(' Add %s  Ub.: %s') % (rma.claim_id.number, rma.claim_id.location)
+            order.internal_notes = notes + _(' Add %s  Ub.: %s (%s)') % (rma.claim_id.number, rma.claim_id.location, rma.claim_id.partner_id.name)
             rma.claim_id.stage_id = state.id
             rma.claim_id.att_order_id = order.id
 

--- a/project-addons/crm_claim_rma_custom/models/sale_order.py
+++ b/project-addons/crm_claim_rma_custom/models/sale_order.py
@@ -67,6 +67,7 @@ class SaleOrderClaimWizard(models.TransientModel):
             notes = order.internal_notes or ''
             order.internal_notes = notes + _(' Add %s  Ub.: %s') % (rma.claim_id.number, rma.claim_id.location)
             rma.claim_id.stage_id = state.id
+            rma.claim_id.att_order_id = order.id
 
 
 

--- a/project-addons/crm_claim_rma_custom/models/sale_order.py
+++ b/project-addons/crm_claim_rma_custom/models/sale_order.py
@@ -8,7 +8,8 @@ class SaleOrder(models.Model):
         for order in self:
             stage_sale_attach_id = self.env['crm.claim.stage'].search([('name', '=', 'Adjuntar con pedido')]).id
             pending_rmas = self.env['crm.claim'].search_count(
-                [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id)])
+                [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id),
+                 ('delivery_address_id', '=', order.partner_shipping_id.id)])
             order.rma_pending_count = pending_rmas
 
     rma_pending_count = fields.Integer(compute='_compute_rma_count', default=0)
@@ -47,7 +48,8 @@ class SaleOrderClaimWizard(models.TransientModel):
         order = self.env['sale.order'].browse(self.env.context.get('active_ids'))
         stage_sale_attach_id = self.env['crm.claim.stage'].search([('name', '=', 'Adjuntar con pedido')]).id
         pending_rmas = self.env['crm.claim'].search(
-            [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id)])
+            [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id),
+             ('delivery_address_id', '=', order.partner_shipping_id.id)])
 
         for rma in pending_rmas:
             new_line = {'choose': False,

--- a/project-addons/crm_claim_rma_custom/models/sale_order.py
+++ b/project-addons/crm_claim_rma_custom/models/sale_order.py
@@ -1,0 +1,75 @@
+from odoo import models, fields, _, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _compute_rma_count(self):
+        for order in self:
+            stage_sale_attach_id = self.env['crm.claim.stage'].search([('name', '=', 'Adjuntar con pedido')]).id
+            pending_rmas = self.env['crm.claim'].search_count(
+                [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id)])
+            order.rma_pending_count = pending_rmas
+
+    rma_pending_count = fields.Integer(compute='_compute_rma_count', default=0)
+
+    def action_view_pending_rma(self):
+        stage_sale_attach_id = self.env['crm.claim.stage'].search([('name', '=', 'Adjuntar con pedido')]).id
+        pending_rmas = self.env['crm.claim'].search(
+            [('partner_id', '=', self.partner_id.id), ('stage_id', '=', stage_sale_attach_id)])
+
+        action = self.env.ref('crm_claim_rma_custom.action_show_pending_claims').read()[0]
+
+        if len(pending_rmas) > 0:
+            action['domain'] = [('id', 'in', pending_rmas.mapped('id'))]
+        else:
+            action = {'type': 'ir.actions.act_window_close'}
+        return action
+
+
+class SaleOrderClaimWizardLine(models.TransientModel):
+    _name = 'sale.order.claim.wizard.line'
+
+    choose = fields.Boolean('Add')
+    claim_id = fields.Many2one('crm.claim', 'Claim')
+    claim_id_ro = fields.Many2one('crm.claim', 'Claim', readonly=True)
+    partner_id = fields.Many2one('res.partner', 'Partner', readonly=True)
+    partner_shipping_id = fields.Many2one('res.partner', 'Shipping', readonly=True)
+    wizard_id = fields.Many2one('sale.order.claim.wizard')
+
+
+class SaleOrderClaimWizard(models.TransientModel):
+    _name = 'sale.order.claim.wizard'
+
+    @api.model
+    def _get_pending_claims(self):
+        wiz_lines = []
+        order = self.env['sale.order'].browse(self.env.context.get('active_ids'))
+        stage_sale_attach_id = self.env['crm.claim.stage'].search([('name', '=', 'Adjuntar con pedido')]).id
+        pending_rmas = self.env['crm.claim'].search(
+            [('partner_id', '=', order.partner_id.id), ('stage_id', '=', stage_sale_attach_id)])
+
+        for rma in pending_rmas:
+            new_line = {'choose': False,
+                        'claim_id': rma.id,
+                        'claim_id_ro': rma.id,
+                        'partner_id': rma.partner_id,
+                        'partner_shipping_id': rma.delivery_address_id}
+            wiz_lines.append(new_line)
+        return wiz_lines
+
+    line_ids = fields.One2many('sale.order.claim.wizard.line', 'wizard_id', default=_get_pending_claims)
+
+    def add_to_sale_order(self):
+        order = self.env['sale.order'].browse(self.env.context.get('active_ids'))
+        state = self.env.ref('crm_claim_rma_custom.stage_claim_pending_rev')
+        for rma in self.line_ids.filtered(lambda l: l.choose):
+            notes = order.internal_notes or ''
+            order.internal_notes = notes + _(' Add %s  Ub.: %s') % (rma.claim_id.number, rma.claim_id.location)
+            rma.claim_id.stage_id = state.id
+
+
+
+
+
+

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -72,6 +72,7 @@
             </field>
             <field name="model_ref_id" position="after">
                 <field name="client_ref" />
+                <field name="att_order_id"/>
             </field>
             <field name="email_from" position="after">
                 <field name="comercial"/>

--- a/project-addons/crm_claim_rma_custom/views/sale_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/sale_view.xml
@@ -38,9 +38,11 @@
             <xpath expr="//button[@name='action_view_invoice']" position="before">
                 <button type="object" name="action_view_pending_rma"
                         class="oe_stat_button"
-                        icon="fa-wrench"
-                        attrs="{'invisible': [('rma_pending_count','=',0)]}">
-                    <field name="rma_pending_count" widget="statinfo" string="Pending RMA"/>
+                        style="background-color: #ECDDE8;"
+                        attrs="{'invisible': ['|',('rma_pending_count','=',0),('state', 'not in', ['reserve','draft','sent'])]}">
+                    <i class="fa fa-wrench" style="font-size: 24px; color: #875A7B; padding:6px;"/>
+                    <label string="Attach RMA" style="font-weight: normal;"/>
+                    <field name="rma_pending_count" widget="statinfo" string="Adjuntar RMA" style="padding:6px;" attrs="{'invisible':True}"/>
                 </button>
             </xpath>
         </field>

--- a/project-addons/crm_claim_rma_custom/views/sale_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/sale_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pending_rma_filter" model="ir.ui.view">
+        <field name="name">view.pending.rma.filter</field>
+        <field name="model">sale.order.claim.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Pending RMA">
+                <field name="line_ids">
+                    <tree string="Pending RMA" create="false" delete="false" editable="top">
+                        <field name="choose"/>
+                        <field name="claim_id_ro"/>
+                        <field name="partner_id"/>
+                        <field name="partner_shipping_id"/>
+                    </tree>
+                </field>
+                <footer>
+                    <button string="Add" name="add_to_sale_order" type="object" class="oe_highlight"/>
+                    <button string="Cancel" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_show_pending_claims" model="ir.actions.act_window">
+        <field name="name">Pending RMA</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sale.order.claim.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_pending_rma_filter"/>
+        <field name="target">new</field>
+    </record>
+
+    <record id="sale_order_form_rma_button" model="ir.ui.view">
+        <field name="name">sale.order.form.rma.button</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_invoice']" position="before">
+                <button type="object" name="action_view_pending_rma"
+                        class="oe_stat_button"
+                        icon="fa-wrench"
+                        attrs="{'invisible': [('rma_pending_count','=',0)]}">
+                    <field name="rma_pending_count" widget="statinfo" string="Pending RMA"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
[IMP]crm_claim_rma_custom: boton para añadir RMA a los pedidos
[IMP]crm_claim_rma_custom: Se cambia el estado del RMA al añadir al pedido
[IMP]crm_claim_rma_custom: se añade el pedido al RMA al ser adjuntado
[IMP]crm_claim_rma_custom: añadido cliente al mensaje de RMA
[IMP]crm_claim_rma_custom: añadido filtro de envío