### PR TITLE
Filtro de RMA pendientes de adjuntar con pedido y pendiente de revisión

### DIFF
--- a/project-addons/crm_claim_rma_custom/i18n/de.po
+++ b/project-addons/crm_claim_rma_custom/i18n/de.po
@@ -17,12 +17,12 @@ msgstr ""
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Adjuntar con pedido"
+msgid "Attach with order"
 msgstr "Bei Bestellung anhängen"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Pendiente de revisión"
+msgid "Pending review"
 msgstr "Ausstehende Bewertung"
 
 #. module: crm_claim_rma_custom

--- a/project-addons/crm_claim_rma_custom/i18n/de.po
+++ b/project-addons/crm_claim_rma_custom/i18n/de.po
@@ -16,6 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Adjuntar con pedido"
+msgstr "Bei Bestellung anhängen"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Pendiente de revisión"
+msgstr "Ausstehende Bewertung"
+
+#. module: crm_claim_rma_custom
 #: code:addons/crm_claim_rma_custom/models/crm_claim.py:101
 #, python-format
 msgid "<p>Dear Customer,</p> <p>We inform you that we have received the products corresponding to %s.</p><p>We will start the procedure as soon as possible.</p> <p>Sincerely,</p><p>VISIOTECH</p>"

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -16,6 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Attach with order"
+msgstr "Adjuntar con pedido"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Pending review"
+msgstr "Pendiente de revisión"
+
+#. module: crm_claim_rma_custom
 #: model:ir.actions.act_window,name:crm_claim_rma_custom.crm_case_categ_claim_sort
 msgid "Received Claims"
 msgstr "RMA Recibidos"

--- a/project-addons/crm_claim_rma_custom/i18n/fr.po
+++ b/project-addons/crm_claim_rma_custom/i18n/fr.po
@@ -16,6 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Adjuntar con pedido"
+msgstr "Joindre à la commande"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Pendiente de revisión"
+msgstr "En attendant l'examen"
+
+#. module: crm_claim_rma_custom
 #: code:addons/crm_claim_rma_custom/models/crm_claim.py:101
 #, python-format
 msgid "<p>Dear Customer,</p> <p>We inform you that we have received the products corresponding to %s.</p><p>We will start the procedure as soon as possible.</p> <p>Sincerely,</p><p>VISIOTECH</p>"

--- a/project-addons/crm_claim_rma_custom/i18n/fr.po
+++ b/project-addons/crm_claim_rma_custom/i18n/fr.po
@@ -17,12 +17,12 @@ msgstr ""
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Adjuntar con pedido"
+msgid "Attach with order"
 msgstr "Joindre à la commande"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Pendiente de revisión"
+msgid "Pending review"
 msgstr "En attendant l'examen"
 
 #. module: crm_claim_rma_custom

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -16,6 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Adjuntar con pedido"
+msgstr "Allega con ordine"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Pendiente de revisión"
+msgstr "Revisione in atto"
+
+#. module: crm_claim_rma_custom
 #: model:ir.actions.act_window,name:crm_claim_rma_custom.crm_case_categ_claim_sort
 msgid "Received Claims"
 msgstr "RMA Ricevuti"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -17,12 +17,12 @@ msgstr ""
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Adjuntar con pedido"
+msgid "Attach with order"
 msgstr "Allega con ordine"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Pendiente de revisión"
+msgid "Pending review"
 msgstr "Revisione in atto"
 
 #. module: crm_claim_rma_custom

--- a/project-addons/crm_claim_rma_custom/i18n/pt.po
+++ b/project-addons/crm_claim_rma_custom/i18n/pt.po
@@ -17,12 +17,12 @@ msgstr ""
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Adjuntar con pedido"
+msgid "Attach with order"
 msgstr "Adjunto com pedido"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
-msgid "Pendiente de revisión"
+msgid "Pending review"
 msgstr "Revisão pendente"
 
 #. module: crm_claim_rma_custom

--- a/project-addons/crm_claim_rma_custom/i18n/pt.po
+++ b/project-addons/crm_claim_rma_custom/i18n/pt.po
@@ -16,6 +16,16 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Adjuntar con pedido"
+msgstr "Adjunto com pedido"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:view_crm_case_claims_filter_custom
+msgid "Pendiente de revisión"
+msgstr "Revisão pendente"
+
+#. module: crm_claim_rma_custom
 #: code:addons/crm_claim_rma_custom/models/crm_claim.py:101
 #, python-format
 msgid "<p>Dear Customer,</p> <p>We inform you that we have received the products corresponding to %s.</p><p>We will start the procedure as soon as possible.</p> <p>Sincerely,</p><p>VISIOTECH</p>"

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -32,8 +32,8 @@
                 <filter string="RMA Madrid" domain="[('warehouse_location','like','madrid')]"/>
                 <filter string="Transport incidence" domain="[('transport_incidence','=', True)]"/>
 
-                <filter string="Adjuntar con pedido" domain="[('stage_id.name','like','Adjuntar con pedido')]"/>
-                <filter string="Pendiente de revisión" domain="[('stage_id.name','like','Pendiente revisión')]"/>
+                <filter string="Attach with order" domain="[('stage_id.name','like','Adjuntar con pedido')]"/>
+                <filter string="Pending review" domain="[('stage_id.name','like','Pendiente revisión')]"/>
 
             </filter>
         </field>

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -31,6 +31,10 @@
                 <filter string="RMA Arcore" domain="[('warehouse_location','=','italia')]"/>
                 <filter string="RMA Madrid" domain="[('warehouse_location','like','madrid')]"/>
                 <filter string="Transport incidence" domain="[('transport_incidence','=', True)]"/>
+
+                <filter string="Adjuntar con pedido" domain="[('stage_id.name','like','Adjuntar con pedido')]"/>
+                <filter string="Pendiente de revisión" domain="[('stage_id.name','like','Pendiente revisión')]"/>
+
             </filter>
         </field>
     </record>


### PR DESCRIPTION
[[IMP]crm_claim_rma_custom: Permite filtrar RMA por adjuntar con pedido y pendiente de revisión](https://github.com/Comunitea/CMNT_004_15/commit/0b262ad549fd2c5410ff6c45d632106dcffdf8fd)

[[IMP]crm_claim_rma_custom: Permite filtrar los RMA por Pendiente de revisión y adjuntar con pedido](https://github.com/Comunitea/CMNT_004_15/commit/624c08b7cd19016526b86a6fc21db8939a57df9d)