### PR TITLE
Referencias de cliente al unir pedidos

### DIFF
--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -130,5 +130,6 @@ class MergePurchaseOrder(models.TransientModel):
         so.internal_notes = internal_notes
         so.sale_notes = sale_notes
         if client_order_ref:
-            so.client_order_ref = client_order_ref
+            client_order_ref_orders = client_order_ref.split('\n')
+            so.client_order_ref = '\n'.join(reversed(client_order_ref_orders))
         so.message_post(body=_('This order has been created by merging these orders: %s')%sale_orders_name)

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -78,16 +78,12 @@ class MergePurchaseOrder(models.TransientModel):
         notes=""
         internal_notes=""
         sale_notes=""
-        client_order_ref = False
-        for order in sale_orders:
+        client_order_ref = ""
+        for order in sale_orders.sorted(key=id):
             notes += order.note + "\n" if order.note else ""
             internal_notes += order.internal_notes + "\n" if order.internal_notes else ""
             sale_notes += order.sale_notes + "\n" if order.sale_notes else ""
-            if order.client_order_ref:
-                if client_order_ref:
-                    client_order_ref += order.client_order_ref + "\n"
-                else:
-                    client_order_ref = order.client_order_ref + "\n"
+            client_order_ref += order.client_order_ref + " + \n" if order.client_order_ref else ""
             if merge_mode and order == so:
                 continue
             for line in order.order_line:
@@ -129,7 +125,5 @@ class MergePurchaseOrder(models.TransientModel):
         so.note = notes
         so.internal_notes = internal_notes
         so.sale_notes = sale_notes
-        if client_order_ref:
-            client_order_ref_orders = client_order_ref.split('\n')
-            so.client_order_ref = ' + '.join(reversed(client_order_ref_orders))[3:]
+        so.client_order_ref = client_order_ref[:-4]
         so.message_post(body=_('This order has been created by merging these orders: %s')%sale_orders_name)

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -75,7 +75,6 @@ class MergePurchaseOrder(models.TransientModel):
         }
 
     def merge_orders(self, sale_orders, so, merge_mode=False):
-        import ipdb
         notes=""
         internal_notes=""
         sale_notes=""

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -86,9 +86,9 @@ class MergePurchaseOrder(models.TransientModel):
             if not merge_mode:
                 client_order_ref += order.client_order_ref + " + \n" if order.client_order_ref else ""
             else:
-                if  order == so:
+                if order == so:
                     continue
-                else:
+                elif so.client_order_ref:
                     so.client_order_ref += " + \n" + order.client_order_ref if order.client_order_ref else ""
             for line in order.order_line:
                 existing_so_line = False

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -131,5 +131,5 @@ class MergePurchaseOrder(models.TransientModel):
         so.sale_notes = sale_notes
         if client_order_ref:
             client_order_ref_orders = client_order_ref.split('\n')
-            so.client_order_ref = '\n'.join(reversed(client_order_ref_orders))
+            so.client_order_ref = ' + '.join(reversed(client_order_ref_orders))[3:]
         so.message_post(body=_('This order has been created by merging these orders: %s')%sale_orders_name)

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -125,5 +125,6 @@ class MergePurchaseOrder(models.TransientModel):
         so.note = notes
         so.internal_notes = internal_notes
         so.sale_notes = sale_notes
-        so.client_order_ref = client_order_ref[:-4]
+        if client_order_ref:
+            so.client_order_ref = client_order_ref[:-4]
         so.message_post(body=_('This order has been created by merging these orders: %s')%sale_orders_name)

--- a/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
+++ b/project-addons/merge_sale_order/wizard/merge_sale_order_wizard.py
@@ -75,6 +75,7 @@ class MergePurchaseOrder(models.TransientModel):
         }
 
     def merge_orders(self, sale_orders, so, merge_mode=False):
+        import ipdb
         notes=""
         internal_notes=""
         sale_notes=""
@@ -90,14 +91,12 @@ class MergePurchaseOrder(models.TransientModel):
                 existing_so_line = False
                 if so.order_line:
                     for so_line in so.order_line:
-                        if line.product_id == so_line.product_id and \
-                                line.price_unit == so_line.price_unit:
+                        if line.product_id == so_line.product_id and line.price_unit == so_line.price_unit:
                             existing_so_line = so_line
                             break
                 if existing_so_line:
                     if existing_so_line.product_id.categ_id.with_context(lang='es_ES').name != 'Portes':
-                        existing_so_line.product_uom_qty += \
-                            line.product_uom_qty
+                        existing_so_line.product_uom_qty += line.product_uom_qty
                         taxes = existing_so_line.tax_id + line.tax_id
                         existing_so_line.tax_id = [(6, 0, taxes.ids)]
                         analytic_tags = existing_so_line.analytic_tag_ids + line.analytic_tag_ids


### PR DESCRIPTION
- [FIX] merge_sale_order: ordenado listado de pedidos por id
- [FIX] merge_sale_order: corregido unir pedidos con referencia cliente vacía
- [FIX] merge_sale_order: referencias para unir en pedido o en pedido nuevo
- [FIX] merge_sale_order: arreglado unir pedidos en uno sin referencia
- [FIX] merge_sale_custom: solucionado error referencias únicas