### PR TITLE
Recuperación imprimir vales de entrega

### DIFF
--- a/project-addons/custom_report_link/views/stock_custom_report.xml
+++ b/project-addons/custom_report_link/views/stock_custom_report.xml
@@ -13,7 +13,6 @@
     </template>
 
     <delete model="ir.actions.report" search="[('id','=',ref('stock.action_report_picking'))]"/>
-    <delete model="ir.actions.report" search="[('id','=',ref('stock.action_report_delivery'))]"/>
     <delete model="ir.actions.report" search="[('id','=',ref('sale.action_report_saleorder'))]"/>
     <delete model="ir.actions.report" search="[('id','=',ref('account.account_invoices'))]"/>
     <delete model="ir.actions.report" search="[('id','=',ref('account.account_invoices_without_payment'))]"/>


### PR DESCRIPTION
Buenas Omar,
imagino que para que vuelva a aparecer tendrás que forzar que se recargue el módulo stock. 
Saludos,
-[IMP] custom_report_link: recuperada acción para imprimir vales de entrega
