### PR TITLE
Traspaso paquetes sim clientes

### DIFF
--- a/project-addons/sim_manager/__manifest__.py
+++ b/project-addons/sim_manager/__manifest__.py
@@ -4,7 +4,7 @@
     'summary': '',
     'description': '',
     'author': 'Visiotech',
-    'depends': ['mrp', 'barcode_action', 'crm_claim_rma', 'stock_custom', 'flask_middleware_connector'],
+    'depends': ['mrp', 'barcode_action', 'crm_claim_rma', 'stock_custom', 'flask_middleware_connector', 'mail'],
     'data': ['views/sim_view.xml', 'views/partner_view.xml', 'views/email_template.xml', 'views/sale_view.xml',
              'security/ir.model.access.csv', 'data/parameters.xml', 'data/cron.xml', 'data/email_template.xml'],
     'installable': True,

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -530,6 +530,7 @@ msgstr "Vendido"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_partner_changer_wzd_partner_id
 msgid "Sold to"
 msgstr "Vendido a"
 
@@ -667,3 +668,29 @@ msgstr "{} creado"
 #, python-format
 msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
 msgstr "<ul><li> Responsable: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:49
+#, python-format
+msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+msgstr "<ul><li> Responsable: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: sim_manager
+#: model:ir.actions.server,name:sim_manager.action_change_partner_from_package
+msgid "Change Partner"
+msgstr "Cambiar Cliente"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_open_sim_partner_changer_wzd
+msgid "Sim Partner Changer"
+msgstr "Cambio de clientes para paquetes SIM"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_partner_changer_wzd_form
+msgid "Change"
+msgstr "Cambiar"
+
+#. module: sim_manager
+#: model:ir.ui.view,arch_db:sim_manager.view_sim_partner_changer_wzd_form
+msgid "Cancel"
+msgstr "Cancelar"

--- a/project-addons/sim_manager/i18n/es.po
+++ b/project-addons/sim_manager/i18n/es.po
@@ -661,3 +661,9 @@ msgstr "simType"
 #, python-format
 msgid "{} created"
 msgstr "{} creado"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:49
+#, python-format
+msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+msgstr "<ul><li> Responsable: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -530,6 +530,7 @@ msgstr "Venduto"
 
 #. module: sim_manager
 #: model:ir.model.fields,field_description:sim_manager.field_sim_package_partner_id
+#: model:ir.model.fields,field_description:sim_manager.field_sim_partner_changer_wzd_partner_id
 msgid "Sold to"
 msgstr "Venduto a"
 
@@ -667,3 +668,19 @@ msgstr "{} creado"
 #, python-format
 msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
 msgstr "<ul><li> Responsabile: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:49
+#, python-format
+msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+msgstr "<ul><li> Responsabile: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: sim_manager
+#: model:ir.actions.server,name:sim_manager.action_change_partner_from_package
+msgid "Change Partner"
+msgstr "Cambiare il cliente"
+
+#. module: sim_manager
+#: model:ir.actions.act_window,name:sim_manager.action_open_sim_partner_changer_wzd
+msgid "Sim Partner Changer"
+msgstr "Cambio di clienti per i pacchetti SIM"

--- a/project-addons/sim_manager/i18n/it.po
+++ b/project-addons/sim_manager/i18n/it.po
@@ -661,3 +661,9 @@ msgstr "simType"
 #, python-format
 msgid "{} created"
 msgstr "{} creado"
+
+#. module: sim_manager
+#: code:addons/sim_manager/models/sim.py:49
+#, python-format
+msgid "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+msgstr "<ul><li> Responsabile: %s</il><li> Cliente: %s <b>&rarr;</b> %s</il></ul>"

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -12,6 +12,7 @@ class ResPartner(models.Model):
 
     sim_serial_ids = fields.One2many('sim.package', 'partner_id')
     sim_active_perc = fields.Float(compute='_get_active_sims_perc', string='Active SIMs')
