### PR TITLE
Comprobación Nº de Serie al ejecutar "Producto a Existencias"

### DIFF
--- a/project-addons/sim_manager/models/claim.py
+++ b/project-addons/sim_manager/models/claim.py
@@ -13,12 +13,19 @@ class ClaimMakePicking(models.TransientModel):
         move = picking_id.move_lines.filtered(lambda l: l.claim_line_id.id == claim_line_id)
         move.write({'lots_text': claim_line.prodlot_id})
 
+
+class ClaimMakePickingFromPicking(models.TransientModel):
+
+    _inherit = 'claim_make_picking_from_picking.wizard'
+
     @api.multi
-    def action_create_picking(self):
-        for wizard_claim_line in self.claim_line_ids:
-            if wizard_claim_line.product_id.track_serial and not wizard_claim_line.prodlot_id:
+    def action_create_picking_from_picking(self):
+        for pick_line in self.picking_line_ids:
+            if pick_line.claim_line_id.product_id.track_serial and not pick_line.claim_line_id.prodlot_id:
                 raise UserError(_("You must specify the serial number of the serial products"))
-        res = super(ClaimMakePicking, self).action_create_picking()
+            elif pick_line.claim_line_id.product_id.track_serial and pick_line.claim_line_id.prodlot_id:
+                pick_line.lots_text = pick_line.claim_line_id.prodlot_id
+        res = super(ClaimMakePickingFromPicking, self).action_create_picking_from_picking()
         return res
 
 


### PR DESCRIPTION
- [[IMP]sim_manager: solo pide numero de serie al meter a existencias](https://github.com/Comunitea/CMNT_004_15/commit/e7dd8abd36ac200fc0627e26604809bb00ad9756)