### PR TITLE
Activar y desactivar sims

### DIFF
--- a/project-addons/sim_manager/data/parameters.xml
+++ b/project-addons/sim_manager/data/parameters.xml
@@ -20,6 +20,18 @@
         <field name="key">web.sim.invoice.endpoint.key</field>
         <field name="value"></field>
     </record>
+     <record id="web_sim_detail_endpoint" model="ir.config_parameter">
+        <field name="key">web.sim.detail.endpoint</field>
+        <field name="value"></field>
+    </record>
+    <record id="web_sim_update_endpoint" model="ir.config_parameter">
+        <field name="key">web.sim.update.endpoint</field>
+        <field name="value"></field>
+    </record>
+    <record id="web_sim_active_endpoint" model="ir.config_parameter">
+        <field name="key">web.sim.active.endpoint</field>
+        <field name="value"></field>
+    </record>
     <record id="web_sim_limit_endpoint" model="ir.config_parameter">
         <field name="key">web.sim.limit.endpoint</field>
         <field name="value"></field>

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -102,6 +102,7 @@ msgstr "Vendido a"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_state
 msgid "State"
 msgstr "Estado"
 

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -29,6 +29,7 @@ msgstr "Tarjetas"
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_sim_serial_id
 msgid "Code"
 msgstr "Código"
 
@@ -257,3 +258,63 @@ msgstr "Error al leer el estado de la tarjeta SIM"
 #: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
 msgid "Active SIMs"
 msgstr "SIMs activas"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Data"
+msgstr "Datos"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Voice"
+msgstr "Voz"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Activated"
+msgstr "Activado"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Deactivated"
+msgstr "Desactivado"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Blocked"
+msgstr "Bloqueado"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
+msgid "Type"
+msgstr "Tipo"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
+msgid "Status"
+msgstr "Estado"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
+msgid "Services"
+msgstr "Servicios"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Save"
+msgstr "Guardar"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Activate"
+msgstr "Activar"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Deactivate"
+msgstr "Desactivar"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+msgid "Open Serial"
+msgstr "Abrir Tarjeta"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -65,6 +65,11 @@ msgid "Active SIMs"
 msgstr "SIMs activas"
 
 #. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.res_partner_view_buttons_add_sims
+msgid "% Active SIMs"
+msgstr "% SIMs activas"
+
+#. module: sim_manager
 #: selection:sim.serial,state:0
 msgid "Active disuse"
 msgstr "Activa en desuso"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -313,8 +313,3 @@ msgstr "Activar"
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
 msgid "Deactivate"
 msgstr "Desactivar"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-msgid "Open Serial"
-msgstr "Abrir Tarjeta"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-03 08:48+0000\n"
-"PO-Revision-Date: 2021-09-03 08:48+0000\n"
+"POT-Creation-Date: 2023-01-12 15:54+0000\n"
+"PO-Revision-Date: 2023-01-12 15:54+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,10 +16,98 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sim_manager
-#: selection:sim.package,state:0
+#: model:mail.template,body_html:sim_manager.email_template_sim_bank_account_error
+msgid "\n"
+"                ${ctx.get('message_warn','') | safe}\n"
+"             \n"
+"            "
+msgstr "<p style=\"margin:0px 0px 9px 0px;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">\n"
+"                ${ctx.get('message_warn','') | safe}\n"
+"             \n"
+"            </p>"
+
+#. module: sim_manager
+#: model:mail.template,body_html:sim_manager.email_template_sim_error
+msgid "\n"
+"                <p>${ctx.get('message_warn','')}</p>\n"
+"             \n"
+"            "
+msgstr "\n"
+"                <p style=\"margin:0px 0px 9px 0px;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">${ctx.get('message_warn','')}</p>\n"
+"             \n"
+"            "
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:183
+#, python-format
+msgid "A SimSerial cannot have state %s"
+msgstr "Una tarjeta SIM no puede tener el estado %s"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Activate"
+msgstr "Activar"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Activated"
+msgstr "Activado"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active"
+msgstr "Activa"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
+#: model:ir.model.fields,field_description:sim_manager.field_res_users_sim_active_perc
+msgid "Active SIMs"
+msgstr "SIMs activas"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active disuse"
+msgstr "Activa en desuso"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
+msgid "Allow SIM"
+msgstr "Permitir SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:195
+#, python-format
+msgid "An error ocurred while updating the sim state"
+msgstr "Se ha producido un error al actualizar el estado de la tarjeta SIM"
+
+#. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+#: selection:sim.package,state:0
 msgid "Available"
-msgstr "Disponible"
+msgstr "Reservado"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+#: selection:sim.service,status:0
+msgid "Blocked"
+msgstr "Bloqueada"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:179
+#, python-format
+msgid "Cannot block a SIM Service"
+msgstr "No se puede bloquear un servicio SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_qty
+msgid "Cantidad"
+msgstr "Cantidad"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_serial_ids
@@ -27,17 +115,160 @@ msgid "Cards"
 msgstr "Tarjetas"
 
 #. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Cliente"
+msgstr "Cliente"
+
+#. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_service_sim_serial_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
 msgid "Code"
 msgstr "Código"
 
 #. module: sim_manager
+#: model:ir.model,name:sim_manager.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator
+msgid "Create SIM package"
+msgstr "Create SIM package"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
+msgid "Create new SIM package"
+msgstr "Crear nuevo paquete SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_create_date
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_create_date
 #: model:ir.model.fields,field_description:sim_manager.field_sim_serial_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_create_date
 msgid "Created on"
 msgstr "Creado en"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Data"
+msgstr "Datos"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Deactivate"
+msgstr "Desactivar"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Deactivated"
+msgstr "Desactivado"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "ES"
+msgstr "ES"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "EU"
+msgstr "EU"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:228
+#, python-format
+msgid "Error while getting SIM services"
+msgstr "Error al obtener los servicios SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:172
+#, python-format
+msgid "Error while reading SIM state"
+msgstr "Error al leer el estado de la tarjeta SIM"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Status"
+msgstr "Estado"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_id
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: sim_manager
+#: model:ir.actions.server,name:sim_manager.ir_cron_invoice_sim_packages_ir_actions_server
+#: model:ir.cron,cron_name:sim_manager.ir_cron_invoice_sim_packages
+#: model:ir.cron,name:sim_manager.ir_cron_invoice_sim_packages
+msgid "Invoice SIM packages"
+msgstr "Factura de paquetes SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_line
+msgid "List of product to return"
+msgstr "Listado de productos a devolver"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
+msgid "Manage the SIM Types"
+msgstr "Gestionar tipos de SIM"
 
 #. module: sim_manager
 #: model:ir.actions.act_window,help:sim_manager.action_sim_package
@@ -45,9 +276,31 @@ msgid "Manage the SIM packages"
 msgstr "Gestionar los paquetes SIM"
 
 #. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_mode
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "Mode"
+msgstr "Modo"
+
+#. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_move_id
 msgid "Move"
 msgstr "Movimiento"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_new_code
+msgid "New package"
+msgstr "Nuevo Paquete"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_open_sim_serial
+msgid "Open SIM Serial"
+msgstr "Abrir Tarjeta SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sale_order.py:34
+#, python-format
+msgid "Order block, the client has too many sims inactive. {}% Active"
+msgstr "Pedido bloqueado, el cliente tiene demasiadas SIM inactivas. {}% Activo"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_code
@@ -56,114 +309,61 @@ msgid "Package"
 msgstr "Paquete"
 
 #. module: sim_manager
