### PR TITLE
Arrastrar lotes al enviar a averiados

### DIFF
--- a/project-addons/crm_claim_rma/i18n/es.po
+++ b/project-addons/crm_claim_rma/i18n/es.po
@@ -1644,3 +1644,9 @@ msgstr "No corresponde con descripción de web"
 #: selection:claim.line,claim_origine:0
 msgid "Missing parts"
 msgstr "Partes o accesorios faltantes"
+
+#. module: crm_claim_rma
+#: code:addons/crm_claim_rma/models/crm_claim_rma.py:210
+#, python-format
+msgid "Wrong number of serial numbers. Remember Separate them by commas"
+msgstr "Cantidad de Números de Serie incorrecto. Recuerda que van separados por comas"

--- a/project-addons/crm_claim_rma/i18n/it.po
+++ b/project-addons/crm_claim_rma/i18n/it.po
@@ -1629,3 +1629,9 @@ msgstr "\n"
 "% endif\n"
 "<p style=\"margin:0px 0px 9px 0px;font-size:13px;font-family:&quot;Lucida Grande&quot;, Helvetica, Verdana, Arial, sans-serif;\">Cordiali saluti,</p>\n"
 "            "
+
+#. module: crm_claim_rma
+#: code:addons/crm_claim_rma/models/crm_claim_rma.py:210
+#, python-format
+msgid "Wrong number of serial numbers. Remember Separate them by commas"
+msgstr "Numero errato di numeri di serie. Ricorda Separali con le virgole"

--- a/project-addons/crm_claim_rma/models/crm_claim_rma.py
+++ b/project-addons/crm_claim_rma/models/crm_claim_rma.py
@@ -22,6 +22,7 @@
 
 from odoo import fields, models, exceptions, _
 from odoo import SUPERUSER_ID, api
+from odoo.exceptions import UserError
 
 REPAIR_SELECTION = [
             ('draft', _('Quotation')),
@@ -195,6 +196,18 @@ class ClaimLine(models.Model):
             help='The move line related to the returned product')
 
     move_ids = fields.One2many('stock.move', 'claim_line_id')
+
+
+    @api.onchange('prodlot_id')
+    def onchange_prodlot_id(self):
+        """ This method check if the product_returned_quantity is equals to len(prodlot_id) split by commas
+        :return: ValidationError if the format is not correct
+        """
+        if self.prodlot_id:
+            self.prodlot_id = self.prodlot_id.replace(" ", "")
+            lots = self.prodlot_id.upper().split(',')
+            if len(lots) != self.product_returned_quantity:
+                raise UserError(_("Wrong number of serial numbers. Remember Separate them by commas"))
 
     def _compute_move_ids_customer_state(self, move_ids):
         dict_moves_states = {'draft': 1, 'waiting': 2, 'confirmed': 3, 'partially_available': 4, 'assigned': 5, 'done': 6,

--- a/project-addons/crm_rma_advance_location/wizard/claim_make_picking_to_refurbish.py
+++ b/project-addons/crm_rma_advance_location/wizard/claim_make_picking_to_refurbish.py
@@ -7,18 +7,14 @@ class ClaimMakePickingToRefurbishWizard(models.TransientModel):
     _name = "claim.make.picking.to.refurbish.wizard"
 
     @staticmethod
-    def get_lots_dict_remaining_moves(move):
-        """ This function return the lots_text of not used moves
+    def get_lots_remaining_moves(move):
+        """ This function returns the lot_text not used in other moves
         :param move: original stock.move from incoming picking
         :return: set() set of lots text
         """
         lot_text = set(move.lots_text.split(','))
-        children_lots_text = move.child_move_ids.mapped('lots_text')
-        not_used_lots_text = set()
-        for lot in lot_text:
-            if lot not in children_lots_text:
-                not_used_lots_text.add(lot)
-        return not_used_lots_text
+        children_lots_text = set(move.child_move_ids.mapped('lots_text'))
+        return lot_text - children_lots_text
 
     @api.model
     def _get_picking_lines(self):
@@ -41,7 +37,7 @@ class ClaimMakePickingToRefurbishWizard(models.TransientModel):
             if claim_id and len(claim_id) == 1:
                 new_line.update({'claim_id': claim_id.id})
             qty = move.product_uom_qty - move.qty_used
-            not_used_lots_text = self.get_lots_dict_remaining_moves(move)
+            not_used_lots_text = self.get_lots_remaining_moves(move)
             for __ in range(int(qty)):
                 new_line_dict = {}
                 if not_used_lots_text:

--- a/project-addons/sim_manager/models/claim.py
+++ b/project-addons/sim_manager/models/claim.py
@@ -37,6 +37,7 @@ class ClaimLine(models.Model):
 
     @api.onchange('prodlot_id')
     def onchange_prodlot_id(self):
+        super().onchange_prodlot_id()
         if self.product_id:
             products = self.env['sim.type'].search([('product_id', '=', self.product_id.id)])
             if products:


### PR DESCRIPTION
- [[IMP] crm_Claim_rma: añadida comprobación de cantidad de números de lote](https://github.com/Comunitea/CMNT_004_15/commit/2f924b8f8d87f7f1e05db0bfc5e52e5582e234f6)
- [[IMP] crm_rma_advance_location: añadido el arrastre del número d elote en el paso a averiados](https://github.com/Comunitea/CMNT_004_15/commit/fd039c2bd707da9de4507c47bb353c1c61a99d8b)
- [[IMP] sim_manager:añadido llamada al super](https://github.com/Comunitea/CMNT_004_15/commit/dd9ff68bcdf42f157e41b9f7cfa75b66878c251d)
- [[I18n] crm_claim_rma: añadido traducciones](https://github.com/Comunitea/CMNT_004_15/commit/f6cbcde73d03251618fd3f902079c7657a95e89b)
- [[IMP] crm_rma_advance_location: mejorada función para saber que lotes  no han sido usados](https://github.com/Comunitea/CMNT_004_15/commit/0f61a7ab29fe61e4f539bd542246795da885a9b6)