### PR TITLE
Modo de batería no obligatorio si el producto es EOL

### DIFF
--- a/project-addons/product_battery/views/product_view.xml
+++ b/project-addons/product_battery/views/product_view.xml
@@ -7,9 +7,9 @@
         <field name="arch" type="xml">
             <group name="group_lots_and_weight" position="inside">
                 <field name="battery_id"/>
-                <field name="battery_mode" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d)],
+                <field name="battery_mode" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d),('state','!=','end')],
                 'readonly':['|',('battery_id','=',False),('battery_id','=',%(product_battery.no_battery)d)]}"/>
-                <field name="num_batteries" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d)],
+                <field name="num_batteries" attrs="{'required':[('battery_id','!=',False),('battery_id','!=',%(product_battery.no_battery)d),('state','!=','end')],
                 'readonly':['|',('battery_id','=',False),('battery_id','=',%(product_battery.no_battery)d)]}"/>
             </group>
         </field>


### PR DESCRIPTION
- [FIX] product_battery: campos requeridos si no está en fin de ciclo de vida