-#: model:ir.actions.act_window,name:sim_manager.act_res_partner_sim_cards
-#: model:ir.ui.view,arch_db:sim_manager.res_partner_view_buttons_add_sims
-msgid "SIM Cards"
-msgstr "Tarjetas SIM"
-
-#. module: sim_manager
-#: model:ir.actions.act_window,name:sim_manager.action_sim_package
-#: model:ir.ui.menu,name:sim_manager.menu_sim_package
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_tree
-msgid "SIM packages"
-msgstr "Paquetes SIM"
-
-#. module: sim_manager
-#: model:ir.ui.menu,name:sim_manager.menu_sim_package_creator
-msgid "Scan SIMs"
-msgstr "Escanear SIMs"
-
-#. module: sim_manager
-#: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator
-msgid "Scanning SIMs"
-msgstr "Escaneando SIMs"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_code
-msgid "Serial"
-msgstr "Nº serie"
-
-#. module: sim_manager
-#: selection:sim.package,state:0
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
-msgid "Sold"
-msgstr "Vendido"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
-msgid "Sold to"
-msgstr "Vendido a"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_state
-msgid "State"
-msgstr "Estado"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:70
-#, python-format
-msgid "{} created"
-msgstr "{} creado"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
-msgid "Create new SIM package"
-msgstr "Crear nuevo paquete SIM"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_new_code
-msgid "New package"
-msgstr "Nuevo Paquete"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
-msgid "Type"
-msgstr "Tipo"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
-msgid "Scan"
-msgstr "Escanear"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
-msgid "Cancel"
-msgstr "Cancelar"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.action_sim_package_report
-msgid "SIM Report"
-msgstr "SIM Informe"
-
-#. module: sim_manager
-#: model:ir.ui.menu,name:sim_manager.menu_sim_report
-msgid "SIM Tags"
-msgstr "Etiquetas SIM"
-
-#. module: sim_manager
 #: code:addons/sim_manager/models/sim.py:81
 #, python-format
 msgid "Package %s finished. Scan for continue with next package"
 msgstr "Paquete %s terminado. Escanea el siguiente para continuar"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:89
-#: code:addons/sim_manager/models/sim.py:113
-#, python-format
-msgid "Scan the #%s serial for %s"
-msgstr "Escanea el #%s ID para el %s"
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Paquete"
+msgstr "Paquete"
 
 #. module: sim_manager
-#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
-msgid "Manage the SIM Types"
-msgstr "Gestionar tipos de SIM"
+#: selection:sim.serial,state:0
+msgid "Preactivated"
+msgstr "Preactivada"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_product_id
 msgid "Product"
 msgstr "Producto"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sale_order
+msgid "Quotation"
+msgstr "Quotation"
+
+#. module: sim_manager
+#: selection:sim.export.wzd,mode:0
+msgid "Return"
+msgstr "Return"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.act_res_partner_sim_cards
+msgid "SIM Cards"
+msgstr "Tarjetas SIM"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_export_wizard
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "SIM Export Wizard"
+msgstr "SIM Export Wizard"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_service_form
+msgid "SIM Service"
+msgstr "Servicio SIM"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "SIM Services"
+msgstr "Servicios SIM"
+
+#. module: sim_manager
+#: model:ir.ui.menu,name:sim_manager.menu_sim_report
+msgid "SIM Tags"
+msgstr "Etiquetas SIM"
 
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_type_form
@@ -178,16 +378,236 @@ msgid "SIM Types"
 msgstr "Tipos de SIM"
 
 #. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
-#: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
-msgid "Type"
-msgstr "Tipo"
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package
+#: model:ir.ui.menu,name:sim_manager.menu_sim_package
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_tree
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_report
+msgid "SIM packages"
+msgstr "Paquetes SIM"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "SMS"
+msgstr "SMS"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sale_id
+msgid "Sale"
+msgstr "Venta"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Save"
+msgstr "Guardar"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
+msgid "Scan"
+msgstr "Escanear"
+
+#. module: sim_manager
+#: model:ir.ui.menu,name:sim_manager.menu_sim_package_creator
+msgid "Scan SIMs"
+msgstr "Escanear SIMs"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:89
+#: code:addons/sim_manager/models/sim.py:113
+#, python-format
+msgid "Scan the #%s serial for %s"
+msgstr "Escanea el #%s ID para el %s"
+
+#. module: sim_manager
+#: code:addons/sim_manager/wizard/sim_creator_wizard.py:42
+#, python-format
+msgid "Scan the #1 serial for %s"
+msgstr "Escanea el #1 ID para el %s"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator_scan
+msgid "Scanning SIMs"
+msgstr "Escaneando SIMs"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Search"
+msgstr "Búsqueda"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_code
+msgid "Serial"
+msgstr "Nº serie"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_2
+msgid "Serie 2"
+msgstr "Serie 2"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_3
+msgid "Serie 3"
+msgstr "Serie 3"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_4
+msgid "Serie 4"
+msgstr "Serie 4"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_5
+msgid "Serie 5"
+msgstr "Serie 5"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_6
+msgid "Serie 6"
+msgstr "Serie 6"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_7
+msgid "Serie 7"
+msgstr "Serie 7"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_8
+msgid "Serie 8"
+msgstr "Serie 8"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_9
+msgid "Serie 9"
+msgstr "Serie 9"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_10
+msgid "Serie Fin"
+msgstr "Serie Fin"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_1
+msgid "Serie Inicio"
+msgstr "Serie Inicio"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Service"
+msgstr "Servicio"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
+msgid "Services"
+msgstr "Servicios"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package_report
+msgid "Sim Report"
+msgstr "Sim Report"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_serial_ids
+#: model:ir.model.fields,field_description:sim_manager.field_res_users_sim_serial_ids
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Sim Serial"
+msgstr "Sim Serial"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_service
+msgid "Sim Service"
+msgstr "Servicio Sim"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+#: selection:sim.export.wzd,mode:0
+#: selection:sim.package,state:0
+msgid "Sold"
+msgstr "Vendido"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
+msgid "Sold to"
+msgstr "Vendido a"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:48
+#, python-format
+msgid "Some introduced SIMs are not assigned to %s"
+msgstr "Algunas SIMs no están asignadas a %s"
 
 #. module: sim_manager
 #: code:addons/sim_manager/models/stock.py:30
 #, python-format
 msgid "Some of these SIM cards %s of the picking %s have not been found in the system."
 msgstr "Algunas de estas tarjetas SIM %s del albarán %s no se encuentran en el sistema."
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_state
+msgid "State"
+msgstr "Estado"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
+msgid "Status"
+msgstr "Estado"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_stock_move
+msgid "Stock Move"
+msgstr "Moviemiento de stock"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "Sync"
+msgstr "Sync"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+msgid "Sync web"
+msgstr "Sync web"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Tarjetas"
+msgstr "Tarjetas"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:44
+#, python-format
+msgid "The serial numbers cannot be found in the system. Check the serials and the format."
+msgstr "Los números de serie no se encuentran en el sistema. Comprueba los números y el formato."
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
+msgid "Type"
+msgstr "Tipo"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Unsuscribed"
+msgstr "Desactivada"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "VIP"
+msgstr "VIP"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Voice"
+msgstr "Voz"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_make_picking_wizard
+msgid "Wizard to create pickings from claim lines"
+msgstr "Asistente para crear envíos desde la línea de reclamación"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_make_picking_from_picking_wizard
+msgid "Wizard to create pickings from picking lines"
+msgstr "Asistente para crear albaranes desde lineas de albarán"
 
 #. module: sim_manager
 #: code:addons/sim_manager/models/claim.py:25
