### PR TITLE
Añade email_sat en flask

### DIFF
--- a/project-addons/flask_middleware_connector/models/res_partner/common.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/common.py
@@ -55,10 +55,10 @@ class PartnerListener(Component):
     def on_record_create(self, record, fields=None):
         partner = record
         up_fields = ["name", "comercial", "vat", "city", "street", "zip",
-                     "country_id", "state_id", "email_web", "ref", 'user_id',
-                     "property_product_pricelist", "lang", "type",
+                     "country_id", "state_id", "email_web", "email3", "ref",
+                     'user_id', "property_product_pricelist", "lang", "type",
                      "parent_id", "is_company", "email",
-                     "prospective", "phone", "mobile","csv_connector_access"]
+                     "prospective", "phone", "mobile", "csv_connector_access"]
         if partner.is_company:
 
             if partner.web and (partner.active or partner.prospective):
@@ -91,7 +91,7 @@ class PartnerListener(Component):
         partner = record
         up_fields = [
             "name", "comercial", "vat", "city", "street", "zip", "country_id",
-            "state_id", "email_web", "ref", "user_id",
+            "state_id", "email_web", "email3", "ref", "user_id",
             "property_product_pricelist", "lang", "sync", "type", "parent_id",
             "is_company", "email", "active", "prospective", "phone", "mobile",
             "property_payment_term_id", "last_sale_date", "csv_connector_access",

--- a/project-addons/flask_middleware_connector/models/res_partner/exporter.py
+++ b/project-addons/flask_middleware_connector/models/res_partner/exporter.py
@@ -28,6 +28,7 @@ class ResPartnerExporter(Component):
             binding.property_product_pricelist.name or "",
             "state": binding.state_id and binding.state_id.name or "",
             "email": binding.email_web or "",
+            "email_sat": binding.email3 or "",
             "prospective": binding.prospective,
             "lang": binding.lang and binding.lang.split("_")[0] or 'es',
             "phone1": binding.phone,

--- a/project-addons/vt_flask_middleware/customer.py
+++ b/project-addons/vt_flask_middleware/customer.py
@@ -60,6 +60,7 @@ class Customer(SyncModel):
     last_sale_date = DateTimeField(formats=['%Y-%m-%d %H:%M:%S'])
     csv_connector_access = BooleanField(default=False)
     brand_pricelist_ids = CharField(null=True)
+    email_sat = CharField(max_length=70, null=True)
 
     MOD_NAME = 'customer'
 


### PR DESCRIPTION
[IMP] flask_middleware_connector, vt_flask_middleware: Añade email_sat en flask

Buenas! Dejo aquí la query para crear el campo de flask:
```
alter table customer
add column email_sat varchar(70)
```