### PR TITLE
Módulo Cron Fin de mes

### DIFF
--- a/project-addons/cron_endmonth/__init__.py
+++ b/project-addons/cron_endmonth/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/cron_endmonth/__manifest__.py
+++ b/project-addons/cron_endmonth/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Cron End Month',
+    'version': '11.0.0.0.0',
+    'summary': 'Add the possibility to select end of month',
+    'author': 'Visiotech',
+    'license': 'AGPL-3',
+    'external_dependencies': {
+        'python': ['croniter']
+    },
+    'depends': ['base'],
+    'installable': True,
+}

--- a/project-addons/cron_endmonth/__manifest__.py
+++ b/project-addons/cron_endmonth/__manifest__.py
@@ -4,9 +4,6 @@
     'summary': 'Add the possibility to select end of month',
     'author': 'Visiotech',
     'license': 'AGPL-3',
-    'external_dependencies': {
-        'python': ['croniter']
-    },
     'depends': ['base'],
     'installable': True,
 }

--- a/project-addons/cron_endmonth/i18n/es.po
+++ b/project-addons/cron_endmonth/i18n/es.po
@@ -19,3 +19,8 @@ msgstr ""
 #: selection:ir.cron,interval_type:0
 msgid "End of month"
 msgstr "Fin de mes"
+
+#. module: cron_crontab
+#: selection:ir.cron,interval_type:0
+msgid "End of month Workday"
+msgstr "Fin de mes Laborable"

--- a/project-addons/cron_endmonth/i18n/es.po
+++ b/project-addons/cron_endmonth/i18n/es.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* cron_crontab
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-24 06:38+0000\n"
+"PO-Revision-Date: 2023-04-24 06:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: cron_crontab
+#: selection:ir.cron,interval_type:0
+msgid "End of month"
+msgstr "Fin de mes"

--- a/project-addons/cron_endmonth/i18n/it.po
+++ b/project-addons/cron_endmonth/i18n/it.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* cron_crontab
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-24 06:38+0000\n"
+"PO-Revision-Date: 2023-04-24 06:38+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: cron_crontab
+#: selection:ir.cron,interval_type:0
+msgid "End of month"
+msgstr "Fine mese"

--- a/project-addons/cron_endmonth/models/__init__.py
+++ b/project-addons/cron_endmonth/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_cron

--- a/project-addons/cron_endmonth/models/ir_cron.py
+++ b/project-addons/cron_endmonth/models/ir_cron.py
@@ -1,18 +1,29 @@
 from odoo import api, fields, models
 from odoo.addons.base.ir.ir_cron import _intervalTypes
 from datetime import datetime
-from croniter import croniter
 from dateutil.relativedelta import relativedelta
+import calendar
 
 
-def get_delta_crontab_end_month():
-    iter = croniter('45 23 L * *', datetime.now())
-    # The actual next call must be today for this to work
-    difference = iter.get_next(datetime) - datetime.now()
+def get_delta_end_month():
+    next_month = (datetime.now() + relativedelta(months=1)).month
+    next_year = datetime.now().year
+    if next_month == 1:
+        next_year += 1
+
+    next_day = calendar.monthrange(next_year, next_month)[1]
+    next_date = datetime(next_year, next_month, next_day)
+
+    if next_date.weekday() in (5, 6):  # Saturday or Sunday
+        # Having 5 (saturday) -4 will be 1 day less (friday) and 6-4 will be 2 days less
+        days_to_decrease = next_date.weekday() - 4  
+        next_date = datetime.datetime(next_year, next_month, next_day - days_to_decrease)
+
+    difference = next_date.date() - datetime.today().date()
     return relativedelta(days=difference.days)
 
 
-_intervalTypes['end_month'] = lambda interval: get_delta_crontab_end_month()
+_intervalTypes['end_month'] = lambda interval: get_delta_end_month()
 
 
 class ir_cron(models.Model):

--- a/project-addons/cron_endmonth/models/ir_cron.py
+++ b/project-addons/cron_endmonth/models/ir_cron.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 import calendar
 
 
-def get_delta_end_month():
+def get_delta_end_month_w():
     next_month = (datetime.now() + relativedelta(months=1)).month
     next_year = datetime.now().year
     if next_month == 1:
@@ -16,13 +16,27 @@ def get_delta_end_month():
 
     if next_date.weekday() in (5, 6):  # Saturday or Sunday
         # Having 5 (saturday) -4 will be 1 day less (friday) and 6-4 will be 2 days less