@@ -201,115 +621,38 @@ msgid "[Odoo] Missing Bank Account on SIM invoice"
 msgstr "[Odoo] Faltan cuentas bancarias en facturas SIM"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:44
+#: model:mail.template,subject:sim_manager.email_template_sim_error
+msgid "[Odoo] SIM card not found"
+msgstr "[Odoo] Tarjeta SIM no encontrada"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_export_wzd
+msgid "sim.export.wzd"
+msgstr "sim.export.wzd"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_package_create_wizard
+msgid "sim.package.create.wizard"
+msgstr "sim.package.create.wizard"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_package
+msgid "simPackage"
+msgstr "simPackage"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_serial
+msgid "simSerial"
+msgstr "simSerial"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_type
+msgid "simType"
+msgstr "simType"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:70
+#: code:addons/sim_manager/models/sim.py:104
 #, python-format
-msgid "The serial numbers cannot be found in the system. Check the serials and the format."
-msgstr "Los números de serie no se encuentran en el sistema. Comprueba los números y el formato."
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:48
-#, python-format
-msgid "Some introduced SIMs are not assigned to %s"
-msgstr "Algunas SIMs no están asignadas a %s"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sale_order.py:34
-#, python-format
-msgid "Order block, the client has too many sims inactive. {}% Active"
-msgstr "Pedido bloqueado, el cliente tiene demasiadas SIM inactivas. {}% Activo"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
-msgid "Allow SIM"
-msgstr "Permitir SIM"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Active"
-msgstr "Activa"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Active disuse"
-msgstr "Activa en desuso"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Unsuscribed"
-msgstr "Desactivada"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Blocked"
-msgstr "Bloqueada"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Preactivated"
-msgstr "Preactivada"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:34
-#, python-format
-msgid "Error while reading SIM state"
-msgstr "Error al leer el estado de la tarjeta SIM"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
-msgid "Active SIMs"
-msgstr "SIMs activas"
-
-#. module: sim_manager
-#: selection:sim.service,type:0
-msgid "Data"
-msgstr "Datos"
-
-#. module: sim_manager
-#: selection:sim.service,type:0
-msgid "Voice"
-msgstr "Voz"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Activated"
-msgstr "Activado"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Deactivated"
-msgstr "Desactivado"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Blocked"
-msgstr "Bloqueado"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
-msgid "Type"
-msgstr "Tipo"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
-msgid "Status"
-msgstr "Estado"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
-msgid "Services"
-msgstr "Servicios"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Save"
-msgstr "Guardar"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Activate"
-msgstr "Activar"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Deactivate"
-msgstr "Desactivar"
+msgid "{} created"
+msgstr "{} creado"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -74,12 +74,6 @@ msgid "Scan SIMs"
 msgstr "Escanear SIMs"
 
 #. module: sim_manager
-#: code:addons/sim_manager/wizard/sim_creator_wizard.py:40
-#, python-format
-msgid "Scan the #1 serial for %s"
-msgstr "Escanea el #1 ID para el %s"
-
-#. module: sim_manager
 #: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator
 msgid "Scanning SIMs"
 msgstr "Escaneando SIMs"
@@ -107,7 +101,7 @@ msgid "State"
 msgstr "Estado"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:29
+#: code:addons/sim_manager/models/sim.py:70
 #, python-format
 msgid "{} created"
 msgstr "{} creado"
@@ -148,14 +142,14 @@ msgid "SIM Tags"
 msgstr "Etiquetas SIM"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:70
+#: code:addons/sim_manager/models/sim.py:81
 #, python-format
 msgid "Package %s finished. Scan for continue with next package"
 msgstr "Paquete %s terminado. Escanea el siguiente para continuar"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:78
-#: code:addons/sim_manager/models/sim.py:99
+#: code:addons/sim_manager/models/sim.py:89
+#: code:addons/sim_manager/models/sim.py:113
 #, python-format
 msgid "Scan the #%s serial for %s"
 msgstr "Escanea el #%s ID para el %s"
@@ -189,13 +183,13 @@ msgid "Type"
 msgstr "Tipo"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/stock.py:27
+#: code:addons/sim_manager/models/stock.py:30
 #, python-format
 msgid "Some of these SIM cards %s of the picking %s have not been found in the system."
 msgstr "Algunas de estas tarjetas SIM %s del albarán %s no se encuentran en el sistema."
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:20
+#: code:addons/sim_manager/models/claim.py:25
 #, python-format
 msgid "You must specify the serial number of the serial products"
 msgstr "Debes especificar el número de serie de los productos con tracking"
@@ -206,19 +200,13 @@ msgid "[Odoo] Missing Bank Account on SIM invoice"
 msgstr "[Odoo] Faltan cuentas bancarias en facturas SIM"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/res_partner.py:82
-#, python-format
-msgid "Partner %s has not a valid mandate or account. Invoice %s has not been changed. \n"
-msgstr "El cliente %s no tiene cuenta o un mandato válido. La factura %s no se ha cambiado. \n"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:37
+#: code:addons/sim_manager/models/claim.py:44
 #, python-format
 msgid "The serial numbers cannot be found in the system. Check the serials and the format."
 msgstr "Los números de serie no se encuentran en el sistema. Comprueba los números y el formato."
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:41
+#: code:addons/sim_manager/models/claim.py:48
 #, python-format
 msgid "Some introduced SIMs are not assigned to %s"
 msgstr "Algunas SIMs no están asignadas a %s"
@@ -233,3 +221,39 @@ msgstr "Pedido bloqueado, el cliente tiene demasiadas SIM inactivas. {}% Activo"
 #: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
 msgid "Allow SIM"
 msgstr "Permitir SIM"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active"
+msgstr "Activa"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active disuse"
+msgstr "Activa en desuso"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Unsuscribed"
+msgstr "Desactivada"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Blocked"
+msgstr "Bloqueada"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Preactivated"
+msgstr "Preactivada"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:34
+#, python-format
+msgid "Error while reading SIM state"
+msgstr "Error al leer el estado de la tarjeta SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
+msgid "Active SIMs"
+msgstr "SIMs activas"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -73,12 +73,6 @@ msgid "Scan SIMs"
 msgstr "Scansionare SIMs"
 
 #. module: sim_manager
-#: code:addons/sim_manager/wizard/sim_creator_wizard.py:40
-#, python-format
-msgid "Scan the #1 serial for %s"
-msgstr "Scansiona il #1 ID per il %s"
-
-#. module: sim_manager
 #: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator
 msgid "Scanning SIMs"
 msgstr "Scasionando SIMs"
@@ -105,7 +99,7 @@ msgid "State"
 msgstr "Stato"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:29
+#: code:addons/sim_manager/models/sim.py:70
 #, python-format
 msgid "{} created"
 msgstr "{} creado"
@@ -136,14 +130,14 @@ msgid "Cancel"
 msgstr "Anulla"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:70
+#: code:addons/sim_manager/models/sim.py:81
 #, python-format
 msgid "Package %s finished. Scan for continue with next package"
 msgstr "Pachetto %s finito. Scansiona il sucesivo per continuare"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:78
