### PR TITLE
Si un albarán tiene personalización asociada, no permitir quitar check "no sincronizable"

### DIFF
--- a/project-addons/kitchen/i18n/es.po
+++ b/project-addons/kitchen/i18n/es.po
@@ -894,6 +894,12 @@ msgid "You cannot cancel this picking because there are customizations in progre
 msgstr "No puedes cancelar este albarán porque hay personalizaciones en proceso"
 
 #. module: kitchen
+#: code:addons/kitchen/models/picking.py:103
+#, python-format
+msgid "This picking cannot be released as it has a customization assigned to it"
+msgstr "No se puede liberar el albarán porque tiene una personalización asociada"
+
+#. module: kitchen
 #: code:addons/kitchen/models/kitchen_customization.py:377
 #, python-format
 msgid "You cannot change the product quantity to less than 0"

--- a/project-addons/kitchen/i18n/fr.po
+++ b/project-addons/kitchen/i18n/fr.po
@@ -232,6 +232,12 @@ msgid "Please add some products before confirming the customization request"
 msgstr "Veuillez ajouter un produit avant de confirmer la demande de personnalisation"
 
 #. module: kitchen
+#: code:addons/kitchen/models/picking.py:103
+#, python-format
+msgid "This picking cannot be released as it has a customization assigned to it"
+msgstr "Le bon de livraison ne peut être libéré car il est associé à une personnalisation"
+
+#. module: kitchen
 #: code:addons/kitchen/models/kitchen_customization.py:69
 msgid "You can't create a customization with a quantity of less than one of a product"
 msgstr "Vous ne pouvez pas créer une personnalisation de ce produit avec une quantité inférieure à un"

--- a/project-addons/kitchen/i18n/it.po
+++ b/project-addons/kitchen/i18n/it.po
@@ -230,6 +230,12 @@ msgid "You can't create a customization with a quantity of less than one of a pr
 msgstr "Non è possibile creare una personalizzazione con quantità inferiore a uno di questo prodotto"
 
 #. module: kitchen
+#: code:addons/kitchen/models/picking.py:103
+#, python-format
+msgid "This picking cannot be released as it has a customization assigned to it"
+msgstr "Questa bolla di consegna non può essere rilasciata in quanto ha una personalizzazione assegnata"
+
+#. module: kitchen
 #: code:addons/kitchen/models/kitchen_customization.py:73
 msgid "You can't confirm a customization without a customization type: %s"
 msgstr "Non puoi confermare una personalizzazione senza un tipo di personalizzazione: %s"

--- a/project-addons/kitchen/models/picking.py
+++ b/project-addons/kitchen/models/picking.py
@@ -97,6 +97,12 @@ class StockPicking(models.Model):
         res = super(StockPicking, self).check_send_email_extended(vals)
         return res and (not self.customization_ids or not self.customization_ids.filtered(lambda c: c.state != 'cancel'))
 
+    @api.onchange("not_sync")
+    def onchange_not_sync(self):
+        if self.customization_ids.filtered(lambda c: c.state not in ['done','cancel']):
+            raise exceptions.UserError(_("This picking cannot be released as it has a customization assigned to it"))
+        
+
 
 class StockMove(models.Model):
     _inherit = 'stock.move'


### PR DESCRIPTION
- [FIX] kitchen: No permitir quitar check "no sincronizable" si tiene personalización asociada