### PR TITLE
Reservas infinitas al marcas check de proyecto

### DIFF
--- a/project-addons/reserve_without_save_sale/models/stock_reservation.py
+++ b/project-addons/reserve_without_save_sale/models/stock_reservation.py
@@ -126,6 +126,7 @@ class StockReservation(models.Model):
         A date until which the product is reserved can be specified.
         """
         moves = self.env['stock.move']
+        reserve_obj = self.env['stock.reservation']
         for reserve in self:
             date_validity = self._get_date_validity(reserve.sale_id)
             current_sale_line_id = reserve.sale_line_id.id
@@ -134,10 +135,10 @@ class StockReservation(models.Model):
             moves |= res
             for move in res:
                 move.sale_line_id = current_sale_line_id
-                reservation = self.env['stock.reservation'].search(
+                reservation = reserve_obj.search(
                     [('move_id', '=', move.id)])
                 if not reservation:
-                    self.env['stock.reservation'].create(
+                    reserve_obj.create(
                         {'move_id': move.id,
                          'sale_line_id': current_sale_line_id,
                          'date_validity': date_validity

--- a/project-addons/reserve_without_save_sale/static/src/js/sale_order_line.js
+++ b/project-addons/reserve_without_save_sale/static/src/js/sale_order_line.js
@@ -25,6 +25,7 @@ odoo.define('reserve_without_save_sale', function(require) {
                 'sale_line_id': element.data.id || false,
                 'warehouse': recordData.warehouse_id.data.id,
                 'sale_id': recordData.id,
+                'infinite_reservation': recordData.infinite_reservation,
                 'user_id': recordData.user_id.data.id,
                 'csrf_token': require('web.core').csrf_token
             }

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -138,7 +138,6 @@ class SaleOrder(models.Model):
             order.not_sync_picking = order.is_project
             order.no_promos = order.is_project
             order.infinite_reservation = order.is_project
-
             order.update_stock_reservation_date_validity()
 
     @api.multi

--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -134,9 +134,12 @@ class SaleOrder(models.Model):
     @api.multi
     @api.onchange('is_project')
     def onchange_is_project(self):
-       for order in self:
+        for order in self:
             order.not_sync_picking = order.is_project
             order.no_promos = order.is_project
+            order.infinite_reservation = order.is_project
+
+            order.update_stock_reservation_date_validity()
 
     @api.multi
     def _get_is_editable(self):

--- a/project-addons/sale_custom/tests/test_sale_order.py
+++ b/project-addons/sale_custom/tests/test_sale_order.py
@@ -1,15 +1,60 @@
 
 from odoo.tests.common import TransactionCase
-
+from mock import patch
 
 class TestSaleOrder(TransactionCase):
     post_install = True
     at_install = True
 
-    def setUp(self):
+    def setup(self):
         super(TestSaleOrder, self).setUp()
         self.so_model = self.env['sale.order']
         self.res_partner_model = self.env['res.partner']
+
+    def test_mark_checkbox_infinite_reservation(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': False,
+                   'infinite_reservation': False}
+        order = self.so_model.create(so_vals)
+
+        # act
+        order.is_project = True
+        order.onchange_is_project()
+
+        # assert
+        self.assertTrue(order.infinite_reservation)
+
+    def test_unmark_checkbox_infinite_reservation(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': True,
+                   'infinite_reservation': True}
+        order = self.so_model.create(so_vals)
+
+        # act
+        order.is_project = False
+        order.onchange_is_project()
+
+        # assert
+        self.assertFalse(order.infinite_reservation)
+
+    def test_call_function_update_stock_reservation_date_validity(self):
+        # arrange
+        partner_id = self.res_partner_model.create(dict(name="Peter"))
+        so_vals = {'partner_id': partner_id.id,
+                   'is_project': True}
+        order = self.so_model.create(so_vals)
+
+        # act
+        with patch('odoo.addons.reserve_without_save_sale.models.sale.SaleOrder.update_stock_reservation_date_validity') as get_date:
+            order.onchange_is_project()
+
+        # assert
+        self.assertEqual(get_date.call_count, 1)
+
 
     def test_change_is_project_from_false_to_true(self):
         #arrange

--- a/project-addons/sale_custom/tests/test_sale_order.py
+++ b/project-addons/sale_custom/tests/test_sale_order.py
@@ -6,7 +6,7 @@ class TestSaleOrder(TransactionCase):
     post_install = True
     at_install = True
 
-    def setup(self):
+    def setUp(self):
         super(TestSaleOrder, self).setUp()
         self.so_model = self.env['sale.order']
         self.res_partner_model = self.env['res.partner']


### PR DESCRIPTION
- [[IMP]sale_custom: Permite que al marcar el pedido como proyecto, se los productos pasen a tener reserva "infinita"](https://github.com/Comunitea/CMNT_004_15/commit/5c9bf1cb834583b90530813b5c2cbed61c53a2de)
- [[IMP] sale_custom: Permite que al marcar el check de "proyecto" se reserve infinito en el pedido](https://github.com/Comunitea/CMNT_004_15/commit/5e3db2961c343b65725ab861556fc006eb31388b)
- [[IMP] reserve_without_save_sale: añadido cálculo de fecha dependiendo de si el pedido tiene el check de reservas infinitas marcado](https://github.com/Comunitea/CMNT_004_15/commit/35ebeb9c79cfe88193adb1c8d6445958802d7fcc)
- [[FIX] sale_custom: eliminado salto de linea innecesario](https://github.com/Comunitea/CMNT_004_15/commit/721eb5f17d1c1d412ade1c4f732f3749cedd08fe)
- [[IMP] reserve_without_save_sale: Reservar con la fecha correcta antes de crear pedido](https://github.com/Comunitea/CMNT_004_15/commit/5e6e304e604d0501e50780775c3c88fb059beae9)
- [[REF] rserve_without_save_sale: añadida variable](https://github.com/Comunitea/CMNT_004_15/commit/acccdc93cfd7eeb1a228eeb45fec4c7cf5432016)
