### PR TITLE
Cambia la visibilidad del botón para exportar los números de serie de los albaranes

### DIFF
--- a/project-addons/stock_custom/views/stock_view.xml
+++ b/project-addons/stock_custom/views/stock_view.xml
@@ -176,6 +176,7 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <button name="action_picking_move_tree" position="attributes">
+                <attribute name="groups">stock.group_production_lot</attribute>
                 <attribute name="attrs">{'invisible': False}</attribute>
             </button>
         </field>


### PR DESCRIPTION
 [IMP] stock_custom: Cambia la visibilidad del botón al grupo Manage lots