### PR TITLE
Borra opciones seleccionables campos RMA

### DIFF
--- a/project-addons/crm_claim_rma/i18n/crm_claim_rma.pot
+++ b/project-addons/crm_claim_rma/i18n/crm_claim_rma.pot
@@ -707,11 +707,6 @@ msgid "Merchandise Not As Described"
 msgstr ""
 
 #. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Exchange request"
-msgstr ""
-
-#. module: crm_claim_rma
 #: model:ir.model,name:crm_claim_rma.model_substate_substate
 msgid "substate that precise a given state"
 msgstr ""
@@ -730,12 +725,6 @@ msgstr ""
 #. module: crm_claim_rma
 #: view:claim.line:0
 msgid "Current"
-msgstr ""
-
-#. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-#: selection:crm.claim,claim_type:0
-msgid "Other"
 msgstr ""
 
 #. module: crm_claim_rma

--- a/project-addons/crm_claim_rma/i18n/es.po
+++ b/project-addons/crm_claim_rma/i18n/es.po
@@ -467,11 +467,6 @@ msgid "Error!"
 msgstr "Error"
 
 #. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Exchange request"
-msgstr "Solicitar cambio"
-
-#. module: crm_claim_rma
 #: model:ir.model.fields,field_description:crm_claim_rma.field_crm_claim_planned_cost
 msgid "Expected cost"
 msgstr "Coste estimado"
@@ -808,11 +803,6 @@ msgstr "El número/referencia debe ser único por compañía"
 #: selection:claim.line,claim_origine:0
 msgid "Order cancellation"
 msgstr "Cancelación de orden"
-
-#. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Other"
-msgstr "Otro"
 
 #. module: crm_claim_rma
 #: model:ir.model.fields,field_description:crm_claim_rma.field_crm_claim_cost_report_delay_expected

--- a/project-addons/crm_claim_rma/i18n/fr.po
+++ b/project-addons/crm_claim_rma/i18n/fr.po
@@ -737,11 +737,6 @@ msgid "Merchandise Not As Described"
 msgstr "Produit ne correspondant pas à sa description"
 
 #. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Exchange request"
-msgstr "Demande d'échange"
-
-#. module: crm_claim_rma
 #: model:ir.model,name:crm_claim_rma.model_substate_substate
 msgid "substate that precise a given state"
 msgstr "Sous état précisant l'état principal"
@@ -761,12 +756,6 @@ msgstr "Produit retourné"
 #: view:claim.line:0
 msgid "Current"
 msgstr "Actuel"
-
-#. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-#: selection:crm.claim,claim_type:0
-msgid "Other"
-msgstr "Autre"
 
 #. module: crm_claim_rma
 #: view:crm.claim:0

--- a/project-addons/crm_claim_rma/i18n/it.po
+++ b/project-addons/crm_claim_rma/i18n/it.po
@@ -467,11 +467,6 @@ msgid "Error!"
 msgstr "Errore!"
 
 #. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Exchange request"
-msgstr "Sollecita cambio"
-
-#. module: crm_claim_rma
 #: model:ir.model.fields,field_description:crm_claim_rma.field_crm_claim_planned_cost
 msgid "Expected cost"
 msgstr "Costo stimato"
@@ -813,11 +808,6 @@ msgstr "Il numero / riferimento deve essere unico per ogni azienda!"
 #: selection:claim.line,claim_origine:0
 msgid "Order cancellation"
 msgstr "Ordine cancellato"
-
-#. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Other"
-msgstr "Altro"
 
 #. module: crm_claim_rma
 #: model:ir.model.fields,field_description:crm_claim_rma.field_crm_claim_cost_report_delay_expected

--- a/project-addons/crm_claim_rma/i18n/pt_BR.po
+++ b/project-addons/crm_claim_rma/i18n/pt_BR.po
@@ -726,11 +726,6 @@ msgid "Merchandise Not As Described"
 msgstr ""
 
 #. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-msgid "Exchange request"
-msgstr ""
-
-#. module: crm_claim_rma
 #: model:ir.model,name:crm_claim_rma.model_substate_substate
 msgid "substate that precise a given state"
 msgstr ""
@@ -749,12 +744,6 @@ msgstr ""
 #. module: crm_claim_rma
 #: view:claim.line:0
 msgid "Current"
-msgstr ""
-
-#. module: crm_claim_rma
-#: selection:claim.line,claim_origine:0
-#: selection:crm.claim,claim_type:0
-msgid "Other"
 msgstr ""
 
 #. module: crm_claim_rma

--- a/project-addons/crm_claim_rma/models/crm_claim_rma.py
+++ b/project-addons/crm_claim_rma/models/crm_claim_rma.py
@@ -105,9 +105,7 @@ class ClaimLine(models.Model):
              ('description_error', 'Does not correspond with web description'),
              ('missing_parts', 'Missing parts'),
              ('error', 'Shipping error'),
-             ('exchange', 'Exchange request'),
-             ('lost', 'Lost during transport'),
-             ('other', 'Other')
+             ('lost', 'Lost during transport')
              ],
             'Claim Subject', default='broken_down',
             required=True,

--- a/project-addons/sale_delivery_type/i18n/es.po
+++ b/project-addons/sale_delivery_type/i18n/es.po
@@ -17,7 +17,6 @@ msgstr ""
 
 #. module: sale_delivery_type
 #: selection:sale.order,delivery_type:0
-#: selection:crm.claim,delivery_type:0
 msgid "Carrier - Customer"
 msgstr "Transportista -  Cliente"
 

--- a/project-addons/sale_delivery_type/i18n/it.po
+++ b/project-addons/sale_delivery_type/i18n/it.po
@@ -17,7 +17,6 @@ msgstr ""
 
 #. module: sale_delivery_type
 #: selection:sale.order,delivery_type:0
-#: selection:crm.claim,delivery_type:0
 msgid "Carrier - Customer"
 msgstr "Corriere -  Cliente"
 

--- a/project-addons/sale_delivery_type/models/claim.py
+++ b/project-addons/sale_delivery_type/models/claim.py
@@ -26,6 +26,5 @@ class CrmClaim(models.Model):
 
     delivery_type = fields.Selection([
             ('shipping', 'Shipping'),
-            ('carrier', 'Carrier - Customer'),
             ('installations', 'Pickup in installations'), ],
             'Delivery type', required=True, default='shipping')


### PR DESCRIPTION
[feature]sale_delivery_type: Elimina la traducción de "Transportista-Cliente" del campo Tipo de envío
[feature]crm_claim_rma: Elimina las traducciones de "Solicitar cambio" y "Otro" del campo Objeto de reclamación
[feature]crm_claim_rma: elimina "Solicitud de cambio" y "Otro" en las opciones de objeto reclamación
[feature]sale_delivery_type: Elimina opción "transportista-cliente" del tipo de envío para RMA