### PR TITLE
Filtros tesoreria

### DIFF
--- a/project-addons/account_treasury_forecast/i18n/es.po
+++ b/project-addons/account_treasury_forecast/i18n/es.po
@@ -442,17 +442,14 @@ msgid "Start Date"
 msgstr "Fecha de inicio"
 
 #. module: account_treasury_forecast
-#: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customer
-msgid "Payment mode"
-msgstr "Modo de pago"
-
-#. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view_add_filters
+#: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view
 msgid "Choose the payment mode"
 msgstr "Seleccione el modo de pago"
 
 #. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view
+#: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customerm2m
 msgid "Payment mode"
 msgstr "Modo de pago"
 

--- a/project-addons/account_treasury_forecast/i18n/es.po
+++ b/project-addons/account_treasury_forecast/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_treasury_forecast
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -445,24 +445,6 @@ msgstr "Fecha de inicio"
 #: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customer
 msgid "Payment mode"
 msgstr "Modo de pago"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Transfer"
-msgstr "Transferencia"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Debit receipt"
-msgstr "Recibo Domiciliado"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Both"
-msgstr "Ambos"
 
 #. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view_add_filters

--- a/project-addons/account_treasury_forecast/i18n/es.po
+++ b/project-addons/account_treasury_forecast/i18n/es.po
@@ -459,10 +459,16 @@ msgid "Transfers filters"
 msgstr "Filtros para Transferencias"
 
 #. module: account_treasury_forecast
-#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:48
+#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:150
 #, python-format
-msgid "Error!:: You must select one option for payment mode fields."
-msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago."
+msgid "Error!:: You must select one option for customer payment mode fields."
+msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de cliente."
+
+#. module: account_treasury_forecast
+#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:153
+#, python-format
+msgid "Error!:: You must select one option for supplier payment mode fields."
+msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de proveedor."
 
 #. module: account_treasury_forecast
 #: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:57

--- a/project-addons/account_treasury_forecast/i18n/it.po
+++ b/project-addons/account_treasury_forecast/i18n/it.po
@@ -442,17 +442,14 @@ msgid "Start Date"
 msgstr "Data di Inizio"
 
 #. module: account_treasury_forecast
-#: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customer
-msgid "Payment mode"
-msgstr "Metodo di pagamento"
-
-#. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view_add_filters
+#: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view
 msgid "Choose the payment mode"
 msgstr "Selezionare il metodo di pagamento"
 
 #. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view
+#: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customer_m2m
 msgid "Payment mode"
 msgstr "Metodo di pagamento"
 

--- a/project-addons/account_treasury_forecast/i18n/it.po
+++ b/project-addons/account_treasury_forecast/i18n/it.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_treasury_forecast
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -445,24 +445,6 @@ msgstr "Data di Inizio"
 #: model:ir.model.fields,field_description:account_treasury_forecast.field_account_treasury_forecast_payment_mode_customer
 msgid "Payment mode"
 msgstr "Metodo di pagamento"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Transfer"
-msgstr "Trasferimento"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Debit receipt"
-msgstr "Ricevuta addebito"
-
-#. module: account_treasury_forecast
-#: selection:account.treasury.forecast,payment_mode_customer:0
-#: selection:account.treasury.forecast,payment_mode_supplier:0
-msgid "Both"
-msgstr "Entrambi"
 
 #. module: account_treasury_forecast
 #: model:ir.ui.view,arch_db:account_treasury_forecast.account_treasury_forecast_form_view_add_filters

--- a/project-addons/account_treasury_forecast/i18n/it.po
+++ b/project-addons/account_treasury_forecast/i18n/it.po
@@ -459,10 +459,16 @@ msgid "Transfers filters"
 msgstr "Filtri di trasferimento"
 
 #. module: account_treasury_forecast
-#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:48
+#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:150
 #, python-format
-msgid "Error!:: You must select one option for payment mode fields."
-msgstr "¡Errore!:: Selezionare una opzione nei campi di pagamento."
+msgid "Error!:: You must select one option for customer payment mode fields."
+msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de cliente."
+
+#. module: account_treasury_forecast
+#: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:153
+#, python-format
+msgid "Error!:: You must select one option for supplier payment mode fields."
+msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de proveedor."
 
 #. module: account_treasury_forecast
 #: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:57

--- a/project-addons/account_treasury_forecast/i18n/it.po
+++ b/project-addons/account_treasury_forecast/i18n/it.po
@@ -462,13 +462,13 @@ msgstr "Filtri di trasferimento"
 #: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:150
 #, python-format
 msgid "Error!:: You must select one option for customer payment mode fields."
-msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de cliente."
+msgstr "¡Errore!:: È necessario selezionare un'opzione per i campi della modalità di pagamento del cliente."
 
 #. module: account_treasury_forecast
 #: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:153
 #, python-format
 msgid "Error!:: You must select one option for supplier payment mode fields."
