### PR TITLE
Color en Many2many_tags

### DIFF
--- a/project-addons/amazon_connector/models/amazon_sale_order.py
+++ b/project-addons/amazon_connector/models/amazon_sale_order.py
@@ -691,3 +691,4 @@ class AmazonMarketplace(models.Model):
     code = fields.Char()
     amazon_name = fields.Char()
     account_id = fields.Many2one("account.account")
+    color = fields.Integer()

--- a/project-addons/amazon_connector/views/amazon_sale_order.xml
+++ b/project-addons/amazon_connector/views/amazon_sale_order.xml
@@ -135,7 +135,7 @@
                                     <field name="product_qty"/>
                                     <field name="price_unit"/>
                                     <field name="price_subtotal"/>
-                                    <field name="tax_id" widget="many2many_tags"/>
+                                    <field name="tax_id" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                     <field name="price_tax"/>
                                     <field name="price_total"/>
                                 </tree>

--- a/project-addons/amazon_connector/views/company.xml
+++ b/project-addons/amazon_connector/views/company.xml
@@ -8,7 +8,7 @@
             <notebook position="inside">
                 <page name="amazon_connector" string="Amazon Connector">
                     <group name="amazon_credentials" string="Credentials">
-                        <field name="marketplace_ids" widget="many2many_tags"/>
+                        <field name="marketplace_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <field name="refresh_token"/>
                         <field name="lwa_app_id"/>
                         <field name="lwa_client_secret"/>

--- a/project-addons/crm_claim_rma/wizard/equivalent_products_wizard_view.xml
+++ b/project-addons/crm_claim_rma/wizard/equivalent_products_wizard_view.xml
@@ -17,7 +17,7 @@
                             <field name="virtual_available"/>
                             <field name="incoming_qty"/>
                             <field name="qty_in_production"/>
-                            <field name="tag_ids" widget="many2many_tags"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </tree>
                     </field>
                 </group>

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -70,7 +70,7 @@
                 <field name="t_incidence_picking" attrs="{'invisible':[('transport_incidence', '=', False)]}"/>
                 <field name="warehouse_date"/>
                 <field name="transport_incidence"/>
-                <field name="deposit_id" invisible="1" domain="['|',('partner_id.commercial_partner_id','=',partner_id),('partner_id','=',partner_id), ('location_dest_id.name','=','Deposito')]" widget="many2many_tags"/>
+                <field name="deposit_id" invisible="1" domain="['|',('partner_id.commercial_partner_id','=',partner_id),('partner_id','=',partner_id), ('location_dest_id.name','=','Deposito')]" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 <field name="amazon_rma" attrs="{'invisible':['|',('partner_name','=',False),'!',('partner_name', 'like', 'amazon')]}"/>
                 <field name="partner_name" invisible="1"/>
             </field>
@@ -80,7 +80,7 @@
             <field name="email_from" position="after">
                 <field name="comercial"/>
                 <field name="country" invisible="True"/>
-                <field name="category_id" widget="many2many_tags"/>
+                <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
             <field name="activity_summary" position="after">
                 <field name="att_order_id"/>
@@ -99,7 +99,7 @@
                           <field name="qty"/>
                           <field name="price_unit"/>
                           <field name="discount"/>
-                          <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use','=','sale')]" required="1"/>
+                          <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use','=','sale')]" options="{'color_field': 'color'}" required="1"/>
                           <field name="price_subtotal"/>
                           <field name="invoiced"/>
                         </tree>
@@ -132,7 +132,7 @@
                                     </div>
                                     <label for="tax_ids"/>
                                     <div>
-                                        <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use','=','sale')]"/>
+                                        <field name="tax_ids" widget="many2many_tags" options="{'color_field': 'color'}" domain="[('type_tax_use','=','sale')]"/>
                                     </div>
                                     <label for="price_subtotal"/>
                                     <div>

--- a/project-addons/custom_account/models/account.py
+++ b/project-addons/custom_account/models/account.py
@@ -390,3 +390,9 @@ class AccountPayment(models.Model):
                     line.write({'blocked': True})
 
         return res
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    color = fields.Integer()

--- a/project-addons/custom_account/views/purchase_view.xml
+++ b/project-addons/custom_account/views/purchase_view.xml
@@ -51,7 +51,7 @@
                   <attribute name="invisible">True</attribute>
               </field>
               <field name="invoice_status" position="after">
