### PR TITLE
Permitir crear y editar direcciones de envío y petición de PR para arreglar web_m2x_options

### DIFF
--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -219,7 +219,7 @@
                     <attribute name="options">{"always_reload": True}</attribute>
                 </field>
                 <field name="partner_shipping_id" position="attributes">
-                    <attribute name="options">{"always_reload": True}</attribute>
+                    <attribute name="options">{"always_reload": True,"create_edit":True,"create":True}</attribute>
                 </field>
                 <field name="partner_invoice_id" position="attributes">
                     <attribute name="options">{"always_reload": True}</attribute>


### PR DESCRIPTION
- [FIX] sale_custom: Añadido opción para permitir crear y editar las direcciones de envío

Buenos días Omar, este cambio va junto al PR que te he comentado en el correo.  Ya me he creado el fork y en una nueva rama he metido el commit con un cherry-pick. Si no era eso lo que querías que hiciéramos dímelo y hago lo que sea. Te paso el repo y la rama para que cuando puedas, lo incorpores.
**Repo**: https://github.com/Albertocanal/web
**Rama**: [11.0-web_m2x_options_fix_searchmore](https://github.com/Albertocanal/web/tree/11.0-web_m2x_options_fix_searchmore)
Muchísimas gracias.