-msgstr "¡Error!:: Debe seleccionar una opción en los campos de método de pago de proveedor."
+msgstr "¡Errore!:: È necessario selezionare un'opzione per i campi relativi alla modalità di pagamento dei fornitori."
 
 #. module: account_treasury_forecast
 #: code:addons/account_treasury_forecast/models/account_treasury_forecast.py:57

--- a/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
+++ b/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
@@ -145,9 +145,12 @@ class AccountTreasuryForecast(models.Model):
                     'payment_mode_supplier_m2m', 'check_old_open_supplier',
                     'opened_start_date_customer', 'opened_start_date_supplier', 'start_date')
     def check_filter(self):
-        if not self.payment_mode_customer_m2m or not self.payment_mode_supplier_m2m:
+        if not self.payment_mode_customer_m2m:
             raise exceptions.Warning(
-                _('Error!:: You must select one option for payment mode fields.'))
+                _('Error!:: You must select one option for customer payment mode fields.'))
+        if not self.payment_mode_supplier_m2m:
+            raise exceptions.Warning(
+                _('Error!:: You must select one option for supplier payment mode fields.'))
         elif ('debit_receipt' not in self.payment_mode_customer_m2m.mapped('treasury_forecast_type')
               and self.check_old_open_customer
               and self.opened_start_date_customer >= self.start_date):

--- a/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
+++ b/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
@@ -23,10 +23,6 @@ from odoo import models, fields, api, exceptions, _
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-PAYMENT_MODE = [('debit_receipt', 'Debit receipt'),
-                ('transfer', 'Transfer'),
-                ('both', 'Both')]
-
 
 class AccountTreasuryForecastInvoice(models.Model):
     _name = 'account.treasury.forecast.invoice'
@@ -97,7 +93,6 @@ class AccountTreasuryForecast(models.Model):
     variable_line_ids = fields.One2many(
         'account.treasury.forecast.line', 'treasury_id',
         string="Variable Lines", domain=[('line_type', '=', 'variable')])
-    payment_mode_customer = fields.Selection(PAYMENT_MODE, 'Payment mode', default='both')
     payment_mode_customer_m2m = fields.Many2many(
         'account.payment.mode',
         'treasury_forecast_customer_payment_mode_rel',
@@ -107,7 +102,6 @@ class AccountTreasuryForecast(models.Model):
                                    domain=lambda self: [('partner_id', '=', self.env.user.company_id.partner_id.id)])
     check_old_open_customer = fields.Boolean(string="Old (opened)")
     opened_start_date_customer = fields.Date(string="Start Date")
-    payment_mode_supplier = fields.Selection(PAYMENT_MODE, "Payment mode", default='both')
     payment_mode_supplier_m2m = fields.Many2many(
         'account.payment.mode',
         'treasury_forecast_supplier_payment_mode_rel',

--- a/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
+++ b/project-addons/account_treasury_forecast/models/account_treasury_forecast.py
@@ -141,8 +141,8 @@ class AccountTreasuryForecast(models.Model):
                 raise exceptions.Warning(_('Error!:: End date is lower than start date.'))
 
     @api.one
-    @api.constrains('payment_mode_customer_m2m', 'check_old_open_customer_m2m',
-                    'payment_mode_supplier', 'check_old_open_supplier',
+    @api.constrains('payment_mode_customer_m2m', 'check_old_open_customer',
+                    'payment_mode_supplier_m2m', 'check_old_open_supplier',
                     'opened_start_date_customer', 'opened_start_date_supplier', 'start_date')
     def check_filter(self):
         if not self.payment_mode_customer_m2m or not self.payment_mode_supplier_m2m:

--- a/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
+++ b/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
@@ -87,7 +87,6 @@
                             <page string="Out invoices">
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
-                                    <field name="payment_mode_customer" string="Choose the payment mode" colspan="4" invisible="1"/>
                                     <field name="payment_mode_customer_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
                                     <field name="has_transfer_payments_customer" colspan="4" invisible="1"/>
                                     <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('has_transfer_payments_customer', '=', False)]}"/>
@@ -105,7 +104,6 @@
                             <page string="In invoices">
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
-                                    <field name="payment_mode_supplier" string="Choose the payment mode" colspan="4" invisible="1"/>
                                     <field name="payment_mode_supplier_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
                                     <field name="has_transfer_payments_supplier" colspan="4" invisible="1"/>
                                     <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('has_transfer_payments_supplier', '=', False)]}"/>

--- a/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
+++ b/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
@@ -88,6 +88,8 @@
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
                                     <field name="payment_mode_customer" string="Choose the payment mode" colspan="4"/>
+                                    <field name="payment_mode_customer_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
+                                    <!--SOLO VISIBLE SI TIENE Transferencia EN LOS MÉTODOS DE PAGO-->
                                     <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('payment_mode_customer', '=', 'debit_receipt')]}"/>
                                     <group col="4" colspan="4">
                                         <field name="account_bank" colspan="4" attrs="{'invisible':[('payment_mode_customer', '=', 'debit_receipt')]}"/>
@@ -104,6 +106,8 @@
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
                                     <field name="payment_mode_supplier" string="Choose the payment mode" colspan="4"/>