-#: code:addons/sim_manager/models/sim.py:99
+#: code:addons/sim_manager/models/sim.py:89
+#: code:addons/sim_manager/models/sim.py:113
 #, python-format
 msgid "Scan the #%s serial for %s"
 msgstr "Scasiona il #%s ID per il %s"
@@ -178,13 +172,13 @@ msgid "Type"
 msgstr "Tipo"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/stock.py:27
+#: code:addons/sim_manager/models/stock.py:30
 #, python-format
 msgid "Some of these SIM cards %s of the picking %s have not been found in the system"
 msgstr "Alcuni di queste SIM card %s della bolla %s non esistono nel sistema."
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:20
+#: code:addons/sim_manager/models/claim.py:25
 #, python-format
 msgid "You must specify the serial number of the serial products"
 msgstr "Devi specificare il numero serie dei prodotti con traking"
@@ -211,3 +205,39 @@ msgstr "Ordine bloccato, il utente ha troppe SIM innative. {}% Attivo"
 #: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
 msgid "Allow SIM"
 msgstr "Permettere SIM"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active"
+msgstr "Attiva"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active disuse"
+msgstr "Attiva in disuso"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Unsuscribed"
+msgstr "Disattivata"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Blocked"
+msgstr "Bloccata"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Preactivated"
+msgstr "Preattivata"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:34
+#, python-format
+msgid "Error while reading SIM state"
+msgstr "Errore di lettura dello stato della carta SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
+msgid "Active SIMs"
+msgstr "SIMs attive"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -297,8 +297,3 @@ msgstr "Attivare"
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
 msgid "Deactivate"
 msgstr "Disattivare"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-msgid "Open Serial"
-msgstr "Carta Aperta"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -65,6 +65,11 @@ msgid "Active SIMs"
 msgstr "SIMs attive"
 
 #. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.res_partner_view_buttons_add_sims
+msgid "% Active SIMs"
+msgstr "% SIMs activas"
+
+#. module: sim_manager
 #: selection:sim.serial,state:0
 msgid "Active disuse"
 msgstr "Attiva in disuso"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -100,6 +100,7 @@ msgstr "Venduto a"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
+#: model.ir.model.fields,field_description:sim_manager.field_sim_serial_state
 msgid "State"
 msgstr "Stato"
 

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -28,6 +28,7 @@ msgstr "Carte"
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_sim_serial_id
 msgid "Code"
 msgstr "Codice"
 
@@ -241,3 +242,63 @@ msgstr "Errore di lettura dello stato della carta SIM"
 #: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
 msgid "Active SIMs"
 msgstr "SIMs attive"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Data"
+msgstr "Dati"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Voice"
+msgstr "Voce"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Activated"
+msgstr "Attivato"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Deactivated"
+msgstr "Disattivato"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Blocked"
+msgstr "Bloccato"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
+msgid "Type"
+msgstr "Tipo"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
+msgid "Status"
+msgstr "Stato"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
+msgid "Services"
+msgstr "Servizi"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Save"
+msgstr "Risparmiare"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Activate"
+msgstr "Attivare"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Deactivate"
+msgstr "Disattivare"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+msgid "Open Serial"
+msgstr "Carta Aperta"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-03 08:48+0000\n"
-"PO-Revision-Date: 2021-09-03 08:48+0000\n"
+"POT-Creation-Date: 2023-01-12 16:07+0000\n"
+"PO-Revision-Date: 2023-01-12 16:07+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,98 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sim_manager
+#: model:mail.template,body_html:sim_manager.email_template_sim_bank_account_error
+msgid "\n"
+"                ${ctx.get('message_warn','') | safe}\n"
+"             \n"
+"            "
+msgstr "\n"
+"                ${ctx.get('message_warn','') | safe}\n"
+"             \n"
+"            "
+
+#. module: sim_manager
+#: model:mail.template,body_html:sim_manager.email_template_sim_error
+msgid "\n"
+"                <p>${ctx.get('message_warn','')}</p>\n"
+"             \n"
+"            "
+msgstr "\n"
+"                <p>${ctx.get('message_warn','')}</p>\n"
+"             \n"
+"            "
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:183
+#, python-format
+msgid "A SimSerial cannot have state %s"
+msgstr "Una carta SIM non può avere lo stato %s"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Activate"
+msgstr "Attiva"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Activated"
+msgstr "Attivato"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active"
+msgstr "Attiva"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
+#: model:ir.model.fields,field_description:sim_manager.field_res_users_sim_active_perc
+msgid "Active SIMs"
+msgstr "SIMs attive"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+msgid "Active disuse"
+msgstr "Attiva in disuso"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
+msgid "Allow SIM"
+msgstr "Permettere SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:195
+#, python-format
+msgid "An error ocurred while updating the sim state"
+msgstr "Si è verificato un errore durante l'aggiornamento dello stato del sim"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
 #: selection:sim.package,state:0
 msgid "Available"
 msgstr "Disponibile"
+
+#. module: sim_manager
+#: selection:sim.serial,state:0
+#: selection:sim.service,status:0
+msgid "Blocked"
+msgstr "Bloccata"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
+msgid "Cancel"
+msgstr "Annulla"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:179
+#, python-format
+msgid "Cannot block a SIM Service"
+msgstr "Impossibile bloccare un servizio SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_qty
+msgid "Cantidad"
+msgstr "Cantidad"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_serial_ids
@@ -26,84 +115,26 @@ msgid "Cards"
 msgstr "Carte"
 
 #. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Cliente"
+msgstr "Cliente"
+
+#. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_service_sim_serial_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_code
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
 msgid "Code"
 msgstr "Codice"
 
 #. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_date
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_create_date
-msgid "Created on"
-msgstr "Creato en"
-
-#. module: sim_manager
-#: model:ir.actions.act_window,help:sim_manager.action_sim_package
-msgid "Manage the SIM packages"
-msgstr "Gestire i pacchetti SIM"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_move_id
-msgid "Move"
-msgstr "Movimento"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_code
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_package_id
-msgid "Package"
-msgstr "Pacchetto"
-
-#. module: sim_manager
-#: model:ir.actions.act_window,name:sim_manager.act_res_partner_sim_cards
-#: model:ir.ui.view,arch_db:sim_manager.res_partner_view_buttons_add_sims
-msgid "SIM Cards"
-msgstr "Carte SIM"
-
-#. module: sim_manager
-#: model:ir.actions.act_window,name:sim_manager.action_sim_package
-#: model:ir.ui.menu,name:sim_manager.menu_sim_package
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_tree
-msgid "SIM packages"
-msgstr "pacchetti SIM"
-
-#. module: sim_manager
-#: model:ir.ui.menu,name:sim_manager.menu_sim_package_creator
-msgid "Scan SIMs"
-msgstr "Scansionare SIMs"
+#: model:ir.model,name:sim_manager.model_res_partner
+msgid "Contact"
+msgstr "Contact"
 
 #. module: sim_manager
 #: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator
