### PR TITLE
Retoques compras

### DIFF
--- a/project-addons/flask_middleware_connector/models/product/common.py
+++ b/project-addons/flask_middleware_connector/models/product/common.py
@@ -54,7 +54,7 @@ class ProductTemplateListener(Component):
         if record.image or len(fields) != 1:
             for field in up_fields:
                 if field in fields:
-                    if record.sale_ok or "sale_ok" in fields:
+                    if record.sale_ok or "sale_ok" in fields or "name" in fields:
                         product = self.env["product.product"].search(
                             [('product_tmpl_id', '=', record.id)])
                         product.with_delay(priority=11, eta=60).update_product()
@@ -88,7 +88,7 @@ class ProductListener(Component):
             "last_sixty_days_sales", "joking_index", "sale_ok", "barcode",
             "description_sale", "manufacturer_pref", "standard_price", "type",
             "discontinued", "state", "item_ids", "sale_in_groups_of", "replacement_id",
-            "weight", "volume", "standard_price_2_inc"
+            "weight", "volume", "standard_price_2_inc", "name"
         ]
 
         country_code = self.env['ir.config_parameter'].sudo().get_param('country_code')
@@ -97,7 +97,7 @@ class ProductListener(Component):
 
         for field in up_fields:
             if field in fields:
-                if record.sale_ok or "sale_ok" in fields:
+                if record.sale_ok or "sale_ok" in fields or "name" in fields:
                     record.with_delay(priority=11, eta=30).update_product()
                     break
 

--- a/project-addons/purchase_picking/models/purchase.py
+++ b/project-addons/purchase_picking/models/purchase.py
@@ -29,7 +29,7 @@ class PurchaseOrder(models.Model):
 
     def _search_containers(self, operator, value):
         containers = self.env['stock.container'].search([('name', operator, value)])
-        return [('id', 'in', containers.mapped('picking_ids').mapped('purchase_id').ids)]
+        return [('id', 'in', containers.mapped('move_ids.purchase_line_id.order_id').ids)]
 
     picking_created = fields.Boolean('Picking created', compute='is_picking_created')
 

--- a/project-addons/separate_purchase_orders/views/purchase_view.xml
+++ b/project-addons/separate_purchase_orders/views/purchase_view.xml
@@ -69,6 +69,7 @@
                                     <field name="date_planned" invisible="1"/>
                                     <field name="product_id"
                                            context="{'partner_id':parent.partner_id, 'quantity':product_qty,'uom':product_uom, 'company_id': parent.company_id}"
+                                           options="{'no_create': True}"
                                     />
                                     <field name="name"/>
                                     <field name="move_dest_ids" invisible="1"/>


### PR DESCRIPTION
- [IMP]purchase_picking: cambiada forma de buscar los contenedores
- [IMP]separate_purchase_orders: eliminada posibilidad de crear producto en OC
- [IMP]flask_middleware_connector: se lanza update siempre que se escribe el nombre