### PR TITLE
Cambiar no aplicar promos en cliente

### DIFF
--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -93,7 +93,7 @@ class SaleOrder(models.Model):
 
     @api.model
     def create(self, vals):
-        if 'partner_id' in vals:
+        if vals.get('partner_id'):
             vals['no_promos'] = self.env['res.partner'].browse(vals['partner_id']).no_promos
         return super().create(vals)
 

--- a/project-addons/sale_promotions_extend/models/sale.py
+++ b/project-addons/sale_promotions_extend/models/sale.py
@@ -91,6 +91,12 @@ class SaleOrder(models.Model):
         "Not apply promotions",
         help="Reload the prices after marking this check")
 
+    @api.model
+    def create(self, vals):
+        if 'partner_id' in vals:
+            vals['no_promos'] = self.env['res.partner'].browse(vals['partner_id']).no_promos
+        return super().create(vals)
+
     @api.multi
     @api.onchange('partner_id')
     def onchange_partner_id(self):

--- a/project-addons/sale_promotions_extend/views/partner_view.xml
+++ b/project-addons/sale_promotions_extend/views/partner_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='ref']" position="after">
+            <xpath expr="//page[@name='sales_purchases']//field[@name='customer']" position="after">
                 <field name="no_promos"/>
             </xpath>
         </field>


### PR DESCRIPTION
[IMP] sale_promotions_extend: Arrsatra no_promos de clientes al crear un pedido
[FIX] sale_promotions_extend: Mueve el check no_promos a la pestaña Ventas y Compras
