### PR TITLE
Cambios varios

### DIFF
--- a/project-addons/picking_incidences/models/stock.py
+++ b/project-addons/picking_incidences/models/stock.py
@@ -269,5 +269,6 @@ class ReturnPicking(models.TransientModel):
     _inherit = 'stock.return.picking'
 
     def create_returns(self):
-        super(ReturnPicking, self).create_returns()
+        res = super(ReturnPicking, self).create_returns()
         self.picking_id.block_picking = False
+        return res

--- a/project-addons/pmp_landed_costs/views/stock_landed_costs_view.xml
+++ b/project-addons/pmp_landed_costs/views/stock_landed_costs_view.xml
@@ -33,6 +33,9 @@
             <xpath expr="//field[@name='valuation_adjustment_lines']/tree/field[@name='volume']" position="after">
                 <field name="tariff" readonly="1"/>
             </xpath>
+            <xpath expr="//field[@name='cost_lines']/tree/field[@name='product_id']" position="attributes">
+                <attribute name="options">{'no_quick_create':True,'no_create_edit':True}</attribute>
+            </xpath>
             <field name="picking_ids" position="attributes">
                 <attribute name="domain">[('state', '=', 'done'),('picking_type_code', '=', 'incoming')]</attribute>
             </field>

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -652,8 +652,7 @@ class PromotionsRulesActions(models.Model):
 
     def action_change_pricelist_category(self, order):
         for order_line in order.order_line:
-            if eval(self.product_code) == \
-                    order_line.product_id.categ_id.name:
+            if eval(self.product_code) in order_line.product_id.categ_id.display_name:
                 self.change_pricelist_line(order_line)
         return {}
 


### PR DESCRIPTION
- [FIX]picking_incidences: se devuelve el super para obtener la acción bien
- [FIX]sale_promotions_extend: recuperamos el in en la categoria
- [IMP]pmp_landed_costs: se elimina posibilidad de crear productos en costes en destino