### PR TITLE
Archivar en vez de eliminar packs y asociados

### DIFF
--- a/project-addons/unlink_to_archive/__init__.py
+++ b/project-addons/unlink_to_archive/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/unlink_to_archive/__manifest__.py
+++ b/project-addons/unlink_to_archive/__manifest__.py
@@ -1,0 +1,16 @@
+
+{
+    'name': 'Unlink to Archive',
+    'version': '1.0',
+    'category': 'Custom',
+    'description': """
+        Change Unlink Action to Archive in some models
+    """,
+    'author': 'Visiotech',
+    'website': '',
+    'depends': ['mrp','associated_products'
+                ],
+    'data': [],
+    'installable': True
+}
+

--- a/project-addons/unlink_to_archive/models/__init__.py
+++ b/project-addons/unlink_to_archive/models/__init__.py
@@ -1,0 +1,2 @@
+from . import mrp
+from . import product

--- a/project-addons/unlink_to_archive/models/mrp.py
+++ b/project-addons/unlink_to_archive/models/mrp.py
@@ -1,0 +1,20 @@
+from odoo import models, api, fields
+
+class MrpBom(models.Model):
+
+    _inherit = 'mrp.bom'
+
+    @api.multi
+    def unlink(self):
+        self.write({'active': False})
+
+class MrpBomLine(models.Model):
+
+    _inherit = 'mrp.bom.line'
+
+
+    active = fields.Boolean('Active', default=True)
+
+    @api.multi
+    def unlink(self):
+        self.write({'active':False})

--- a/project-addons/unlink_to_archive/models/mrp.py
+++ b/project-addons/unlink_to_archive/models/mrp.py
@@ -7,6 +7,7 @@ class MrpBom(models.Model):
     @api.multi
     def unlink(self):
         self.write({'active': False})
+        self.bom_line_ids.unlink()
 
 class MrpBomLine(models.Model):
 

--- a/project-addons/unlink_to_archive/models/product.py
+++ b/project-addons/unlink_to_archive/models/product.py
@@ -1,0 +1,13 @@
+from odoo import models,api,fields
+
+
+class AssociatedProducts(models.Model):
+
+    _inherit = 'product.associated'
+
+    active = fields.Boolean('Active', default=True)
+
+    @api.multi
+    def unlink(self):
+        self.write({'active': False})
+

--- a/project-addons/unlink_to_archive/tests/__init__.py
+++ b/project-addons/unlink_to_archive/tests/__init__.py
@@ -1,0 +1,3 @@
+
+from . import test_mrp_bom
+from . import test_product_associated

--- a/project-addons/unlink_to_archive/tests/test_mrp_bom.py
+++ b/project-addons/unlink_to_archive/tests/test_mrp_bom.py
@@ -1,0 +1,49 @@
+
+from odoo.tests.common import SavepointCase
+
+
+class TestMrpBom(SavepointCase):
+    post_install = True
+    at_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMrpBom, cls).setUpClass()
+        cls.mrp_bom_model = cls.env['mrp.bom']
+        cls.uom_unit = cls.env.ref('product.product_uom_unit')
+        cls.product_model = cls.env['product.product']
+
+        cls.product_id = cls.product_model.create({'name': "Test",
+                                                   'default_code': "Test"})
+
+        cls.product_id2 = cls.product_model.create({'name': "Test2",
+                                                     'default_code': "Test2"})
+        cls.mrp_bom_obj = cls.mrp_bom_model.create({
+            'product_id': cls.product_id.id,
+            'product_tmpl_id': cls.product_id.product_tmpl_id.id,
+            'product_uom_id': cls.uom_unit.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0,0,{'product_id': cls.product_id2.id,
+            'product_qty': 2})]
+        })
+
+    def test_when_unlink_mrp_bom_it_must_be_archived(self):
+
+        #act
+        self.mrp_bom_obj.unlink()
+
+        #assert
+        self.assertFalse(self.mrp_bom_obj.active)
+        self.assertTrue(self.mrp_bom_obj.exists())
+
+    def test_when_unlink_mrp_bom_line_it_must_be_archived_but_not_its_bom(self):
+
+        #act
+        self.mrp_bom_obj.bom_line_ids.unlink()
+        line = self.mrp_bom_obj.bom_line_ids
+
+        #assert
+        self.assertTrue(line.exists())
+        self.assertFalse(line.active)
+

--- a/project-addons/unlink_to_archive/tests/test_product_associated.py
+++ b/project-addons/unlink_to_archive/tests/test_product_associated.py
@@ -1,0 +1,34 @@
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProductAssociated(TransactionCase):
+    post_install = True
+    at_install = True
+
+    def setUp(self):
+        super(TestProductAssociated, self).setUp()
+        self.product_model = self.env['product.product']
+
+
+    def test_when_unlink_a_product_associated_must_be_archived(self):
+        #arrange
+        product_id = self.product_model.create({'name': "Test",
+                                                    'default_code': "Test"})
+        uom_unit = self.env.ref('product.product_uom_unit')
+
+        product_id2 = self.product_model.create({'name': "Test2",
+                                                      'default_code': "Test2",
+                                                 'associated_product_ids':[(0,0,{'associated_id':product_id.id,
+                                                                                 'quantity':1,
+                                                                                 'uom_id':uom_unit.id})]
+                                                    })
+
+        #act
+        associated_product = product_id2.associated_product_ids
+        associated_product.unlink()
+
+        #assert
+        self.assertFalse(associated_product.active)
+        self.assertTrue(associated_product.exists())
+


### PR DESCRIPTION
- [[IMP] unlink_to_archive: Añadido nuevo módulo que archiva en vez de eliminar ciertos modelos](https://github.com/Comunitea/CMNT_004_15/commit/8760e469c7fa9302d4bba63092cff44fd4274598)
- [[IMP] unlink_to_archive: eliminar líneas en el caso de que se elimine el pack](https://github.com/Comunitea/CMNT_004_15/commit/bd610cce2bf0263b74c048f8a5c33a68ba2a869b)