+    sim_partner_changer_ids = fields.One2many('sim.partner.changer.wzd', 'partner_id')
 
     def _get_active_sims_perc(self):
         """

--- a/project-addons/sim_manager/models/res_partner.py
+++ b/project-addons/sim_manager/models/res_partner.py
@@ -12,7 +12,6 @@ class ResPartner(models.Model):
 
     sim_serial_ids = fields.One2many('sim.package', 'partner_id')
     sim_active_perc = fields.Float(compute='_get_active_sims_perc', string='Active SIMs')
-    sim_partner_changer_ids = fields.One2many('sim.partner.changer.wzd', 'partner_id')
 
     def _get_active_sims_perc(self):
         """

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -135,6 +135,8 @@ class SimPackage(models.Model):
     def notify_sale_web(self, mode):
         web_endpoint = self.env['ir.config_parameter'].sudo().get_param('web.sim.endpoint')
         c_code = self.env['ir.config_parameter'].sudo().get_param('country_code')
+        api_key = self.env['ir.config_parameter'].sudo().get_param('web.sim.endpoint.key')
+        headers = {'x-api-key': api_key, 'Content-Type': 'application/json'}
         for package in self:
             data = {
                 "origin": c_code.lower(),
@@ -144,9 +146,7 @@ class SimPackage(models.Model):
                 "codes": [sim.code for sim in package.serial_ids],
                 "sim_package": package.code
             }