-                  <field name="container_ids" string="Shipments" widget="many2many_tags" readonly="1"/>
+                  <field name="container_ids" string="Shipments" widget="many2many_tags" readonly="1" options="{'color_field': 'color'}"/>
               </field>
               <field name="date_planned" position="after">
                   <field name="manufacture_date"/>

--- a/project-addons/custom_account/views/stock_view.xml
+++ b/project-addons/custom_account/views/stock_view.xml
@@ -14,7 +14,7 @@
                 </group>
             </field>
             <field name="partner_id" position="after">
-                <field name="partner_tags" widget="many2many_tags"/>
+                <field name="partner_tags" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 <field name="ref_partner" />
             </field>
             <field name="validity_date" position="attributes">

--- a/project-addons/custom_financial_risk/wizard/update_risk.xml
+++ b/project-addons/custom_financial_risk/wizard/update_risk.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="Update Partner Risk">
                 <group>
-                    <field name="partner_ids" widget="many2many_tags"/>
+                    <field name="partner_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="new_risk"/>
                 </group>
 

--- a/project-addons/custom_partner/views/partner_view.xml
+++ b/project-addons/custom_partner/views/partner_view.xml
@@ -454,7 +454,7 @@
                     <attribute name="invisible">0</attribute>
                 </field>
                 <field name="user_id" position="after">
-                    <field name="category_id"/>
+                    <field name="category_id" widget="many2many_tags" options="{'color_field':'color'}"/>
                     <field name="annual_invoiced"/>
                     <field name="last_sale_date"/>
                     <button name="open_partner" type="object" string="" icon="fa-window-restore" help="Open partner in new tab"/>

--- a/project-addons/customer_mood/views/res_partner_view.xml
+++ b/project-addons/customer_mood/views/res_partner_view.xml
@@ -20,7 +20,7 @@
             <field eval="1" name="priority"/>
             <field name="arch" type="xml">
                <field name="category_id" position="attributes">
-                   <attribute name ="options">{'no_quick_create':True,'no_create_edit':True}</attribute>
+                   <attribute name ="options">{'color_field': 'color','no_quick_create':True,'no_create_edit':True}</attribute>
                </field>
                <field name="category_id" position="after">
                     <field name="mood_image" colspan="2" placeholder="Mood..."/>

--- a/project-addons/equivalent_products/models/product.py
+++ b/project-addons/equivalent_products/models/product.py
@@ -72,3 +72,4 @@ class ProductTag(models.Model):
     child_id = fields.One2many('product.tag', 'parent_id', string="Child tags")
     parent_left = fields.Integer("Left Parent", index=True)
     parent_right = fields.Integer("Right Parent", index=True)
+    color = fields.Integer()

--- a/project-addons/equivalent_products/views/product_view.xml
+++ b/project-addons/equivalent_products/views/product_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <notebook position="inside">
                     <page string="Tags">
-                        <field name="tag_ids" widget="many2many_tags" colspan="4" nolabel="1"/>
+                        <field name="tag_ids" widget="many2many_tags" colspan="4" nolabel="1" options="{'color_field': 'color'}"/>
                     </page>
                 </notebook>
             </field>

--- a/project-addons/kitchen/models/customization_type.py
+++ b/project-addons/kitchen/models/customization_type.py
@@ -9,3 +9,5 @@ class KitchenCustomization(models.Model):
     rule_ids = fields.One2many('automatic.customization.type.rule','type_id')
 
     preview = fields.Boolean()
+
+    color = fields.Integer()

--- a/project-addons/kitchen/views/kitchen_customization.xml
+++ b/project-addons/kitchen/views/kitchen_customization.xml
@@ -89,7 +89,7 @@
                             <field name="partner_id"
                                    attrs="{'readonly': [('state', '!=', 'draft')],'required': [('is_manager','=',False)]}"/>
                             <field name="commercial_id" attrs="{'readonly': [('state', 'not in', ('draft','sent','waiting'))]}"/>
-                            <field name="notify_users" widget="many2many_tags"/>
+                            <field name="notify_users" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="notify_sales_team"/>
                             <field name="user"/>
                             <field name="scheduled_shipping_date"/>
@@ -106,7 +106,7 @@
                                     <field name="product_id"/>
                                     <field name="product_qty"/>
                                     <field name="product_erase_logo" invisible="1"/>
-                                    <field name="type_ids" widget="many2many_tags"
+                                    <field name="type_ids" widget="many2many_tags" options="{'color_field': 'color'}"
                                            attrs="{'readonly': ['|',('product_erase_logo','=',True),('state', 'not in', ('draft','sent','waiting'))]}"/>
                                     <field name="erase_logo"/>
                                     <field name="state" invisible="1"/>

