### PR TITLE
Configurar no aplicar promociones en cliente

### DIFF
--- a/project-addons/sale_promotions_extend/__manifest__.py
+++ b/project-addons/sale_promotions_extend/__manifest__.py
@@ -23,6 +23,7 @@ Features:
         "views/sale_view.xml",
         "views/rule.xml",
         "views/product_view.xml",
+        "views/partner_view.xml",
         'security/ir.model.access.csv'
     ],
     "demo": [],

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -727,6 +727,6 @@ msgid "Order Pricelist Brand"
 msgstr "Tarifas especiales por marca"
 
 #. module: sale_promotions_extend
-#: model:ir.model.fields,field_description:custom_partner.field_res_partner_no_promos
+#: model:ir.model.fields,field_description:sale_promotions_extend.field_res_partner_no_promos
 msgid "Not apply promotions"
 msgstr "No aplicar promociones"

--- a/project-addons/sale_promotions_extend/i18n/es.po
+++ b/project-addons/sale_promotions_extend/i18n/es.po
@@ -725,3 +725,8 @@ msgstr "No hay producto con el nombre % s"
 #: selection:promos.rules.conditions.exps,attribute:0
 msgid "Order Pricelist Brand"
 msgstr "Tarifas especiales por marca"
+
+#. module: sale_promotions_extend
+#: model:ir.model.fields,field_description:custom_partner.field_res_partner_no_promos
+msgid "Not apply promotions"
+msgstr "No aplicar promociones"

--- a/project-addons/sale_promotions_extend/i18n/it.po
+++ b/project-addons/sale_promotions_extend/i18n/it.po
@@ -710,3 +710,8 @@ msgstr "Sconto per il programma di punti in marchi"
 #, python-format
 msgid "Sale points programme discount Excluding Brand"
 msgstr "Sconto per il programma di punti escluso marchi "
+
+#. module: sale_promotions_extend
+#: model:ir.model.fields,field_description:custom_partner.field_res_partner_no_promos
+msgid "Not apply promotions"
+msgstr "Non applicare promozioni"

--- a/project-addons/sale_promotions_extend/i18n/it.po
+++ b/project-addons/sale_promotions_extend/i18n/it.po
@@ -712,6 +712,6 @@ msgid "Sale points programme discount Excluding Brand"
 msgstr "Sconto per il programma di punti escluso marchi "
 
 #. module: sale_promotions_extend
-#: model:ir.model.fields,field_description:custom_partner.field_res_partner_no_promos
+#: model:ir.model.fields,field_description:sale_promotions_extend.field_res_partner_no_promos
 msgid "Not apply promotions"
 msgstr "Non applicare promozioni"

--- a/project-addons/sale_promotions_extend/models/__init__.py
+++ b/project-addons/sale_promotions_extend/models/__init__.py
@@ -1,5 +1,3 @@
 # © 2019 Comunitea
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from . import sale
-from . import rule
-from . import product
+from . import sale, rule, product, partner

--- a/project-addons/sale_promotions_extend/models/partner.py
+++ b/project-addons/sale_promotions_extend/models/partner.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    no_promos = fields.Boolean(string="Not apply promotions")

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -91,6 +91,13 @@ class SaleOrder(models.Model):
         "Not apply promotions",
         help="Reload the prices after marking this check")
 
+    @api.multi
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        super().onchange_partner_id()
+        if self.partner_id:
+            self.no_promos = self.partner_id.no_promos
+
     def apply_commercial_rules(self):
         context2 = dict(self._context)
         context2.pop('default_state', False)

--- a/project-addons/sale_promotions_extend/views/partner_view.xml
+++ b/project-addons/sale_promotions_extend/views/partner_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_form_add_no_promos" model="ir.ui.view">
+        <field name="name">view.partner.form.add.no.promos</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ref']" position="after">
+                <field name="no_promos"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
 [FIX] sale_promotions_extend: Corrige traducciones
 [IMP] sale_promotions_extend: Arrastra no_promos a pedido al cambiar cliente
 [IMP] sale_promotions_extend: Añade campo no_promos en cliente
