### PR TITLE
[IMPORTANT] Añadir campos cantidad facturada y pendiente rappels en flask

### DIFF
--- a/project-addons/flask_middleware_connector/models/rappel/exporter.py
+++ b/project-addons/flask_middleware_connector/models/rappel/exporter.py
@@ -44,6 +44,8 @@ class RappelInfoExporter(Component):
                 "date_end": binding.date_end,
                 "amount": binding.amount,
                 "amount_est": binding.amount_est,
+                "qty_invoiced": binding.curr_qty,
+                "qty_to_invoice": binding.curr_qty_pickings,
                 }
         if mode == "insert":
             return self.backend_adapter.insert(vals)

--- a/project-addons/vt_flask_middleware/rappel.py
+++ b/project-addons/vt_flask_middleware/rappel.py
@@ -24,6 +24,8 @@ class RappelCustomerInfo(SyncModel):
     date_end = CharField(max_length=15)
     amount = FloatField(default=0.0)
     amount_est = FloatField(default=0.0)
+    qty_invoiced = FloatField(default=0.0)
+    qty_to_invoice = FloatField(default=0.0)
 
     MOD_NAME = 'rappelcustomerinfo'
 


### PR DESCRIPTION
- [[IMP] flask_middleware_connector: añadido campos cantidad facturada y pendiente a rappels](https://github.com/Comunitea/CMNT_004_15/commit/ba72a67bf4beff0ec6034de76282d2d9a8eb1677)
- [[IMP] vt_flask_middleware: añadidos campos cantidad facturada y pendiente en rappels](https://github.com/Comunitea/CMNT_004_15/commit/3456143c3348d45eb352c1ea8516d9930c161609)

Buenas tardes Omar,
te dejo por aquí las ddls.
Saludos.
ALTER TABLE rappelcustomerinfo ADD COLUMN qty_invoiced numeric NULL;
ALTER TABLE rappelcustomerinfo ADD COLUMN qty_to_invoice numeric NULL;