### PR TITLE
[HOTFIX] RMAS

### DIFF
--- a/project-addons/crm_claim_rma_custom/wizard/claim_make_picking_view.xml
+++ b/project-addons/crm_claim_rma_custom/wizard/claim_make_picking_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <group name="locations" position="after">
                 <group readonly="1" invisible="context.get('product_return', False)">
-                    <field name="odoo_management" readonly="1"/>
+                    <field name="odoo_management"/>
                     <field name="not_sync"/>
                 </group>
             </group>


### PR DESCRIPTION
- [[FIX] crm_claim_rma_custom: eliminado readonly que hacía que no se arrastrase el gestionado en Odoo](https://github.com/Comunitea/CMNT_004_15/commit/86444b7b1f3f817c84f186ebd22fd91e507c42b0)
- [[FIX] crm_claim_rma: dejar enviar productos de reemplazo sin límite](https://github.com/Comunitea/CMNT_004_15/commit/b6ef0c8f307a38283fc37883caa3efbdb202f4f2)