### PR TITLE
Añadir "Last supplier" en vez de "Fabricante" en el email de valoración de stock

### DIFF
--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -95,8 +95,7 @@ class ProductProduct(models.Model):
             for row in res:
                 fifo_automated_values[(row[0], row[1])] = row[2]
         for product in products:
-            #import wdb
-            #wdb.set_trace()
+
             value = 0
             category_name = product["categ_id"][1]
 
@@ -122,8 +121,8 @@ class ProductProduct(models.Model):
                                                          valuation_account_id)) or 0, 2)
             seller_ids = product["seller_ids"]
             if seller_ids:
-                sellers = self.env['product.supplierinfo'].browse(seller_ids)
-                display_name = sellers[0].display_name or 0
+                #sellers = self.env['product.supplierinfo'].browse(seller_ids)
+                #display_name = sellers[0].display_name or 0
                 product_fields = [product["id"], product['display_name'], brand_name, category_name,
                                   last_supplier_id, product["qty_available"], value]
                 rows.append(product_fields)

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -65,7 +65,7 @@ class ProductProduct(models.Model):
                   ('product_tmpl_id', 'in', products_real_time_ids)]
 
         fields = ["display_name", "qty_available", "standard_price", "cost_method", "categ_id", "product_brand_id",
-                  "seller_ids", "last_supplier_id"]
+                  "last_supplier_id"]
         rows = []
         if to_date:
             products = self.env['product.product'].with_context(company_owned=True, owner_id=False,

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -3,7 +3,6 @@ import base64
 from datetime import datetime, timedelta
 import xlsxwriter
 
-
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -3,6 +3,7 @@ import base64
 from datetime import datetime, timedelta
 import xlsxwriter
 
+
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
@@ -97,11 +98,10 @@ class ProductProduct(models.Model):
 
             value = 0
             category_name = product["categ_id"][1]
+            last_supplier_id = None
 
             if product["last_supplier_id"]:
                 last_supplier_id = product["last_supplier_id"][1]
-            else:
-                last_supplier_id = 0
 
             brand_name = product["product_brand_id"][1] if product["product_brand_id"] and product["product_brand_id"][
                 1] else 0
@@ -118,23 +118,10 @@ class ProductProduct(models.Model):
                     property_stock_valuation_account_id.id
                 value = round(fifo_automated_values.get((product["id"],
                                                          valuation_account_id)) or 0, 2)
-            seller_ids = product["seller_ids"]
-            if seller_ids:
-                #sellers = self.env['product.supplierinfo'].browse(seller_ids)
-                #display_name = sellers[0].display_name or 0
-                product_fields = [product["id"], product['display_name'], brand_name, category_name,
-                                  last_supplier_id, product["qty_available"], value]
-                rows.append(product_fields)
-                """if len(sellers) > 1:
-                    sellers = sellers[1::]
-                    for seller in sellers:
-                        display_name = seller.display_name or 0
-                        product_fields = ["", "", "", "", display_name, "", ""]
-                        rows.append(product_fields)"""
-            else:
-                product_fields = [product["id"], product['display_name'], brand_name, category_name,
-                                  last_supplier_id, product["qty_available"], value]
-                rows.append(product_fields)
+
+            product_fields = [product["id"], product['display_name'], brand_name, category_name,
+                              last_supplier_id, product["qty_available"], value]
+            rows.append(product_fields)
 
         file_b64 = self.generate_xls(headers, rows)
         if not to_date:

--- a/project-addons/cron_stock_catalog/models/product.py
+++ b/project-addons/cron_stock_catalog/models/product.py
@@ -1,7 +1,8 @@
 from odoo import api, fields, models, _, exceptions, tools
 import base64
-from datetime import datetime,timedelta
+from datetime import datetime, timedelta
 import xlsxwriter
+
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
@@ -12,11 +13,13 @@ class ProductProduct(models.Model):
         """
         headers = ["ID", "Último Proveedor", "Referencia interna", "Fabricando", "Entrante", "Stock cocina",
                    "Stock real", "Stock disponible", "Ventas en los últimos 60 días con stock",
-                   "Cant. pedido más grande", "Días de stock restantes", "Días de stock restantes (real)", "Stock en playa",
+                   "Cant. pedido más grande", "Días de stock restantes", "Días de stock restantes (real)",
+                   "Stock en playa",
                    "Media de margen de últimas ventas", "Cost Price", "Último precio de compra",
                    "Última fecha de compra", "Reemplazado por", "Estado"]
 
-        domain = [('custom', '=', False), ('type', '!=', 'service'),("categ_id.name", "not in", ["Outlet", "O1", "O2" , "Descatalogados"])]
+        domain = [('custom', '=', False), ('type', '!=', 'service'),
+                  ("categ_id.name", "not in", ["Outlet", "O1", "O2", "Descatalogados"])]
 
         fields = ["id", "last_supplier_id", "code", "qty_in_production", "incoming_qty", "qty_available_wo_wh",
                   "qty_available", "virtual_stock_conservative", "last_sixty_days_sales", "biggest_sale_qty",
@@ -26,7 +29,8 @@ class ProductProduct(models.Model):
         translate_state = {"draft": "En desarrollo", "sellable": "Normal", "end": "Fin del ciclo de vida",
                            "obsolete": "Obsoleto", "make_to_order": "Bajo pedido"}
 
-        products = self.env['product.product'].with_context({'lang': 'es_ES'}).search_read(domain, fields + ["seller_id"])
+        products = self.env['product.product'].with_context({'lang': 'es_ES'}).search_read(domain,
+                                                                                           fields + ["seller_id"])
         for product in products:
             product_fields = []
             for field in fields:
@@ -54,14 +58,14 @@ class ProductProduct(models.Model):
                         "cron_stock_catalog.email_template_purchase_stock_catalog")
 
     def cron_product_valuation(self, to_date=False):
-        headers = ["ID", "Nombre del Producto", "Marca", "Categoria", "Proveedores", "Cantidad", "Valor"]
+        headers = ["ID", "Nombre del Producto", "Marca", "Categoría", "Último proveedor", "Cantidad", "Valor"]
 
         products_real_time_ids = self.env['product.template'].search([('property_valuation', '=', 'real_time')]).ids
         domain = [('type', '=', 'product'), ('qty_available', '>', 0),
                   ('product_tmpl_id', 'in', products_real_time_ids)]
 
         fields = ["display_name", "qty_available", "standard_price", "cost_method", "categ_id", "product_brand_id",
-                  "seller_ids"]
+                  "seller_ids", "last_supplier_id"]
         rows = []
         if to_date:
             products = self.env['product.product'].with_context(company_owned=True, owner_id=False,
@@ -91,8 +95,16 @@ class ProductProduct(models.Model):
             for row in res:
                 fifo_automated_values[(row[0], row[1])] = row[2]
         for product in products:
+            #import wdb
+            #wdb.set_trace()
             value = 0
             category_name = product["categ_id"][1]
+
+            if product["last_supplier_id"]:
+                last_supplier_id = product["last_supplier_id"][1]
+            else:
+                last_supplier_id = 0
+
             brand_name = product["product_brand_id"][1] if product["product_brand_id"] and product["product_brand_id"][
                 1] else 0
             if product["cost_method"] in ['standard', 'average']:
@@ -113,17 +125,17 @@ class ProductProduct(models.Model):
                 sellers = self.env['product.supplierinfo'].browse(seller_ids)
                 display_name = sellers[0].display_name or 0
                 product_fields = [product["id"], product['display_name'], brand_name, category_name,
-                                  display_name, product["qty_available"], value]
+                                  last_supplier_id, product["qty_available"], value]
                 rows.append(product_fields)
-                if len(sellers) > 1:
+                """if len(sellers) > 1:
                     sellers = sellers[1::]
                     for seller in sellers:
                         display_name = seller.display_name or 0
                         product_fields = ["", "", "", "", display_name, "", ""]
-                        rows.append(product_fields)
+                        rows.append(product_fields)"""
             else:
                 product_fields = [product["id"], product['display_name'], brand_name, category_name,
-                                  0, product["qty_available"], value]
+                                  last_supplier_id, product["qty_available"], value]
                 rows.append(product_fields)
 
         file_b64 = self.generate_xls(headers, rows)
@@ -135,20 +147,25 @@ class ProductProduct(models.Model):
 
     def cron_general_alberto_3(self):
         headers = ["ID", "Referencia interna", "Entrante",
-                   "PVP_Iberia", "PVP_Italia", "PVP_Francia", "PVP_Europa", "PVI_Iberia", "PVI_Italia", "PVI_Francia", "PVI_Europa",
-                   "Margen PVD_Iberia", "Margen PVD_Italia", "Margen PVD_Francia","Margen PVD_Europa", "Margen PVI_Iberia", "Margen PVI_Italia",
+                   "PVP_Iberia", "PVP_Italia", "PVP_Francia", "PVP_Europa", "PVI_Iberia", "PVI_Italia", "PVI_Francia",
+                   "PVI_Europa",
+                   "Margen PVD_Iberia", "Margen PVD_Italia", "Margen PVD_Francia", "Margen PVD_Europa",
+                   "Margen PVI_Iberia", "Margen PVI_Italia",
                    "Margen PVI_Francia", "Margen PVI_Europa", "Stock Real", "Stock Disponible", "Coste 2",
                    "Nombre de la categoría Padre", "Nombre de la categoría", "Ventas en los últimos 60 días con stock",
-                   "Días de stock restantes", "Días de stock restantes (real)", "Nombre de la marca", "Stock Cocina", "Estado", "Joking",
+                   "Días de stock restantes", "Días de stock restantes (real)", "Nombre de la marca", "Stock Cocina",
+                   "Estado", "Joking",
                    "Fabricando"]
 
         domain = [('sale_ok', '=', True)]
 
-        fields = ["id", "default_code", "incoming_qty", "list_price1", "list_price3","list_price4", "list_price2",
+        fields = ["id", "default_code", "incoming_qty", "list_price1", "list_price3", "list_price4", "list_price2",
                   "pvi1_price", "pvi3_price", "pvi4_price", "pvi2_price", "margin_pvd1", "margin_pvd3",
-                  "margin_pvd4", 'margin_pvd2', "margin_pvi1", "margin_pvi3", "margin_pvi4", "margin_pvi2", "qty_available",
+                  "margin_pvd4", 'margin_pvd2', "margin_pvi1", "margin_pvi3", "margin_pvi4", "margin_pvi2",
+                  "qty_available",
                   "virtual_available_wo_incoming", "standard_price_2_inc", "categ_id",
-                  "last_sixty_days_sales", "remaining_days_sale", "real_remaining_days_sale", "product_brand_id", "qty_available_wo_wh",
+                  "last_sixty_days_sales", "remaining_days_sale", "real_remaining_days_sale", "product_brand_id",
+                  "qty_available_wo_wh",
                   "state", "joking", "qty_in_production"]
 
         translate_state = {"draft": "En desarrollo", "sellable": "Normal", "end": "Fin del ciclo de vida",
@@ -191,7 +208,7 @@ class ProductProduct(models.Model):
         """ :returns the super domain adding only sales if it comes in the context"""
         domain = super()._get_eol_stock_move_domain(date)
         if self.env.context.get('only_sales', False):
-            domain += ['&',('sale_line_id','!=',False)] + domain
+            domain += ['&', ('sale_line_id', '!=', False)] + domain
         return domain
 
     def cron_eol_products(self, date=False):
@@ -202,7 +219,7 @@ class ProductProduct(models.Model):
         if not date:
             date = (datetime.now() - timedelta(days=365)).strftime("%Y-%m-%d %H:%M:%S")
         rows = []
-        domain = self.with_context({'only_sales':True})._get_eol_stock_move_domain(date)
+        domain = self.with_context({'only_sales': True})._get_eol_stock_move_domain(date)
         moves = self.env['stock.move'].search(domain)
         for move in moves:
             picking_name = move.picking_id.name if move.picking_id else ""
@@ -234,11 +251,11 @@ class ProductProduct(models.Model):
 
         if self.replacement_id and self.state == 'end' and self.replacement_id not in product_visited:
             product_visited.add(self.replacement_id)
-            return self.replacement_id.get_first_no_eol_replacement_product(product_visited=product_visited, first=False)
+            return self.replacement_id.get_first_no_eol_replacement_product(product_visited=product_visited,
+                                                                            first=False)
         if first:
             return self.replacement_id
         return self
-
 
     @api.multi
     def send_email(self, file, name, datas_fname, template_name):

--- a/project-addons/stock_custom/views/product_view.xml
+++ b/project-addons/stock_custom/views/product_view.xml
@@ -192,7 +192,7 @@
             </field>
         </field>
     </record>
- 
+
 
     <record id="product_product_last_purchase_info_form_view" model="ir.ui.view">
         <field name="name">product.product.last.purchase.info.form</field>


### PR DESCRIPTION
[[IMP] cron_stock_catalog: sustituimos la columna de proveedores (la cual mostraba los fabricantes) por la de último proveedor](https://github.com/Comunitea/CMNT_004_15/commit/47aec2fc0f23189ad7afcb1cc020cdfe535934f6)

[[IMP] cron_stock_catalog: permite en el email de valoración de stock "Last supplier" en vez de "Fabricante"
](https://github.com/Comunitea/CMNT_004_15/commit/ec0b5beaa4c3faca215c982b65a65ae4a0056e0f)

[[IMP] cron_stock_catalog: Añadir "Last supplier" en vez de "Fabricante" en el email de valoración de stock](https://github.com/Comunitea/CMNT_004_15/commit/1ef19cb961f93da2111271c58a5f4989e69b924c)

[[FIX] cron_stock_catalog: Comentarios eliminados y código innecesario eliminado](https://github.com/Comunitea/CMNT_004_15/commit/25661eff21bb862c501cb97056edac9472c263d9)

[[FIX] cron_stock_catalog: Eliminado código innecesario](https://github.com/Comunitea/CMNT_004_15/commit/5028b552f2cc11afeff25e63993ba6b07ab05466)