-msgid "Scanning SIMs"
-msgstr "Scasionando SIMs"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_code
-msgid "Serial"
-msgstr "Nº serie"
-
-#. module: sim_manager
-#: selection:sim.package,state:0
-msgid "Sold"
-msgstr "Venduto"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
-msgid "Sold to"
-msgstr "Venduto a"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
-#: model.ir.model.fields,field_description:sim_manager.field_sim_serial_state
-msgid "State"
-msgstr "Stato"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:70
-#, python-format
-msgid "{} created"
-msgstr "{} creado"
+msgid "Create SIM package"
+msgstr "Creare il pacchetto SIM"
 
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
@@ -111,24 +142,171 @@ msgid "Create new SIM package"
 msgstr "Creare nuovo pack SIM"
 
 #. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_create_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_create_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Data"
+msgstr "Dati"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Deactivate"
+msgstr "Disattivare"
+
+#. module: sim_manager
+#: selection:sim.service,status:0
+msgid "Deactivated"
+msgstr "Disattivato"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_display_name
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_display_name
+msgid "Display Name"
+msgstr "Visualizza Nome"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "ES"
+msgstr "ES"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "EU"
+msgstr "EU"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:228
+#, python-format
+msgid "Error while getting SIM services"
+msgstr "Errore durante l'ottenimento dei servizi SIM"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:172
+#, python-format
+msgid "Error while reading SIM state"
+msgstr "Errore di lettura dello stato della carta SIM"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Status"
+msgstr "Stato"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_id
+msgid "ID"
+msgstr "ID"
+
+#. module: sim_manager
+#: model:ir.actions.server,name:sim_manager.ir_cron_invoice_sim_packages_ir_actions_server
+#: model:ir.cron,cron_name:sim_manager.ir_cron_invoice_sim_packages
+#: model:ir.cron,name:sim_manager.ir_cron_invoice_sim_packages
+msgid "Invoice SIM packages"
+msgstr "Fattura pacchetti SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service___last_update
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type___last_update
+msgid "Last Modified on"
+msgstr "Data di ultima modifica"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_write_uid
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_write_uid
+msgid "Last Updated by"
+msgstr "Ultima modifica di"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_write_date
+#: model:ir.model.fields,field_description:sim_manager.field_sim_type_write_date
+msgid "Last Updated on"
+msgstr "Ultima modifica il"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_line
+msgid "List of product to return"
+msgstr "List of product to return"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
+msgid "Manage the SIM Types"
+msgstr "Gestire tipi de SIM"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,help:sim_manager.action_sim_package
+msgid "Manage the SIM packages"
+msgstr "Gestire i pacchetti SIM"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_export_wzd_mode
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "Mode"
+msgstr "Modalità"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_move_id
+msgid "Move"
+msgstr "Move"
+
+#. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_new_code
 msgid "New package"
 msgstr "Nuovo Pacchetto"
 
 #. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
-msgid "Type"
-msgstr "Tipo"
+#: model:ir.actions.act_window,name:sim_manager.action_open_sim_serial
+msgid "Open SIM Serial"
+msgstr "Aprire la scheda SIM"
 
 #. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
-msgid "Scan"
-msgstr "Scansiona"
+#: code:addons/sim_manager/models/sale_order.py:34
+#, python-format
+msgid "Order block, the client has too many sims inactive. {}% Active"
+msgstr "Ordine bloccato, il utente ha troppe SIM innative. {}% Attivo"
 
 #. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
-msgid "Cancel"
-msgstr "Anulla"
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_code
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_package_id
+msgid "Package"
+msgstr "Confezione"
 
 #. module: sim_manager
 #: code:addons/sim_manager/models/sim.py:81
@@ -137,22 +315,55 @@ msgid "Package %s finished. Scan for continue with next package"
 msgstr "Pachetto %s finito. Scansiona il sucesivo per continuare"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:89
-#: code:addons/sim_manager/models/sim.py:113
-#, python-format
-msgid "Scan the #%s serial for %s"
-msgstr "Scasiona il #%s ID per il %s"
-
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Paquete"
+msgstr "Paquete"
 
 #. module: sim_manager
-#: model:ir.actions.act_window,help:sim_manager.action_sim_type_config
-msgid "Manage the SIM Types"
-msgstr "Gestire tipi de SIM"
+#: selection:sim.serial,state:0
+msgid "Preactivated"
+msgstr "Preattivata"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_product_id
 msgid "Product"
 msgstr "Prodotto"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sale_order
+msgid "Quotation"
+msgstr "Quotation"
+
+#. module: sim_manager
+#: selection:sim.export.wzd,mode:0
+msgid "Return"
+msgstr "Return"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.act_res_partner_sim_cards
+msgid "SIM Cards"
+msgstr "Carte SIM"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_export_wizard
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "SIM Export Wizard"
+msgstr "SIM Export Wizard"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_service_form
+msgid "SIM Service"
+msgstr "Servizio SIM"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "SIM Services"
+msgstr "Servizi SIM"
+
+#. module: sim_manager
+#: model:ir.ui.menu,name:sim_manager.menu_sim_report
+msgid "SIM Tags"
+msgstr "SIM Tags"
 
 #. module: sim_manager
 #: model:ir.ui.view,arch_db:sim_manager.view_sim_type_form
@@ -167,16 +378,236 @@ msgid "SIM Types"
 msgstr "Tipi de SIM"
 
 #. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package
+#: model:ir.ui.menu,name:sim_manager.menu_sim_package
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_tree
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_report
+msgid "SIM packages"
+msgstr "pacchetti SIM"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "SMS"
+msgstr "SMS"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sale_id
+msgid "Sale"
+msgstr "Vendite"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Save"
+msgstr "Salva"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_creator
+msgid "Scan"
+msgstr "Scansiona"
+
+#. module: sim_manager
+#: model:ir.ui.menu,name:sim_manager.menu_sim_package_creator
+msgid "Scan SIMs"
+msgstr "Scansionare SIMs"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:89
+#: code:addons/sim_manager/models/sim.py:113
+#, python-format
+msgid "Scan the #%s serial for %s"
+msgstr "Scasiona il #%s ID per il %s"
+
+#. module: sim_manager
+#: code:addons/sim_manager/wizard/sim_creator_wizard.py:42
+#, python-format
+msgid "Scan the #1 serial for %s"
+msgstr "Scansiona il #1 ID per il %s"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package_creator_scan
+msgid "Scanning SIMs"
+msgstr "Scasionando SIMs"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Search"
+msgstr "Ricerca"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_code
+msgid "Serial"
+msgstr "Nº serie"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_2
+msgid "Serie 2"
+msgstr "Serie 2"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_3
+msgid "Serie 3"
+msgstr "Serie 3"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_4
+msgid "Serie 4"
+msgstr "Serie 4"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_5
+msgid "Serie 5"
+msgstr "Serie 5"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_6
+msgid "Serie 6"
+msgstr "Serie 6"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_7
+msgid "Serie 7"
+msgstr "Serie 7"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_8
+msgid "Serie 8"
+msgstr "Serie 8"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_9
+msgid "Serie 9"
+msgstr "Serie 9"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_10
+msgid "Serie Fin"
+msgstr "Serie Fin"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_sim_1
+msgid "Serie Inicio"
+msgstr "Serie Inicio"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Service"
+msgstr "Servizio"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
+msgid "Services"
+msgstr "Servizi"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_sim_package_report
+msgid "Sim Report"
+msgstr "Rapporto Sim"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_serial_ids
+#: model:ir.model.fields,field_description:sim_manager.field_res_users_sim_serial_ids
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
+msgid "Sim Serial"
+msgstr "Carta Sim"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_service
+msgid "Sim Service"
+msgstr "Servizio Sim"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+#: selection:sim.export.wzd,mode:0
+#: selection:sim.package,state:0
+msgid "Sold"
+msgstr "Venduto"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
+msgid "Sold to"
+msgstr "Venduto a"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:48
+#, python-format
+msgid "Some introduced SIMs are not assigned to %s"
+msgstr "Qualche SIM non è di %s"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/stock.py:30
+#, python-format
+msgid "Some of these SIM cards %s of the picking %s have not been found in the system."
+msgstr "Alcune di queste schede SIM %s del prelievo %s non sono state trovate nel sistema."
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_package_state
+#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_state
+msgid "State"
+msgstr "Stato"
+
+#. module: sim_manager
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
+msgid "Status"
+msgstr "Stato"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_stock_move
+msgid "Stock Move"
+msgstr "Movimento di magazzino"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.sim_export_wizard_view
+msgid "Sync"
+msgstr "Sync"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_form
+msgid "Sync web"
+msgstr "Sync web"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "Tarjetas"
+msgstr "Tarjetas"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/claim.py:44
+#, python-format
+msgid "The serial numbers cannot be found in the system. Check the serials and the format."
+msgstr "I numeri di serie non sono presenti nel sistema. Controllare i numeri e il formato."
+
+#. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_create_wizard_type_sim
+#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
 #: model:ir.model.fields,field_description:sim_manager.field_sim_type_type
 msgid "Type"
 msgstr "Tipo"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/stock.py:30
