### PR TITLE
[Important] Restringir baterias en envios aereos

### DIFF
--- a/project-addons/product_battery/__manifest__.py
+++ b/project-addons/product_battery/__manifest__.py
@@ -5,7 +5,7 @@
     'description': """""",
     'author': 'Visiotech',
     'website': 'www.visiotechsecurity.com',
-    "depends": ['product', 'stock'],
-    "data": ['views/product_view.xml', 'views/battery_view.xml', 'security/ir.model.access.csv'],
+    "depends": ['product', 'stock', 'transportation'],
+    "data": ['views/product_view.xml', 'views/battery_view.xml', 'views/sale_view.xml', 'security/ir.model.access.csv'],
     "installable": True
 }

--- a/project-addons/product_battery/i18n/es.po
+++ b/project-addons/product_battery/i18n/es.po
@@ -37,3 +37,13 @@ msgstr "Notas"
 #: model:ir.actions.act_window,help:product_battery.action_battery
 msgid "Manage the battery types"
 msgstr "Gestionar los tipos de batería"
+
+#. module: product_battery
+#: model:ir.model.fields,field_description:product_battery.field_product_battery_forbidden_ship_ids
+msgid "Forbidden shipping services"
+msgstr "Servicios de envío no permitidos"
+
+#. module: product_battery
+#: model:ir.model.fields,field_description:product_battery.field_sale_order_allow_ship_battery
+msgid "Allow ship batteries"
+msgstr "Permitir envío de baterías"

--- a/project-addons/product_battery/i18n/es.po
+++ b/project-addons/product_battery/i18n/es.po
@@ -47,3 +47,11 @@ msgstr "Servicios de envío no permitidos"
 #: model:ir.model.fields,field_description:product_battery.field_sale_order_allow_ship_battery
 msgid "Allow ship batteries"
 msgstr "Permitir envío de baterías"
+
+#. module: product_battery
+#: code:addons/product_battery/models/sale.py:20
+#, python-format
+msgid "\n"
+"The order can not be confirmed, there are products with batteries that can not be shipped by %s"
+msgstr "\n"
+"El pedido no se puede confirmar, hay productos con baterías que no pueden ser enviadas por %s"

--- a/project-addons/product_battery/i18n/it.po
+++ b/project-addons/product_battery/i18n/it.po
@@ -47,3 +47,11 @@ msgstr "Servizi di spedizione vietati"
 #: model:ir.model.fields,field_description:product_battery.field_sale_order_allow_ship_battery
 msgid "Allow ship batteries"
 msgstr "Permettere spedizione di batterie"
+
+#. module: product_battery
+#: code:addons/product_battery/models/sale.py:20
+#, python-format
+msgid "\n"
+"The order can not be confirmed, there are products with batteries that can not be shipped by %s"
+msgstr "\n"
+"L'ordine non puo essere confirmato, ci sono prodotti con batterie che non possono essere spedite con %s"

--- a/project-addons/product_battery/i18n/it.po
+++ b/project-addons/product_battery/i18n/it.po
@@ -37,3 +37,13 @@ msgstr "Note"
 #: model:ir.actions.act_window,help:product_battery.action_battery
 msgid "Manage the battery types"
 msgstr "Gestire i tipi di batteria"
+
+#. module: product_battery
+#: model:ir.model.fields,field_description:product_battery.field_product_battery_forbidden_ship_ids
+msgid "Forbidden shipping services"
+msgstr "Servizi di spedizione vietati"
+
+#. module: product_battery
+#: model:ir.model.fields,field_description:product_battery.field_sale_order_allow_ship_battery
+msgid "Allow ship batteries"
+msgstr "Permettere spedizione di batterie"

--- a/project-addons/product_battery/models/__init__.py
+++ b/project-addons/product_battery/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_battery
 from . import product
 from . import stock
+from . import sale

--- a/project-addons/product_battery/models/product_battery.py
+++ b/project-addons/product_battery/models/product_battery.py
@@ -7,3 +7,4 @@ class ProductBattery(models.Model):
 
     name = fields.Char("Battery type", size=64, required=True)
     notes = fields.Text('Notes')
+    forbidden_ship_ids = fields.Many2many('transportation.service', string='Forbidden shipping services')

--- a/project-addons/product_battery/models/sale.py
+++ b/project-addons/product_battery/models/sale.py
@@ -1,0 +1,25 @@
+from odoo import fields, models, _, exceptions, api
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    allow_ship_battery = fields.Boolean("Allow ship batteries")
+
+    @api.multi
+    def action_confirm(self):
+        for sale in self:
+            if not sale.allow_ship_battery:
+                transport_service = sale.service_id
+                msg = ''
+                for line in sale.order_line:
+                    if transport_service in line.product_id.battery_id.forbidden_ship_ids:
+                        msg += "\n %s - %s" % (line.product_id.default_code, line.product_id.battery_id.name)
+                if msg:
+                    msg_error = _("\nThe order can not be confirmed, there are products with batteries that can not be shipped by %s") \
+                           % transport_service.name
+                    msg_error += msg
+                    raise exceptions.UserError(msg_error)
+
+        return super(SaleOrder, self).action_confirm()

--- a/project-addons/product_battery/views/battery_view.xml
+++ b/project-addons/product_battery/views/battery_view.xml
@@ -17,11 +17,13 @@
         <field name="arch" type="xml">
             <form string="Battery types">
                 <sheet>
-                    <label for="name"/>
-                    <field name="name"/>
-                    <div class="text-muted">
-                        <field name="notes" placeholder="Notes"/>
-                    </div>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="notes" placeholder="Notes"/>
+                            <field name="forbidden_ship_ids" widget="many2many_tags"/>
+                        </group>
+                    </group>
                 </sheet>
             </form>
         </field>

--- a/project-addons/product_battery/views/sale_view.xml
+++ b/project-addons/product_battery/views/sale_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_add_allow_confirm_form" model="ir.ui.view">
+        <field name="name">sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="fiscal_position_id" position="after">
+                <field name="allow_ship_battery"
+                    groups="block_invoices.group_unblock_magreb"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- [IMP]product_battery: no permitir confirmar pedido para ciertos envios con baterias
- [IMP]product_battery: añadidos ficheros
- [IMP]product_battery: añadida traduccion del mensaje de warning