-        days_to_decrease = next_date.weekday() - 4  
+        days_to_decrease = next_date.weekday() - 4
         next_date = datetime.datetime(next_year, next_month, next_day - days_to_decrease)
 
     difference = next_date.date() - datetime.today().date()
     return relativedelta(days=difference.days)
 
 
+def get_delta_end_month():
+    next_month = (datetime.now() + relativedelta(months=1)).month
+    next_year = datetime.now().year
+    if next_month == 1:
+        next_year += 1
+
+    next_day = calendar.monthrange(next_year, next_month)[1]
+    next_date = datetime(next_year, next_month, next_day)
+
+    difference = next_date.date() - datetime.today().date()
+    return relativedelta(days=difference.days)
+
+
+_intervalTypes['end_month_w'] = lambda interval: get_delta_end_month_w()
 _intervalTypes['end_month'] = lambda interval: get_delta_end_month()
 
 
@@ -30,4 +44,4 @@ class ir_cron(models.Model):
 
     _inherit = "ir.cron"
 
-    interval_type = fields.Selection(selection_add=[('end_month', 'End of month')])
+    interval_type = fields.Selection(selection_add=[('end_month_w', 'End of month Workday'), ('end_month', 'End of month')])

--- a/project-addons/cron_endmonth/models/ir_cron.py
+++ b/project-addons/cron_endmonth/models/ir_cron.py
@@ -1,0 +1,22 @@
+from odoo import api, fields, models
+from odoo.addons.base.ir.ir_cron import _intervalTypes
+from datetime import datetime
+from croniter import croniter
+from dateutil.relativedelta import relativedelta
+
+
+def get_delta_crontab_end_month():
+    iter = croniter('45 23 L * *', datetime.now())
+    # The actual next call must be today for this to work
+    difference = iter.get_next(datetime) - datetime.now()
+    return relativedelta(days=difference.days)
+
+
+_intervalTypes['end_month'] = lambda interval: get_delta_crontab_end_month()
+
+
+class ir_cron(models.Model):
+
+    _inherit = "ir.cron"
+
+    interval_type = fields.Selection(selection_add=[('end_month', 'End of month')])

--- a/project-addons/cron_endmonth/models/ir_cron.py
+++ b/project-addons/cron_endmonth/models/ir_cron.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 import calendar
 
 
-def get_delta_end_month_w():
+def _get_next_month():
     next_month = (datetime.now() + relativedelta(months=1)).month
     next_year = datetime.now().year
     if next_month == 1:
@@ -13,24 +13,25 @@ def get_delta_end_month_w():
 
     next_day = calendar.monthrange(next_year, next_month)[1]
     next_date = datetime(next_year, next_month, next_day)
+    return next_date
+
+
+def get_delta_end_month_w():
+
+    next_date = _get_next_month()
 
     if next_date.weekday() in (5, 6):  # Saturday or Sunday
         # Having 5 (saturday) -4 will be 1 day less (friday) and 6-4 will be 2 days less
         days_to_decrease = next_date.weekday() - 4
-        next_date = datetime.datetime(next_year, next_month, next_day - days_to_decrease)
+        next_date = next_date - relativedelta(days=days_to_decrease)
 
     difference = next_date.date() - datetime.today().date()
     return relativedelta(days=difference.days)
 
 
 def get_delta_end_month():
-    next_month = (datetime.now() + relativedelta(months=1)).month
-    next_year = datetime.now().year
-    if next_month == 1:
-        next_year += 1
 
-    next_day = calendar.monthrange(next_year, next_month)[1]
-    next_date = datetime(next_year, next_month, next_day)
+    next_date = _get_next_month()
 
     difference = next_date.date() - datetime.today().date()
     return relativedelta(days=difference.days)


### PR DESCRIPTION
- [[IMP]cron_endmonth: nuevo modulo para seleccionar fin de mes en los cron](https://github.com/Comunitea/CMNT_004_15/commit/bb6d9dc79284d1c786003ae00c5b7e31246759b9)
- [[IMP]cron_endmonth: nueva forma de calcular el último día laboral del mes](https://github.com/Comunitea/CMNT_004_15/commit/6e7198092588240ca0643480c0643d808ded65a3)
- [[IMP]cron_end_month: se añade una nueva función para final de mes no laborable](https://github.com/Comunitea/CMNT_004_15/commit/a16444556d03fbc129a6586fab53508669cd5cac)
- [[IMP]cron_endmonth: se unifica el calculo de proxima fecha](https://github.com/Comunitea/CMNT_004_15/commit/8aa0e6b99584762ffd4aa2cd06f9fa700add4c7f)