### PR TITLE
Error al cancelar albaranes en IT

### DIFF
--- a/project-addons/picking_sync_it/__manifest__.py
+++ b/project-addons/picking_sync_it/__manifest__.py
@@ -4,7 +4,7 @@
     'version': '11.0.0.0.1',
     'author': 'Visiotech',
     'category': '',
-    'depends': ['stock', 'purchase', 'base_synchro', 'picking_incidences', 'queue_job'],
+    'depends': ['stock', 'purchase', 'purchase_picking', 'base_synchro', 'picking_incidences', 'queue_job'],
     'data': ["views/stock_picking_view.xml",
              "views/email_template.xml"],
     'active': False,


### PR DESCRIPTION
- [[FIX] picking_Sync_it: corregido error de dependencias que hacía que no se ejecutaran bien los trabajos al cancelar albarán](https://github.com/Comunitea/CMNT_004_15/commit/4bb40b425cacd3e1d694baeb48f894a38c8061d2)