--- a/project-addons/kitchen/views/product.xml
+++ b/project-addons/kitchen/views/product.xml
@@ -10,7 +10,7 @@
                 <group name="customization" string="Customization conditions">
                     <field name="customizable" readonly="1"/>
                     <field name="customization_type_ids" widget="many2many_tags"
-                           attrs="{'invisible':[('customizable','=',False)],'readonly':1}"/>
+                           attrs="{'invisible':[('customizable','=',False)],'readonly':1}" options="{'color_field': 'color'}"/>
                     <field name="erase_logo" readonly="1"/>
                 </group>
             </group>

--- a/project-addons/kitchen/wizard/create_customization_wizard.xml
+++ b/project-addons/kitchen/wizard/create_customization_wizard.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form string="Create customization">
                 <group>
-                    <field name="notify_users" widget="many2many_tags"/>
+                    <field name="notify_users" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="notify_sales_team"/>
                     <field name="order_id" invisible="1"/>
                 </group>
@@ -18,7 +18,7 @@
                         <field name="product_erase_logo" invisible="1"/>
                         <field name="product_qty"/>
                         <field name="qty"/>
-                        <field name="type_ids" widget="many2many_tags" attrs="{'readonly':[('product_erase_logo','=',True)]}"/>
+                        <field name="type_ids" widget="many2many_tags" attrs="{'readonly':[('product_erase_logo','=',True)]}" options="{'color_field': 'color'}"/>
                         <field name="erase_logo"/>
                     </tree>
                 </field>

--- a/project-addons/pmp_landed_costs/views/stock_landed_costs_view.xml
+++ b/project-addons/pmp_landed_costs/views/stock_landed_costs_view.xml
@@ -45,7 +45,7 @@
                 <attribute name="domain">[('state', '=', 'done'),('picking_type_code', '=', 'incoming')]</attribute>
             </field>
             <field name="picking_ids" position="after">
-                <field name="container_ids"  widget="many2many_tags"/>
+                <field name="container_ids"  widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
             <field name="account_move_id" position="after">
                 <field name="forwarder_invoice"/>
@@ -59,8 +59,8 @@
         <field name="inherit_id" ref="stock_landed_costs.view_stock_landed_cost_tree"/>
         <field name="arch" type="xml">
             <field name="date" position="after">
-                <field name="picking_ids" widget="many2many_tags"/>
-                <field name="container_ids" widget="many2many_tags"/>
+                <field name="picking_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="container_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
         </field>
     </record>

--- a/project-addons/product_battery/views/battery_view.xml
+++ b/project-addons/product_battery/views/battery_view.xml
@@ -21,7 +21,7 @@
                         <group>
                             <field name="name"/>
                             <field name="notes" placeholder="Notes"/>
-                            <field name="forbidden_ship_ids" widget="many2many_tags"/>
+                            <field name="forbidden_ship_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </group>
                     </group>
                 </sheet>

--- a/project-addons/product_pricelist_custom/models/product.py
+++ b/project-addons/product_pricelist_custom/models/product.py
@@ -30,6 +30,7 @@ class ProductPricelist(models.Model):
     brand_group_id = fields.Many2one("brand.group")
     default_brand_pricelist = fields.Boolean("Default Brand Pricelist", copy=False)
     team_id = fields.Many2one('crm.team', copy=False)
