### PR TITLE
Comprobación producto genérico al tramitar pedido

### DIFF
--- a/project-addons/crm_rma_advance_location/i18n/es.po
+++ b/project-addons/crm_rma_advance_location/i18n/es.po
@@ -150,11 +150,6 @@ msgstr "Producto a pérdidas"
 
 #. module: crm_rma_advance_location
 #: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
-msgid "Product to refurbish stock"
-msgstr "Producto a averiados"
-
-#. module: crm_rma_advance_location
-#: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
 msgid "Product to stock"
 msgstr "Producto a existencias"
 
@@ -352,3 +347,8 @@ msgstr "Todos los productos deben tener una descripción del problema, rellénel
 #: model:ir.model.fields,field_description:crm_rma_advance_location.field_res_partner_rmp_partner
 msgid "RMP partner"
 msgstr "Empresa RMP"
+
+#. module: crm_rma_advance_location
+#: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
+msgid "Product to refurbish stock"
+msgstr "Producto a reacondicionamiento"

--- a/project-addons/crm_rma_advance_location/i18n/it.po
+++ b/project-addons/crm_rma_advance_location/i18n/it.po
@@ -150,11 +150,6 @@ msgstr "Invia a perdite"
 
 #. module: crm_rma_advance_location
 #: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
-msgid "Product to refurbish stock"
-msgstr "Prodotto a danneggiato"
-
-#. module: crm_rma_advance_location
-#: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
 msgid "Product to stock"
 msgstr "Invia a stock"
 
@@ -351,3 +346,8 @@ msgstr "Tutti i prodotti devono avere una descrizione del problema, si prega di 
 #: model:ir.model.fields,field_description:crm_rma_advance_location.field_res_partner_rmp_partner
 msgid "RMP partner"
 msgstr "Azienda RMP"
+
+#. module: crm_rma_advance_location
+#: model:ir.ui.view,arch_db:crm_rma_advance_location.picking_in_form
+msgid "Product to refurbish stock"
+msgstr "Prodotto in guasti"

--- a/project-addons/sale_custom/i18n/es.po
+++ b/project-addons/sale_custom/i18n/es.po
@@ -198,3 +198,14 @@ msgstr "Albarán no sincronizable"
 #: model:ir.actions.act_window,name:sale_custom.open_historical_orders
 msgid "Historical orders"
 msgstr "Pedidos del cliente"
+
+#. module: sale_custom
+#: code:addons/sale_custom/models/sale.py:241
+#, python-format
+msgid "You can't confirm a sale with the product %s."
+msgstr "No puedes confirmar un pedido con el producto %s."
+
+#. module: sale_custom
+#: model:ir.ui.view,arch_db:sale_custom.view_order_form_sync_picking
+msgid "Force generic product"
+msgstr "Forzar producto genérico"

--- a/project-addons/sale_custom/i18n/it.po
+++ b/project-addons/sale_custom/i18n/it.po
@@ -194,3 +194,14 @@ msgstr "Quest'anno"
 #: model:ir.actions.act_window,name:sale_custom.open_historical_orders
 msgid "Historical orders"
 msgstr "Ordini dei clienti"
+
+#. module: sale_custom
+#: code:addons/sale_custom/models/sale.py:241
+#, python-format
+msgid "You can't confirm a sale with the product %s."
+msgstr "Non è possibile confermare un ordine con il prodotto %s."
+
+#. module: sale_custom
+#: model:ir.ui.view,arch_db:sale_custom.view_order_form_sync_picking
+msgid "Force generic product"
+msgstr "Forza prodotto generico"

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -237,7 +237,7 @@ class SaleOrder(models.Model):
             self.env.user.notify_warning(message=warning, sticky=True)
 
     def action_confirm(self):
-        if any(d.product_id.id == 17897 for d in self.order_line) and not self.force_generic_product:
+        if any(d.product_id.id == self.env.ref('product_product.generic_product').id for d in self.order_line) and not self.force_generic_product:
             raise UserError(_("You can't confirm a sale with the product %s.")%(next(item.product_id.name for item in self.order_line if item.product_id.id == 17897)))
         if not self.env.context.get('bypass_override', False) and (
                 not self.env.context.get('bypass_risk', False) or self.env.context.get('force_check', False)):

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -118,6 +118,7 @@ class SaleOrder(models.Model):
     not_sync_picking = fields.Boolean()
     pricelist_id = fields.Many2one(
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)], 'reserve': [('readonly', False)]})
+    force_generic_product = fields.Boolean(default= False)
 
     is_editable = fields.Boolean(compute='_get_is_editable', default=True)
 
@@ -236,6 +237,8 @@ class SaleOrder(models.Model):
             self.env.user.notify_warning(message=warning, sticky=True)
 
     def action_confirm(self):
+        if any(d.product_id.id == 17897 for d in self.order_line) and not self.force_generic_product:
+            raise UserError(_("You can't confirm a sale with the product %s.")%(next(item.product_id.name for item in self.order_line if item.product_id.id == 17897)))
         if not self.env.context.get('bypass_override', False) and (
                 not self.env.context.get('bypass_risk', False) or self.env.context.get('force_check', False)):
             user_buyer = self.env['ir.config_parameter'].sudo().get_param(

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -326,6 +326,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_shipping']/field[@name='scheduled_date']" position="after">
                 <field name="not_sync_picking" string="Non-Synchronizable Picking" groups="base.group_system" />
+                <field name="force_generic_product" string="Force generic product" groups="base.group_system" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- [IMP] sale_custom: no tramitar pedidos con producto genérico y chec forzar producto genérico
- [IMP] sale_custom: añadida comprobacion con el xml_id
- [FIX] crm_rma_advance_location: actualizada traducción 'Product to refurbish stock'