### PR TITLE
Gestión de reservas por equipo

### DIFF
--- a/project-addons/custom_account/views/sale_view.xml
+++ b/project-addons/custom_account/views/sale_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="fiscal_position_id" position="after">
                 <field name="allow_payment_term"
-                    groups="base.group_system"/>
+                    groups="account.group_account_manager"/>
             </field>
         </field>
     </record>

--- a/project-addons/reserve_without_save_sale/models/sale.py
+++ b/project-addons/reserve_without_save_sale/models/sale.py
@@ -234,9 +234,6 @@ class SaleOrderLine(models.Model):
     @api.depends('order_id.partner_id')
     def _compute_hide_reserve_buttons(self):
         for line in self:
-            if line.order_id.partner_id.user_id.id == line.env.user.id \
-                    or line.env.user.has_group('reserve_without_save_sale.reserves_editor'):
-                line.hide_reserve_buttons = False
-            else:
-                line.hide_reserve_buttons = True
+            line.hide_reserve_buttons = not(line.order_id.partner_id.user_id.id == line.env.user.id \
+                    or line.env.user.has_group('reserve_without_save_sale.reserves_editor'))
 

--- a/project-addons/stock_custom/models/sale.py
+++ b/project-addons/stock_custom/models/sale.py
@@ -1,7 +1,7 @@
 # © 2016 Comunitea
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class SaleOrder(models.Model):
@@ -129,3 +129,17 @@ WHERE A.order_id IS NOT NULL
             'target': 'new',
             'context': ctx,
         }
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    @api.depends('order_id.partner_id')
+    def _compute_hide_reserve_buttons(self):
+        super(SaleOrderLine, self)._compute_hide_reserve_buttons()
+        for line in self:
+            line.hide_reserve_buttons = line.hide_reserve_buttons and \
+                                        not (line.order_id.partner_id.user_id.sale_team_id.id == line.env.user.sale_team_id.id
+                                             and not line.env.user.has_group('stock_custom.group_comercial_ext'))


### PR DESCRIPTION
-[[FIX] reserve_without_save_sale: refactorizado método](https://github.com/Comunitea/CMNT_004_15/commit/c1e05491ef113b3ea4903dde9cd40e08bf2e373b)
-[[IMP] stock_custom: Añadido que se pueda gestionar las reservas entre el mismo equipo de ventas(https://github.com/Comunitea/CMNT_004_15/commit/13467d34fc337b95cff98b2b925f20535858f5e6)
- [[FIX] custom_account: Cambio de grupo en límite por prepago](https://github.com/Comunitea/CMNT_004_15/commit/7ca06cf09114734dbfe3db064056d8cdc4e7177f)