+    color = fields.Integer()
 
     display_name = fields.Char(
         compute='_compute_display_name',

--- a/project-addons/product_pricelist_custom/views/brand_group_view.xml
+++ b/project-addons/product_pricelist_custom/views/brand_group_view.xml
@@ -42,7 +42,7 @@
                         </h1>
                     </div>
                     <separator string="Brands"/>
-                    <field name="brand_ids" widget="many2many_tags"/>
+                    <field name="brand_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 </sheet>
             </form>
         </field>

--- a/project-addons/product_pricelist_custom/views/partner_view.xml
+++ b/project-addons/product_pricelist_custom/views/partner_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="product.view_partner_property_form"/>
         <field name="arch" type="xml">
             <field name="property_product_pricelist" position="after">
-                <field name="pricelist_brand_ids" widget="many2many_tags" />
+                <field name="pricelist_brand_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
         </field>
     </record>

--- a/project-addons/product_pricelist_custom/views/sale_view.xml
+++ b/project-addons/product_pricelist_custom/views/sale_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <field name="pricelist_id" position="after">
-                <field name="pricelist_brand_ids" widget="many2many_tags"/>
+                <field name="pricelist_brand_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
         </field>
     </record>

--- a/project-addons/purchase_picking/views/purchase_view.xml
+++ b/project-addons/purchase_picking/views/purchase_view.xml
@@ -54,7 +54,7 @@
                 <field name="total_disc" widget="monetary"/>
             </field>
             <field name="partner_ref" position="after">
-                <field name="container_ids" widget="many2many_tags" readonly="1"/>
+                <field name="container_ids" widget="many2many_tags" readonly="1" options="{'color_field': 'color'}"/>
             </field>
         </field>
     </record>

--- a/project-addons/purchase_picking/views/stock_view.xml
+++ b/project-addons/purchase_picking/views/stock_view.xml
@@ -40,7 +40,7 @@
             </field>
             <field name="origin" position="after">
                 <field name="shipping_identifier" attrs="{'invisible': [('picking_type_code', '!=', 'incoming')]}"/>
-                <field name="container_ids" attrs="{'invisible': [('picking_type_code', '!=', 'incoming')]}" widget="many2many_tags" readonly="1"/>
+                <field name="container_ids" attrs="{'invisible': [('picking_type_code', '!=', 'incoming')]}" widget="many2many_tags" readonly="1" options="{'color_field': 'color'}"/>
             </field>
             <button name="button_scrap" position="attributes">
                 <attribute name="invisible">1</attribute>

--- a/project-addons/sale_custom/views/product_view.xml
+++ b/project-addons/sale_custom/views/product_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="product_brand.view_product_brand_form"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="before">
-                <field name="category_ids" widget="many2many_tags"/>
+                <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </field>
         </field>
     </record>

--- a/project-addons/sale_custom/views/sale_view.xml
+++ b/project-addons/sale_custom/views/sale_view.xml
@@ -15,7 +15,7 @@
             <xpath expr="//field[@name='order_line']/tree/field[@name='tax_id']" position="replace">
             </xpath>
             <xpath expr="//field[@name='order_line']/tree/field[@name='margin_perc']" position="after">
-                <field name="tax_id" widget="many2many_tags" required="1" options="{'no_create': True}"
+                <field name="tax_id" widget="many2many_tags" required="1" options="{'color_field': 'color','no_create': True}"
                     domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"
                     attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"/>
                 <field name="description_editable_related" invisible="1"/>

--- a/project-addons/sale_margin_percentage/views/sale_view.xml
+++ b/project-addons/sale_margin_percentage/views/sale_view.xml
@@ -21,7 +21,7 @@
             <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                 <field name="margin_perc_rappel" readonly="1"/>
                 <field name="margin_perc" readonly="1" invisible="1"/>
-                <field name="tax_id" widget="many2many_tags" domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]"/>
+                <field name="tax_id" widget="many2many_tags" options="{'color_field': 'color'}" domain="[('parent_id','=',False),('type_tax_use','&lt;&gt;','purchase')]"/>
             </xpath>
             <field name="amount_untaxed" position="after">
                 <label for="margin_rappel"/>

--- a/project-addons/sale_product_customize/view/mrp_production_view.xml
+++ b/project-addons/sale_product_customize/view/mrp_production_view.xml
@@ -24,7 +24,7 @@
                 <field name="origin" position="after">
                     <field name="sale_id"/>
                     <field name="production_name"/>
-                    <field name="type_ids" widget="many2many_tags" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
+                    <field name="type_ids" options="{'color_field': 'color'}" widget="many2many_tags" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
                 </field>
                 <field name="availability" position="after">
                     <field name="picking_out"/>
@@ -42,7 +42,7 @@
             <field name="inherit_id" ref="mrp.mrp_production_tree_view"/>
             <field name="arch" type="xml">
                 <field name="origin" position="after">
-                    <field name="type_ids" widget="many2many_tags"/>
+                    <field name="type_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 </field>
                 <!--tree position="attributes">
                     <attribute name="create">0</attribute>

--- a/project-addons/sale_product_customize/view/sale_view.xml
+++ b/project-addons/sale_product_customize/view/sale_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="after">
-                    <field name="customization_types"  widget="many2many_tags"/>
+                    <field name="customization_types"  widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="requires_mount"  invisible="1"/>
                     <field name="can_mount_id" widget="selection" domain="[('head_product_id', '=', product_id)]" attrs="{'invisible': [('requires_mount', '=', False)], 'required': [('requires_mount', '=', True)]}"/>
                 </xpath>