+                                    <field name="payment_mode_supplier_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
+                                    <!--SOLO VISIBLE SI TIENE Transferencia EN LOS MÉTODOS DE PAGO-->
                                     <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('payment_mode_supplier', '=', 'debit_receipt')]}"/>
                                     <group col="4" colspan="4">
                                         <group col="2" colspan="2">

--- a/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
+++ b/project-addons/account_treasury_forecast/views/account_treasury_forecast_view.xml
@@ -87,15 +87,15 @@
                             <page string="Out invoices">
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
-                                    <field name="payment_mode_customer" string="Choose the payment mode" colspan="4"/>
+                                    <field name="payment_mode_customer" string="Choose the payment mode" colspan="4" invisible="1"/>
                                     <field name="payment_mode_customer_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
-                                    <!--SOLO VISIBLE SI TIENE Transferencia EN LOS MÉTODOS DE PAGO-->
-                                    <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('payment_mode_customer', '=', 'debit_receipt')]}"/>
+                                    <field name="has_transfer_payments_customer" colspan="4" invisible="1"/>
+                                    <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('has_transfer_payments_customer', '=', False)]}"/>
                                     <group col="4" colspan="4">
-                                        <field name="account_bank" colspan="4" attrs="{'invisible':[('payment_mode_customer', '=', 'debit_receipt')]}"/>
-                                        <field name="check_old_open_customer" colspan="2" attrs="{'invisible':[('payment_mode_customer', '=', 'debit_receipt')]}"/>
+                                        <field name="account_bank" colspan="4" attrs="{'invisible':[('has_transfer_payments_customer', '=', False)]}"/>
+                                        <field name="check_old_open_customer" colspan="2" attrs="{'invisible':[('has_transfer_payments_customer', '=', False)]}"/>
                                         <field name="opened_start_date_customer" colspan="2" attrs="{'invisible':['|', ('check_old_open_customer', '=', False),
-                                                                                                               ('payment_mode_customer', '=', 'debit_receipt')],
+                                                                                                               ('has_transfer_payments_customer', '=', False)],
                                                                                                      'required': [('check_old_open_customer', '=', True)]}"/>
                                     </group>
                                     <separator string="" colspan="4" />
@@ -105,17 +105,17 @@
                             <page string="In invoices">
                                 <group colspan="4" col="4">
                                     <separator string="Payment mode" colspan="4"/>
-                                    <field name="payment_mode_supplier" string="Choose the payment mode" colspan="4"/>
+                                    <field name="payment_mode_supplier" string="Choose the payment mode" colspan="4" invisible="1"/>
                                     <field name="payment_mode_supplier_m2m" string="Choose the payment mode" colspan="4" widget="many2many_tags"/>
-                                    <!--SOLO VISIBLE SI TIENE Transferencia EN LOS MÉTODOS DE PAGO-->
-                                    <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('payment_mode_supplier', '=', 'debit_receipt')]}"/>
+                                    <field name="has_transfer_payments_supplier" colspan="4" invisible="1"/>
+                                    <separator string="Transfers filters" colspan="4" attrs="{'invisible':[('has_transfer_payments_supplier', '=', False)]}"/>
                                     <group col="4" colspan="4">
                                         <group col="2" colspan="2">
-                                            <field name="check_old_open_supplier" attrs="{'invisible':[('payment_mode_supplier', '=', 'debit_receipt')]}"/>
-                                            <field name="not_bankable_supplier" attrs="{'invisible':[('payment_mode_supplier', '=', 'debit_receipt')]}"/>
+                                            <field name="check_old_open_supplier" attrs="{'invisible':[('has_transfer_payments_supplier', '=', False)]}"/>
+                                            <field name="not_bankable_supplier" attrs="{'invisible':[('has_transfer_payments_supplier', '=', False)]}"/>
                                         </group>
                                         <field name="opened_start_date_supplier" colspan="2" attrs="{'invisible':['|', ('check_old_open_supplier', '=', False),
-                                                                                                               ('payment_mode_supplier', '=', 'debit_receipt')],
+                                                                                                               ('has_transfer_payments_supplier', '=', False)],
                                                                                                      'required': [('check_old_open_supplier', '=', True)]}"/>
                                     </group>
                                     <separator string="" colspan="4" />


### PR DESCRIPTION
[FIX] accoutn_treasury_forecast: Corrige las traducciones del error en italiano
[IMP] account_treasury_forecast: Separa errores de cliente y proveedor en el modo de pago
[FIX] account_treasury_forecast: Corrige las restricciones en los modos de pago
[I18N] account_treasury_forecast: Añade traducciones
[IMP] account_treasury_forecast: Elimina el antiguo campo de modo de pago
[IMP] account_treasury_forecast: Añade campos para comprobar si hay transferencias
[FIX] account_treasury_forecast: Corrige el filtro de las facturas
[IMP] accoutn_treasury_forecast: Añade campo many2many con modo de pago
[REF] account_treasury_forecast: Refactoriza calculate_invoices