-#, python-format
-msgid "Some of these SIM cards %s of the picking %s have not been found in the system"
-msgstr "Alcuni di queste SIM card %s della bolla %s non esistono nel sistema."
+#: selection:sim.serial,state:0
+msgid "Unsuscribed"
+msgstr "Disattivata"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_package_filter
+msgid "VIP"
+msgstr "VIP"
+
+#. module: sim_manager
+#: selection:sim.service,type:0
+msgid "Voice"
+msgstr "Voce"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_make_picking_wizard
+msgid "Wizard to create pickings from claim lines"
+msgstr "Wizard to create pickings from claim lines"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_claim_make_picking_from_picking_wizard
+msgid "Wizard to create pickings from picking lines"
+msgstr "Wizard to create pickings from picking lines"
 
 #. module: sim_manager
 #: code:addons/sim_manager/models/claim.py:25
@@ -185,115 +616,43 @@ msgid "You must specify the serial number of the serial products"
 msgstr "Devi specificare il numero serie dei prodotti con traking"
 
 #. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:37
+#: model:mail.template,subject:sim_manager.email_template_sim_bank_account_error
+msgid "[Odoo] Missing Bank Account on SIM invoice"
+msgstr "[Odoo] Missing Bank Account on SIM invoice"
+
+#. module: sim_manager
+#: model:mail.template,subject:sim_manager.email_template_sim_error
+msgid "[Odoo] SIM card not found"
+msgstr "[Odoo] SIM card not found"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_export_wzd
+msgid "sim.export.wzd"
+msgstr "sim.export.wzd"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_package_create_wizard
+msgid "sim.package.create.wizard"
+msgstr "sim.package.create.wizard"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_package
+msgid "simPackage"
+msgstr "simPackage"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_serial
+msgid "simSerial"
+msgstr "simSerial"
+
+#. module: sim_manager
+#: model:ir.model,name:sim_manager.model_sim_type
+msgid "simType"
+msgstr "simType"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:70
+#: code:addons/sim_manager/models/sim.py:104
 #, python-format
-msgid "The serial numbers cannot be found in the system. Check the serials and the format."
-msgstr "Los números de serie no se encuentran en el sistema. Comprueba los números y el formato."
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/claim.py:41
-#, python-format
-msgid "Some introduced SIMs are not assigned to %s"
-msgstr "Qualche SIM non è di %s"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sale_order.py:34
-#, python-format
-msgid "Order block, the client has too many sims inactive. {}% Active"
-msgstr "Ordine bloccato, il utente ha troppe SIM innative. {}% Attivo"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sale_order_allow_sale_sim
-msgid "Allow SIM"
-msgstr "Permettere SIM"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Active"
-msgstr "Attiva"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Active disuse"
-msgstr "Attiva in disuso"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Unsuscribed"
-msgstr "Disattivata"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Blocked"
-msgstr "Bloccata"
-
-#. module: sim_manager
-#: selection:sim.serial,state:0
-msgid "Preactivated"
-msgstr "Preattivata"
-
-#. module: sim_manager
-#: code:addons/sim_manager/models/sim.py:34
-#, python-format
-msgid "Error while reading SIM state"
-msgstr "Errore di lettura dello stato della carta SIM"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_res_partner_sim_active_perc
-msgid "Active SIMs"
-msgstr "SIMs attive"
-
-#. module: sim_manager
-#: selection:sim.service,type:0
-msgid "Data"
-msgstr "Dati"
-
-#. module: sim_manager
-#: selection:sim.service,type:0
-msgid "Voice"
-msgstr "Voce"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Activated"
-msgstr "Attivato"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Deactivated"
-msgstr "Disattivato"
-
-#. module: sim_manager
-#: selection:sim.service,status:0
-msgid "Blocked"
-msgstr "Bloccato"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_service_type
-msgid "Type"
-msgstr "Tipo"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_service_status
-msgid "Status"
-msgstr "Stato"
-
-#. module: sim_manager
-#: model:ir.model.fields,field_description:sim_manager.field_sim_serial_sim_service_ids
-msgid "Services"
-msgstr "Servizi"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Save"
-msgstr "Risparmiare"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Activate"
-msgstr "Attivare"
-
-#. module: sim_manager
-#: model:ir.ui.view,arch_db:sim_manager.view_sim_serial_form
-msgid "Deactivate"
-msgstr "Disattivare"
+msgid "{} created"
+msgstr "{} creado"

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -17,7 +17,7 @@ class ResPartner(models.Model):
         """
         Obtains the percentage of active SimSerials
         """
-        sim_count = sum([int(package_id.qty) for package_id in self.sim_serial_ids])
+        sim_count = len(self.sim_serial_ids.mapped('serial_ids'))
         if sim_count == 0:
             # if no sims then no active sims
             self.sim_active_perc = 0
@@ -39,7 +39,7 @@ class ResPartner(models.Model):
         if response.status_code == 200:
             num_active_sims = int(response.content)
 
-        self.sim_active_perc = num_active_sims * 100 / sim_count
+        self.sim_active_perc = round(num_active_sims * 100 / sim_count, 2)
 
     def invoice_sim_packages(self, month=None):
         # execute only if come the month or if today is the last day of the month

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -13,7 +13,6 @@ class ResPartner(models.Model):
     sim_serial_ids = fields.One2many('sim.package', 'partner_id')
     sim_active_perc = fields.Float(compute='_get_active_sims_perc', string='Active SIMs')
 
