### PR TITLE
Filtro de RMA recibidos en Italia

### DIFF
--- a/project-addons/crm_claim_rma_custom/__manifest__.py
+++ b/project-addons/crm_claim_rma_custom/__manifest__.py
@@ -41,9 +41,9 @@
                 'picking_incidences',
                 'custom_account'],
     "data": [
-             'data/stage_data.xml',
              'views/assets.xml',
              'data/groups.xml',
+             'data/stage_data.xml',
              'views/crm_claim_view.xml',
              'data/substate_data.xml',
              'security/ir.model.access.csv',

--- a/project-addons/crm_claim_rma_custom/__manifest__.py
+++ b/project-addons/crm_claim_rma_custom/__manifest__.py
@@ -41,6 +41,7 @@
                 'picking_incidences',
                 'custom_account'],
     "data": [
+             'data/stage_data.xml',
              'views/assets.xml',
              'data/groups.xml',
              'views/crm_claim_view.xml',
@@ -51,7 +52,6 @@
              'wizard/claim_make_picking_from_picking_view.xml',
              'report/crm_claim_report_view.xml',
              'wizard/invoice_discount_wiz.xml',
-             'data/stage_data.xml',
              'views/res_users_view.xml',
              'data/email_layout.xml',
              'views/res_partner_view.xml',

--- a/project-addons/crm_claim_rma_custom/data/stage_data.xml
+++ b/project-addons/crm_claim_rma_custom/data/stage_data.xml
@@ -17,7 +17,7 @@
     </record>
     <record model="crm.claim.stage" id="stage_claim_received">
         <field name="name">Recibido a borrar</field>
-        <field name="sequence">6</field>
+        <field name="sequence">30</field>
         <field name="case_default" eval="True"/>
     </record>
 </odoo>

--- a/project-addons/crm_claim_rma_custom/data/stage_data.xml
+++ b/project-addons/crm_claim_rma_custom/data/stage_data.xml
@@ -15,4 +15,9 @@
         <field name="sequence">29</field>
         <field name="case_default" eval="True"/>
     </record>
+    <record model="crm.claim.stage" id="stage_claim_received">
+        <field name="name">Recibido a borrar</field>
+        <field name="sequence">30</field>
+        <field name="case_default" eval="True"/>
+    </record>
 </odoo>

--- a/project-addons/crm_claim_rma_custom/data/stage_data.xml
+++ b/project-addons/crm_claim_rma_custom/data/stage_data.xml
@@ -17,7 +17,7 @@
     </record>
     <record model="crm.claim.stage" id="stage_claim_received">
         <field name="name">Recibido a borrar</field>
-        <field name="sequence">30</field>
+        <field name="sequence">6</field>
         <field name="case_default" eval="True"/>
     </record>
 </odoo>

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -23,7 +23,7 @@ msgstr "RMA Recibidos"
 #. module: crm_claim_rma_custom
 #: model:ir.ui.menu,name:crm_claim_rma_custom.menu_crm_case_claims
 msgid "Received Claims"
-msgstr "RMAs Recividos"
+msgstr "RMAs Recibidos"
 
 #. module: crm_claim_rma_custom
 #: model:ir.model.fields,field_description:crm_claim_rma_custom.field_crm_claim_bool_category_id

--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -123,7 +123,7 @@ class CrmClaimRma(models.Model):
             stage_pending_shipping_id = self.env.ref('crm_claim_rma_custom.stage_claim6').id
             stage_ids.append(stage_pending_shipping_id)
             stage_received_id = self.env.ref('crm_claim_rma_custom.stage_claim_received').id
-            #stage_received_id = self.env['crm.claim.stage'].search([('name', '=', 'Recibido')]).id
+
             if vals['stage_id'] == stage_received_id and \
                     not (self.warehouse_location or vals.get('warehouse_location', False)):
                 raise exceptions.UserError(_('Please, select the warehouse location of the RMA'))

--- a/project-addons/crm_claim_rma_custom/models/crm_claim.py
+++ b/project-addons/crm_claim_rma_custom/models/crm_claim.py
@@ -122,8 +122,8 @@ class CrmClaimRma(models.Model):
             stage_ids.append(stage_repaired_id)
             stage_pending_shipping_id = self.env.ref('crm_claim_rma_custom.stage_claim6').id
             stage_ids.append(stage_pending_shipping_id)
-
-            stage_received_id = self.env['crm.claim.stage'].search([('name', '=', 'Recibido')]).id
+            stage_received_id = self.env.ref('crm_claim_rma_custom.stage_claim_received').id
+            #stage_received_id = self.env['crm.claim.stage'].search([('name', '=', 'Recibido')]).id
             if vals['stage_id'] == stage_received_id and \
                     not (self.warehouse_location or vals.get('warehouse_location', False)):
                 raise exceptions.UserError(_('Please, select the warehouse location of the RMA'))

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -361,9 +361,9 @@
                                      'claim_type': ref('crm_claim_type.crm_claim_type_customer'),
                                      'default_claim_type': ref('crm_claim_type.crm_claim_type_customer')}"/>
         <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer')),
-                                    ('warehouse_location','!=','transit
-                                    ('stage_id', '=', ref('crm_claim_rma_custom.stage_claim_received')),
-                                    ('date_received','!=', False)]"/>
+                            ('warehouse_location','!=','transit'),
+                            ('date_received','!=', False),
+                            ('stage_id','=', ref('crm_claim_rma_custom.stage_claim_received'))]"/>
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -349,7 +349,6 @@
                                      'default_claim_type': ref('crm_claim_type.crm_claim_type_customer')}"/>
         <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer')),
                                     ('warehouse_location','!=','transit'),
-                                    ('stage_id.name', '=', 'Recibido'),
                                     ('date_received','!=', False)]"/>
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -352,7 +352,8 @@
                                      'claim_type': ref('crm_claim_type.crm_claim_type_customer'),
                                      'default_claim_type': ref('crm_claim_type.crm_claim_type_customer')}"/>
         <field name="domain" eval="[('claim_type','=',ref('crm_claim_type.crm_claim_type_customer')),
-                                    ('warehouse_location','!=','transit'),
+                                    ('warehouse_location','!=','transit
+                                    ('stage_id', '=', ref('crm_claim_rma_custom.stage_claim_received')),
                                     ('date_received','!=', False)]"/>
         <field name="search_view_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="help" type="html">


### PR DESCRIPTION
[[IMP] crm_claim_rma_custom: Filtro de RMA para estado recibidos (ricevuto) en odoo Italia](https://github.com/Comunitea/CMNT_004_15/commit/0c6df527e66d886cc8cac280bc37912271fc5dd5)

[[IMP] crm_claim_rma_custom: Permite filtrar los RMA recibidos desde el menú de opciones](https://github.com/Comunitea/CMNT_004_15/commit/fb1448eb71a4c3f9ec9a4c234f3dd6069c825fec)

[[IMP] crm_claim_rma_custom: Permite filtrar los RMA recibidos mediante el menú postventa](https://github.com/Comunitea/CMNT_004_15/commit/8a5a787faaee09ddc215c6505fe64af79e60d757)

[[FIX] crm_claim_rma_custom: Se ha cambiado el orden de carga de los ficheros en manifest](https://github.com/Comunitea/CMNT_004_15/commit/a76fe88689dec02bbd448ab51659040dd26554e6)

[[FIX] crm_claim_rma_custom: Comentarios eliminados](https://github.com/Comunitea/CMNT_004_15/commit/dc37fa52edac7dedd1861d478a78db6b4a7fd768)