### PR TITLE
Cambios en análisis de Albaranes para baterías

### DIFF
--- a/project-addons/product_battery/__manifest__.py
+++ b/project-addons/product_battery/__manifest__.py
@@ -6,7 +6,8 @@
     'author': 'Visiotech',
     'website': 'www.visiotechsecurity.com',
     "depends": ['product', 'stock', 'transportation'],
-    "data": ['views/product_view.xml', 'views/battery_view.xml', 'views/sale_view.xml', 'security/ir.model.access.csv',
+    "data": ['data/battery_data.xml', 'views/product_view.xml', 'views/battery_view.xml', 'views/sale_view.xml',
+             'security/ir.model.access.csv'
              ],
     "installable": True
 }

--- a/project-addons/product_battery/data/battery_data.xml
+++ b/project-addons/product_battery/data/battery_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record model="product.battery" id="no_battery">
+        <field name="name">No battery</field>
+    </record>
+</odoo>

--- a/project-addons/product_battery/views/product_view.xml
+++ b/project-addons/product_battery/views/product_view.xml
@@ -7,8 +7,10 @@
         <field name="arch" type="xml">
             <group name="group_lots_and_weight" position="inside">
                 <field name="battery_id"/>
-                <field name="num_batteries"/>
-                <field name="battery_mode"/>
+                <field name="battery_mode" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d)],
+                'readonly':['|',('battery_id','=',False),('battery_id','=',%(product_battery.no_battery)d)]}"/>
+                <field name="num_batteries" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d)],
+                'readonly':['|',('battery_id','=',False),('battery_id','=',%(product_battery.no_battery)d)]}"/>
             </group>
         </field>
     </record>

--- a/project-addons/stock_custom/i18n/es.po
+++ b/project-addons/stock_custom/i18n/es.po
@@ -704,3 +704,19 @@ msgstr "Número de Baterías"
 #: model:ir.model.fields,field_description:stock_custom.field_stock_picking_report_product_weight
 msgid "Weight"
 msgstr "Peso del producto"
+
+#. module: stock_custom
+#: model:ir.model.fields,field_description:stock_custom.field_stock_picking_report_weight_total
+msgid "Total Weight"
+msgstr "Peso total"
+
+#. module: stock_custom
+#: model:ir.model.fields,field_description:stock_custom.field_stock_picking_report_num_batteries_total
+msgid "Num. Batteries Total"
+msgstr "Nº Total de Baterías"
+
+#. module: stock_custom
+#: model:ir.model.fields,field_description:stock_custom.field_stock_picking_report_country_dest_id
+msgid "Country Dest"
+msgstr "País de Destino"
+

--- a/project-addons/stock_custom/report/stock_report.py
+++ b/project-addons/stock_custom/report/stock_report.py
@@ -49,6 +49,9 @@ class StockPickingReport(models.Model):
     product_country_origin_id = fields.Many2one('res.country',readonly=True)
     product_num_batteries = fields.Float('Num Batteries', readonly=True)
     product_weight = fields.Float('Weight', readonly=True)
+    weight_total = fields.Float('Total Weight', readonly=True)
+    num_batteries_total = fields.Float('Num. Batteries Total', readonly=True)
+    country_dest_id = fields.Many2one('res.country', readonly=True)
 
     def _select(self):
         select_str = """
@@ -90,7 +93,10 @@ class StockPickingReport(models.Model):
                     t.battery_id as product_battery,
                     t.battery_mode as product_battery_mode,
                     t.num_batteries as product_num_batteries,
-                    t.weight as product_weight
+                    t.weight as product_weight,
+                    t.weight * sm.product_qty as weight_total,
+                    t.num_batteries * sm.product_qty as num_batteries_total,
+                    r.country_id as country_dest_id
 
         """
         return select_str
@@ -159,7 +165,8 @@ class StockPickingReport(models.Model):
                     t.battery_id,
                     t.battery_mode,
                     t.num_batteries,
-                    t.weight
+                    t.weight,
+                    r.country_id
         """
         return group_by_str
 


### PR DESCRIPTION
-  [[IMP] product_battery: añadido condiciones de solo lectura y de obligatoriedad](https://github.com/Comunitea/CMNT_004_15/commit/4f7d5c28e57f21ce26cd59a349b9f34acbc344b7)
- [[IMP] syock_custom: Añadido peso total, nº baterias totales y país de  destino en el informe de albaranes](https://github.com/Comunitea/CMNT_004_15/commit/c43552fd4cd79b73ec0276d00292d21070b5e9d5)