-
     def _get_active_sims_perc(self):
         """
         Obtains the percentage of active SimSerials
@@ -33,7 +32,7 @@ class ResPartner(models.Model):
             'origin': country_code.lower()
         }
         web_endpoint = (
-            "http://sim-visiotech-dev.visiotechsecurity.com/administrator/customer/odoo/customerActiveSims"
+            f"{self.env['ir.config_parameter'].sudo().get_param('web.sim.active.endpoint')}"
             f"?{urllib.parse.urlencode(data)}"
         )
         response = requests.get(web_endpoint, headers=headers, data=json.dumps({}))
@@ -41,7 +40,6 @@ class ResPartner(models.Model):
             num_active_sims = int(response.content)
 
         self.sim_active_perc = num_active_sims * 100 / sim_count
-
 
     def invoice_sim_packages(self, month=None):
         # execute only if come the month or if today is the last day of the month

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -4,12 +4,44 @@ import requests
 import json
 from datetime import datetime
 import calendar
+import urllib
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     sim_serial_ids = fields.One2many('sim.package', 'partner_id')
+    sim_active_perc = fields.Float(compute='_get_active_sims_perc', string='Active SIMs')
+
+
+    def _get_active_sims_perc(self):
+        """
+        Obtains the percentage of active SimSerials
+        """
+        sim_count = sum([int(package_id.qty) for package_id in self.sim_serial_ids])
+        if sim_count == 0:
+            # if no sims then no active sims
+            self.sim_active_perc = 0
+            return
+
+        num_active_sims = 0
+        api_key = self.env['ir.config_parameter'].sudo().get_param('web.sim.invoice.endpoint.key')
+        headers = {'x-api-key': api_key, 'Content-Type': 'application/json'}
+        country_code = self.env['ir.config_parameter'].sudo().get_param('country_code')
+        data = {
+            'odoo_id': self.id,
+            'origin': country_code.lower()
+        }
+        web_endpoint = (
+            "http://sim-visiotech-dev.visiotechsecurity.com/administrator/customer/odoo/customerActiveSims"
+            f"?{urllib.parse.urlencode(data)}"
+        )
+        response = requests.get(web_endpoint, headers=headers, data=json.dumps({}))
+        if response.status_code == 200:
+            num_active_sims = int(response.content)
+
+        self.sim_active_perc = num_active_sims * 100 / sim_count
+
 
     def invoice_sim_packages(self, month=None):
         # execute only if come the month or if today is the last day of the month

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -142,7 +142,16 @@ class SimSerial(models.Model):
 
     code = fields.Char(string='Serial')
     package_id = fields.Many2one('sim.package', string='Package')
-    state = fields.Char(compute='_get_sim_state', string="State")
+    state = fields.Selection(
+        compute='_get_sim_state', string="State", readonly=True,
+        selection=[
+            ('active', 'Active'),
+            ('active_disuse', 'Active disuse'),
+            ('unsuscribed', 'Unsuscribed'),
+            ('blocked', 'Blocked'),
+            ('preactivated', 'Preactivated')
+        ]
+    )
 
     def _get_sim_state(self):
         """

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -228,15 +228,14 @@ class SimSerial(models.Model):
             raise UserError(_('Error while getting SIM services'))
         services_response = json.loads(response.content.decode('utf-8'))['simServices']
         service_list = ('data', 'sms', 'voice')
-        services = [
+        services_ids = [
             self.env['sim.service'].create({
                 'sim_serial_id': self.id,
                 'type': service_name,
                 'status': services_response[f'{service_name}Service']
-            }) for service_name in service_list
+            }).id for service_name in service_list
         ]
-        to_update_list = [(5,)] + [(4, s.id) for s in services]
-        self.write({'sim_service_ids': to_update_list})
+        self.write({'sim_service_ids': [(6, 0, services_ids)]})
 
     @api.multi
     def action_open_sim_serial(self):

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -207,6 +207,15 @@ class SimSerial(models.Model):
         """
         self._set_state_to_sim('unsuscribed')
 
+    @api.multi
+    def action_open_sim_serial(self):
+        """
+        Returns the action that opens a SimSerial form
+        """
+        action = self.env.ref('sim_manager.action_open_sim_serial').read()[0]
+        action['res_id'] = self.id
+        return action
+
 
 class SimType(models.Model):
     _name = 'sim.type'
@@ -238,10 +247,10 @@ class SimService(models.TransientModel):
     _name = "sim.service"
     _description = "Sim Service"
 
-    sim_serial_id = fields.One2many('sim.serial', string="Code")
+    sim_serial_id = fields.Many2one('sim.serial', string="Code")
     type = fields.Selection(string="Type", selection=[
         ("data", "Data"), ("sms", "SMS"), ("voice", "Voice")
     ])
     status = fields.Selection(string="Status", selection=[
-        ("active", "Active"), ("inactive", "Inactive"), ("bloacked", "Blocked")
+        ("active", "Active"), ("inactive", "Inactive"), ("blocked", "Blocked")
     ])

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -152,6 +152,7 @@ class SimSerial(models.Model):
             ('preactivated', 'Preactivated')
         ]
     )
+    sim_service_ids = fields.One2many('sim.service', 'sim_serial_id', string="Services")
 
     def _get_sim_state(self):
         """
@@ -228,3 +229,19 @@ class SimExport(models.TransientModel):
     def sync_sim_web(self):
         pkg = self.env['sim.package'].browse(self.env.context["active_ids"])
         pkg.with_delay(priority=10).notify_sale_web(self.mode)
+
+
+class SimService(models.TransientModel):
+    """
+    Models the different services that a SimSerial has
+    """
+    _name = "sim.service"
+    _description = "Sim Service"
+
+    sim_serial_id = fields.One2many('sim.serial', string="Code")
+    type = fields.Selection(string="Type", selection=[
+        ("data", "Data"), ("sms", "SMS"), ("voice", "Voice")
+    ])
+    status = fields.Selection(string="Status", selection=[
+        ("active", "Active"), ("inactive", "Inactive"), ("bloacked", "Blocked")
+    ])

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -5,6 +5,8 @@ import logging
 from odoo.addons.queue_job.job import job
 import requests
 import urllib
+from odoo.exceptions import UserError
+
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +156,10 @@ class SimSerial(models.Model):
             f"?{urllib.parse.urlencode(data)}"
         )
         response = requests.get(web_endpoint, headers=headers, data=json.dumps({}))
-        self.state = json.loads(response.content.decode('utf-8'))['state']
+        if response.status_code == 200:
+            self.state = json.loads(response.content.decode('utf-8'))['state']
+        else:
+            raise UserError(_('Error while reading SIM state'))
 
 
 class SimType(models.Model):

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -175,7 +175,7 @@ class SimSerial(models.Model):
         """
         Given a new state, sets this state to the SIM Serial.
         """
-        if any(['blocked' == s['status'] for s in self.sim_service_ids]):
+        if self.sim_service_ids.filtered(lambda service: service.status == 'blocked'):
             raise UserError(_('Cannot block a SIM Service'))
 
         posible_states = ('active', 'active_disuse', 'unsuscribed', 'blocked', 'preactivated')

--- a/project-addons/sim_manager/views/partner_view.xml
+++ b/project-addons/sim_manager/views/partner_view.xml
@@ -15,8 +15,10 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_inline oe_stat_button" type="action" name="%(act_res_partner_sim_cards)d"
-                    attrs="{'invisible': [('customer', '=', False)]}" string="SIM Cards"
-                    icon="fa-wifi"/>
+                    attrs="{'invisible': [('customer', '=', False)]}"
+                    icon="fa-wifi">
+                    <field name="sim_active_perc" widget="statinfo"/>
+                </button>
             </xpath>
         </field>
     </record>

--- a/project-addons/sim_manager/views/partner_view.xml
+++ b/project-addons/sim_manager/views/partner_view.xml
@@ -17,7 +17,7 @@
                 <button class="oe_inline oe_stat_button" type="action" name="%(act_res_partner_sim_cards)d"
                     attrs="{'invisible': [('customer', '=', False)]}"
                     icon="fa-wifi">
