### PR TITLE
Filtrar tarifas especiales marcas en promos

### DIFF
--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -714,3 +714,8 @@ msgstr "Descuento % en Sub total excluyendo marcas"
 #, python-format
 msgid "No product with the code"
 msgstr "No hay producto con el nombre % s"
+
+#. module: sale_promotions_extend
+#: selection:promos.rules.conditions.exps,attribute:0
+msgid "Order Pricelist Brand"
+msgstr "Tarifas especiales por marca"

--- a/project-addons/sale_promotions_extend/i18n/it.po
+++ b/project-addons/sale_promotions_extend/i18n/it.po
@@ -693,3 +693,8 @@ msgstr "Sconto % nell Sub total marchi escluse"
 #, python-format
 msgid "No product with the code %s"
 msgstr "Non ci sono prodotti con il nome %s"
+
+#. module: sale_promotions_extend
+#: selection:promos.rules.conditions.exps,attribute:0
+msgid "Order Pricelist Brand"
+msgstr "Marca di listino"

--- a/project-addons/sale_promotions_extend/models/rule.py
+++ b/project-addons/sale_promotions_extend/models/rule.py
@@ -79,16 +79,16 @@ class PromotionsRulesConditionsExprs(models.Model):
                     "Value for computed subtotal combination is invalid\n"
                     "Eg for right format is `['brand1,brand2',..]|120.50`")
             product_brands_iter, quantity = value.split("|")
-            if not (type(eval(product_brands_iter)) in [tuple, list] and
+            if not (type(eval(product_brands_iter)) not in [tuple, list] and
                     type(eval(quantity)) in [int, float]):
                 raise UserError(
                     "Value for Compute sub total of brand is invalid\n"
                     "Eg for right format is `['brand1,brand2',..]|120.50`")
-        if attribute == 'category_in_order' and type(eval(value)) in [tuple, list]:
+        if attribute == 'category_in_order' and type(eval(value)) not in [tuple, list]:
             raise UserError(
                 "Value for Product Category in Order is invalid\n"
                 "Eg for right format is ['prod_categ_1','prod_categ_2',...]")
-        if attribute == 'order_pricelist_brand' and type(eval(value)) in [tuple, list]:
+        if attribute == 'order_pricelist_brand' and type(eval(value)) not in [tuple, list]:
             raise UserError(
                 "Value for Order Pricelist Brand in Order is invalid\n"
                 "Eg for right format is ['order_pricelist_brand_1','order_pricelist_brand_2',...]")


### PR DESCRIPTION
- [[IMP] sale_promotions_extend: Añadido posibilidad de filtrar promos por tarifas especiales por marca](https://github.com/Comunitea/CMNT_004_15/commit/b028067ce646a3e4067189ec68d270ea2f34a0c7)
- [[l18n] sale_promotions_extend: Añadido traducción nuevo atributo para filtrar por tarifas especiales](https://github.com/Comunitea/CMNT_004_15/commit/9a7122dd0fdc95765036dc3e942d5b3f7f4e5b4a)
- [[FIX] sale_promotions_extend: corregido error de formato](https://github.com/Comunitea/CMNT_004_15/commit/b49f7085692dce88010bfa8d91229ef7a1113b1d)