### PR TITLE
Marcar check de "Proyecto" para que se reserve "infinito" el pedido

### DIFF
--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -134,9 +134,12 @@ class SaleOrder(models.Model):
     @api.multi
     @api.onchange('is_project')
     def onchange_is_project(self):
-       for order in self:
+        for order in self:
             order.not_sync_picking = order.is_project
             order.no_promos = order.is_project
+            order.infinite_reservation = order.is_project
+
+            order.update_stock_reservation_date_validity()
 
     @api.multi
     def _get_is_editable(self):

--- a/project-addons/sale_custom/tests/test_sale_order.py
+++ b/project-addons/sale_custom/tests/test_sale_order.py
@@ -1,15 +1,60 @@
 
 from odoo.tests.common import TransactionCase
-
+from mock import patch
 
 class TestSaleOrder(TransactionCase):
     post_install = True
     at_install = True
 
-    def setUp(self):
+    def setup(self):
         super(TestSaleOrder, self).setUp()
         self.so_model = self.env['sale.order']
         self.res_partner_model = self.env['res.partner']
+
+    def test_mark_checkbox_infinite_reservation(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': False,
+                   'infinite_reservation': False}
+        order = self.so_model.create(so_vals)
+
+        # act
+        order.is_project = True
+        order.onchange_is_project()
+
+        # assert
+        self.assertTrue(order.infinite_reservation)
+
+    def test_unmark_checkbox_infinite_reservation(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': True,
+                   'infinite_reservation': True}
+        order = self.so_model.create(so_vals)
+
+        # act
+        order.is_project = False
+        order.onchange_is_project()
+
+        # assert
+        self.assertFalse(order.infinite_reservation)
+
+    def test_call_function_update_stock_reservation_date_validity(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': True}
+        order = self.so_model.create(so_vals)
+
+        # act
+        with patch('odoo.addons.reserve_without_save_sale.models.sale.SaleOrder.update_stock_reservation_date_validity') as get_date:
+            order.onchange_is_project()
+
+        # assert
+        self.assertEqual(get_date.call_count, 1)
+
 
     def test_change_is_project_from_false_to_true(self):
         #arrange

--- a/project-addons/sale_custom/tests/test_sale_order.py
+++ b/project-addons/sale_custom/tests/test_sale_order.py
@@ -6,7 +6,7 @@ class TestSaleOrder(TransactionCase):
     post_install = True
     at_install = True
 
-    def setup(self):
+    def setUp(self):
         super(TestSaleOrder, self).setUp()
         self.so_model = self.env['sale.order']
         self.res_partner_model = self.env['res.partner']


### PR DESCRIPTION
- [[IMP]sale_custom: Permite que al marcar el pedido como proyecto, se los productos pasen a tener reserva "infinita"](https://github.com/Comunitea/CMNT_004_15/commit/5c9bf1cb834583b90530813b5c2cbed61c53a2de)
 
- [[IMP] sale_custom: Permite que al marcar el check de "proyecto" se reserve infinito en el pedido ](https://github.com/Comunitea/CMNT_004_15/commit/5e3db2961c343b65725ab861556fc006eb31388b)

