### PR TITLE
[HOTFIX] Error albaranes parcializados

### DIFF
--- a/project-addons/kitchen/i18n/es.po
+++ b/project-addons/kitchen/i18n/es.po
@@ -543,6 +543,11 @@ msgid "Erase Logo"
 msgstr "Borrar Logo"
 
 #. module: kitchen
+#: model:ir.model.fields,field_description:kitchen.field_customization_line_wizard_id
+msgid "wizard"
+msgstr "wizard"
+
+#. module: kitchen
 #: code:addons/kitchen/wizard/create_customization_wizard.py:70
 #: code:addons/kitchen/models/kitchen_customization.py:342
 msgid "You can't create a customization without check erase logo option of this product : %s"

--- a/project-addons/kitchen/models/picking.py
+++ b/project-addons/kitchen/models/picking.py
@@ -79,8 +79,6 @@ class StockPicking(models.Model):
                     body=_('This picking has been created from an order with customized products'))
             elif bck.customization_ids:
                 bck.not_sync = True
-            else:
-                pick.not_sync = True
         return bcks
 
     @api.multi


### PR DESCRIPTION
- [HOTFIX] kirchen: corregido error que hacía que todos los albaranes parcializados con o sin personalizaciones se pusieran como no sincronizables