-                    <field name="sim_active_perc" widget="statinfo"/>
+                    <field name="sim_active_perc" widget="statinfo" string="% Active SIMs"/>
                 </button>
             </xpath>
         </field>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -201,7 +201,7 @@
                 <field name="sim_service_ids">
                     <tree string="SIM Services" default_order="type asc" create="false" delete="false" editable="bottom">
                         <field name="type" string="Service" readonly="1"/>
-                        <field name="status" string="Estado" readonly="0"/>
+                        <field name="status" string="Status" readonly="0"/>
                     </tree>
                 </field>
                 <footer>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -194,16 +194,36 @@
         <field name="arch" type="xml">
             <form string="Sim Serial">
                  <group colspan="2">
-                     <field name="code"/>
-                     <field name="package_id"/>
+                     <field name="code" readonly="1"/>
+                     <field name="package_id" readonly="1"/>
                      <field name="state"/>
                 </group>
+                <field name="sim_service_ids" widget="one2many_list">
+                    <tree string="SIM Services" default_order="type asc" create="false" delete="false">
+                        <field name="type" string="Service" readonly="1"/>
+                        <field name="status" string="Estado" readonly="0"/>
+                    </tree>
+                </field>
                 <footer>
                     <button name="activate_sim" string="Activate" type="object"
                             class="oe_stat_button" attrs="{'invisible': [('state','!=','unsuscribed')]}"/>
                     <button name="deactivate_sim" string="Deactivate" type="object"
                             class="oe_stat_button" attrs="{'invisible': [('state','=','unsuscribed')]}"/>
                 </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_sim_service_form" model="ir.ui.view">
+        <field name="name">sim.service.view</field>
+        <field name="model">sim.service</field>
+        <field name="arch" type="xml">
+            <form string="SIM Service">
+                <group col="1" colspan="2">
+                    <field name="sim_serial_id" readonly="1"/>
+                    <field name="type" readonly="1"/>
+                    <field name="status"/>
+                </group>
             </form>
         </field>
     </record>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -205,6 +205,8 @@
                     </tree>
                 </field>
                 <footer>
+                    <button name="update_sim_services" string="Save" type="object"
+                            class="oe_stat_button"/>
                     <button name="activate_sim" string="Activate" type="object"
                             class="oe_stat_button" attrs="{'invisible': [('state','!=','unsuscribed')]}"/>
                     <button name="deactivate_sim" string="Deactivate" type="object"

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -198,8 +198,8 @@
                      <field name="package_id" readonly="1"/>
                      <field name="state"/>
                 </group>
-                <field name="sim_service_ids" widget="one2many_list">
-                    <tree string="SIM Services" default_order="type asc" create="false" delete="false">
+                <field name="sim_service_ids">
+                    <tree string="SIM Services" default_order="type asc" create="false" delete="false" editable="bottom">
                         <field name="type" string="Service" readonly="1"/>
                         <field name="status" string="Estado" readonly="0"/>
                     </tree>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -69,7 +69,7 @@
                     <field name="serial_ids" nolabel="1">
                         <tree editable="top">
                             <field name="code" style="pointer-events:none;"/>
-                            <button name="action_open_sim_serial" string="Open Serial" type="object"/>
+                            <button name="action_open_sim_serial" type="object" icon="fa-external-link"/>
                         </tree>
                     </field>
                 </sheet>
@@ -206,11 +206,11 @@
                 </field>
                 <footer>
                     <button name="update_sim_services" string="Save" type="object"
-                            class="oe_stat_button"/>
+                            class="btn-primary"/>
                     <button name="activate_sim" string="Activate" type="object"
-                            class="oe_stat_button" attrs="{'invisible': [('state','!=','unsuscribed')]}"/>
+                            attrs="{'invisible': [('state','!=','unsuscribed')]}"/>
                     <button name="deactivate_sim" string="Deactivate" type="object"
-                            class="oe_stat_button" attrs="{'invisible': [('state','=','unsuscribed')]}"/>
+                            class="btn-danger" attrs="{'invisible': [('state','=','unsuscribed')]}"/>
                 </footer>
             </form>
         </field>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -68,7 +68,8 @@
                     </group>
                     <field name="serial_ids" nolabel="1">
                         <tree editable="top">
-                            <field name="code"/>
+                            <field name="code" style="pointer-events:none;"/>
+                            <button name="action_open_sim_serial" string="Open Serial" type="object"/>
                         </tree>
                     </field>
                 </sheet>
@@ -205,6 +206,15 @@
                 </footer>
             </form>
         </field>
+    </record>
+
+    <record id="action_open_sim_serial" model="ir.actions.act_window">
+        <field name="name">Open SIM Serial</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sim.serial</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_sim_serial_form"/>
+        <field name="target">new</field>
     </record>
 
     <record id="action_sim_package_creator" model="ir.actions.act_window">

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -187,6 +187,26 @@
         </field>
     </record>
 
+    <record id="view_sim_serial_form" model="ir.ui.view">
+        <field name="name">sim.serial.view</field>
+        <field name="model">sim.serial</field>
+        <field name="arch" type="xml">
+            <form string="Sim Serial">
+                 <group colspan="2">
+                     <field name="code"/>
+                     <field name="package_id"/>
+                     <field name="state"/>
+                </group>
+                <footer>
+                    <button name="activate_sim" string="Activate" type="object"
+                            class="oe_stat_button" attrs="{'invisible': [('state','!=','unsuscribed')]}"/>
+                    <button name="deactivate_sim" string="Deactivate" type="object"
+                            class="oe_stat_button" attrs="{'invisible': [('state','=','unsuscribed')]}"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
     <record id="action_sim_package_creator" model="ir.actions.act_window">
         <field name="name">Create SIM package</field>
         <field name="type">ir.actions.act_window</field>


### PR DESCRIPTION
[fix] sim_manager: cambios en las SIMs
[i18n]sim_manager: Añade traducciones en español e italiano
[feature]sim_manager: Añade parámetros de las urls
[fix]sim_manager: Cambia una url a un parámetro del sistema
[i18n]sim_manager: Elimina la traducción de un botón que ya no tiene texto
[feature]sim_manager: Cambia los botones de SimService y de abrir SimSerial
[feature]sim_manager: Cambia la vista en árbol de los Servicios
[feature]sim_manager: Mejora la manera de crear los Servicios
[i18n]sim_manager: Añade traducciones en español e italiano
[feature]sim_manager: Añade botón para guardar los cambios en SimService
[feature]sim_manager: Modifica la interacción con los SimService
[feature]sim_manager: Cambia la forma de abrir la vista form de una SimSerial
[feature]sim_manager: Añade el modelo para los servicios de una tarjeta
[feature]sim_manager: Añade botones para activar y desactivar las SIMs
[i18n]sim_manager: Modifica los ficheros de traducción en español e italiano
[feature]sim_manager: Cambia el campo state como seleccionable y solo lectura
[feature]sim_manager: Añade la gestión de la respuesta al pedir el estado de la SIM
[feature]sim_manager: Añade un campo con el porcentaje de SIMs activas de un cliente
[i18n]sim_manager: Añade la traducción del campos estado en español e italiano
[feature]sim_manager: Crea el campo estado en SimSerial