-            api_key = self.env['ir.config_parameter'].sudo().get_param('web.sim.endpoint.key')
-            headers = {'x-api-key': api_key}
-            response = requests.post(web_endpoint, headers=headers, data=json.dumps({"data": data}))
+            response = requests.post(web_endpoint, headers=headers, data=json.dumps(data))
 
     def open_sim_partner_changer_action(self):
         partner_changer_packages_ids = [self.env['sim.partner.changer.package'].create({

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -42,11 +42,13 @@ class SimPackage(models.Model):
 
     @api.multi
     def write(self, vals):
+
         if 'partner_id' in vals:
-            new_partner_id = self.env['res.partner'].browse(vals['partner_id'])
-            self.message_post(body=_(
-                "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
-            ) % (self.env.user.partner_id.name, self.partner_id.name, new_partner_id.name))
+            for package in self:
+                new_partner_id = self.env['res.partner'].browse(vals['partner_id'])
+                package.message_post(body=_(
+                    "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+                ) % (self.env.user.partner_id.name, package.partner_id.name, new_partner_id.name))
         return super().write(vals)
 
     def _get_serials(self):

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -148,6 +148,19 @@ class SimPackage(models.Model):
             headers = {'x-api-key': api_key}
             response = requests.post(web_endpoint, headers=headers, data=json.dumps({"data": data}))
 
+    def open_sim_partner_changer_action(self):
+        partner_changer_packages_ids = [self.env['sim.partner.changer.package'].create({
+            'package_id': package_id
+        }).id for package_id in self.ids]
+        changer_wzd = self.env['sim.partner.changer.wzd'].create({
+            'partner_changer_package_ids': [(6, 0, partner_changer_packages_ids)],
+            'partner_id': False
+        })
+
+        action = self.env.ref('sim_manager.action_open_sim_partner_changer_wzd').read()[0]
+        action['res_id'] = changer_wzd.id
+        return action
+
 
 class SimSerial(models.Model):
     _name = 'sim.serial'

--- a/project-addons/sim_manager/models/sim.py
+++ b/project-addons/sim_manager/models/sim.py
@@ -15,6 +15,7 @@ class SimPackage(models.Model):
     _name = 'sim.package'
     _description = 'simPackage'
     _rec_name = 'code'
+    _inherit = 'mail.thread'
 
     code = fields.Char(string='Package')
     serial_ids = fields.One2many('sim.serial', 'package_id', string='Cards')
@@ -38,6 +39,15 @@ class SimPackage(models.Model):
     sim_9 = fields.Char(string="Serie 9", compute='_get_serials')
     sim_10 = fields.Char(string="Serie Fin", compute='_get_serials')
     qty = fields.Char(string="Cantidad", default='10')
+
+    @api.multi
+    def write(self, vals):
+        if 'partner_id' in vals:
+            new_partner_id = self.env['res.partner'].browse(vals['partner_id'])
+            self.message_post(body=_(
+                "<ul><li> Officer: %s</il><li> Partner: %s <b>&rarr;</b> %s</il></ul>"
+            ) % (self.env.user.partner_id.name, self.partner_id.name, new_partner_id.name))
+        return super().write(vals)
 
     def _get_serials(self):
         for pkg in self:

--- a/project-addons/sim_manager/security/ir.model.access.csv
+++ b/project-addons/sim_manager/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sim_package,access_sim_package,model_sim_package,base.group_user,1,1,1,1
 access_sim_serial,access_sim_serial,model_sim_serial,base.group_user,1,1,1,1
 access_sim_type,access_sim_type,model_sim_type,base.group_user,1,1,1,1
+access_sim_partner_changer_wzd,access_sim_partner_changer_wzd,model_sim_partner_changer_wzd,base.group_user,1,1,1,1

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -74,6 +74,10 @@
                         </tree>
                     </field>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -247,6 +247,23 @@
         </field>
     </record>
 
+    <record id="view_sim_partner_changer_wzd_form" model="ir.ui.view">
+        <field name="name">sim.partner.changer.wzd.view</field>
+        <field name="model">sim.partner.changer.wzd</field>
+        <field name="arch" type="xml">
+            <form string="Partner Changer">
+                <group col="1" colspan="2">
+                    <field name="partner_id" domain="[('is_company', '=', True)]"/>
+                </group>
+                <footer>
+                    <button string="Change" name="change_packages_partner" class="btn-primary"
+                            type="object" attrs="{'invisible': [('partner_id','=', False)]}"/>
+                    <button string="Cancel" special="cancel" class="btn-danger"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
     <record id="action_open_sim_serial" model="ir.actions.act_window">
         <field name="name">Open SIM Serial</field>
         <field name="type">ir.actions.act_window</field>

--- a/project-addons/sim_manager/views/sim_view.xml
+++ b/project-addons/sim_manager/views/sim_view.xml
@@ -300,6 +300,23 @@
         <field name="help">Manage the SIM Types</field>
     </record>
 
+    <record model="ir.actions.server" id="action_change_partner_from_package">
+       <field name="name">Change Partner</field>
+        <field name="model_id" ref="model_sim_package"/>
+        <field name="binding_model_id" ref="model_sim_package"/>
+       <field name="state">code</field>
+       <field name="code">action = records.open_sim_partner_changer_action()</field>
+    </record>
+
+    <record id="action_open_sim_partner_changer_wzd" model="ir.actions.act_window">
+        <field name="name">Sim Partner Changer</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sim.partner.changer.wzd</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_sim_partner_changer_wzd_form"/>
+        <field name="target">new</field>
+    </record>
+
     <menuitem id="menu_sim_package" action="action_sim_package" parent="mrp.menu_mrp_bom" sequence="40"/>
     <menuitem id="menu_sim_package_creator" action="action_sim_package_creator" name="Scan SIMs"
             parent="mrp.menu_mrp_manufacturing" sequence="50"/>


### PR DESCRIPTION
[fix] sim_manager: Elimina sim_partner_changer_ids en res.partner
[fix] sim_manager: Elimina el modelo de relación entre paquetes y el cambiador de cliente de sims
[feature] sim_manager: Modifica la función de sincronizaciónde sims
[i18n] sim_manager: Añade traducciones en español e italiano
[feature] sim_manager: Añade las acciones para poder cambiar el cliente de los paquetes desde interfaz
[feature] sim_manager: Añade modelo para el cambio de cliente de los paquetes
[fix] sim_manager: Corrige la escritura del mensaje para que se haga con varios paquetes
[feature] sim_manager: Añade mensaje con el cambio de cliente en los paquetes