--- a/project-addons/sale_product_customize/wizard/mrp_customization_view.xml
+++ b/project-addons/sale_product_customize/wizard/mrp_customization_view.xml
@@ -14,7 +14,7 @@
                             <field name="product_uom"/>
                         </group>
                         <group>
-                            <field name="customization_type_ids" widget="many2many_tags"/>
+                            <field name="customization_type_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="requires_mount" invisible="1"/>
                             <field name="requires_partner" invisible="1"/>
                             <field name="partner_id" attrs="{'invisible': [('requires_partner', '=',False)], 'required': [('requires_partner', '=', True)]}"/>

--- a/project-addons/separate_purchase_orders/views/purchase_view.xml
+++ b/project-addons/separate_purchase_orders/views/purchase_view.xml
@@ -87,7 +87,7 @@
                                     <field name="taxes_id" widget="many2many_tags"
                                            domain="[('type_tax_use','=','purchase')]"
                                            context="{'default_type_tax_use': 'purchase'}"
-                                           options="{'no_create': True}"/>
+                                           options="{'color_field': 'color', 'no_create': True}"/>
                                     <field name="price_subtotal" widget="monetary"/>
                                 </tree>
 

--- a/project-addons/stock_deposit/views/stock_deposit.xml
+++ b/project-addons/stock_deposit/views/stock_deposit.xml
@@ -63,7 +63,7 @@
                                 <field name="sale_picking_id"/>
                                 <field name="return_picking_id" />
                                 <field name="loss_picking_id" />
-                                <field name="damaged_move_ids" widget="many2many_tags" />
+                                <field name="damaged_move_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                 <field name="damaged_picking_id"/>
                                 <field name="claim_move_id" />
                                 <field name="claim_picking_id" />

--- a/project-addons/web_custom/__manifest__.py
+++ b/project-addons/web_custom/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': "Web custom",
+    'version': '1.0',
+    'category': 'Custom',
+    'description': """Little customizations in web js""",
+    'author': 'Visiotech',
+    "depends": ['web'],
+    "data": ["data/groups.xml",
+             "views/assets.xml"],
+    "installable": True
+}

--- a/project-addons/web_custom/data/groups.xml
+++ b/project-addons/web_custom/data/groups.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="group_select_tag_color" model="res.groups">
+            <field name="name">Select Tag Color</field>
+    </record>
+</odoo>

--- a/project-addons/web_custom/static/src/css/styles.css
+++ b/project-addons/web_custom/static/src/css/styles.css
@@ -1,0 +1,4 @@
+/* This fix many2many tags display above the table header */
+.o_list_view.table th{
+    z-index: 1;
+}

--- a/project-addons/web_custom/static/src/js/relational_fields.js
+++ b/project-addons/web_custom/static/src/js/relational_fields.js
@@ -1,0 +1,25 @@
+odoo.define('web_custom.relational_fields', function (require) {
+    "use strict";
+
+    const session = require('web.session');
+    const relational_fields = require('web.relational_fields');
+    const FormFieldMany2ManyTags = relational_fields.FormFieldMany2ManyTags;
+
+    FormFieldMany2ManyTags.include({
+        /**
+         * @override to add a group
+         * @param {MouseEvent} event
+         */
+        _onOpenColorPicker: function (event) {
+            let _super = this._super.bind(this);
+            session.user_has_group('web_custom.group_select_tag_color').then(function (has_group) {
+                if (has_group) {
+                    _super(event);
+                }
+            });
+
+
+        }
+
+    })
+})

--- a/project-addons/web_custom/views/assets.xml
+++ b/project-addons/web_custom/views/assets.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <template id="add_group_to_color_picker_in_tags" name="Add group to color picker in tags" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="web_custom/static/src/js/relational_fields.js"/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/project-addons/web_custom/views/assets.xml
+++ b/project-addons/web_custom/views/assets.xml
@@ -2,6 +2,7 @@
     <template id="add_group_to_color_picker_in_tags" name="Add group to color picker in tags" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="web_custom/static/src/js/relational_fields.js"/>
+            <link rel="stylesheet" href="web_custom/static/src/css/styles.css"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
- [[IMP] web_custom: añadido módulo que hereda el widget many2many_tags y añade un grupo al cambio de color](https://github.com/Comunitea/CMNT_004_15/commit/63f7add9ea6b5355b29cf65614441b948056e5c7)
- [[FIX] web_custom: Añadido css para que las etiquetas many2many no salgan por encima de la cabecera de la tabla](https://github.com/Comunitea/CMNT_004_15/commit/546cda993e5f92d870b888cf22c0ad87f7935a12)
