### PR TITLE
[Compras] Botón para crear costes en destino desde la ficha de importación

### DIFF
--- a/project-addons/pmp_landed_costs/i18n/es.po
+++ b/project-addons/pmp_landed_costs/i18n/es.po
@@ -238,6 +238,7 @@ msgstr "Hoja de importación"
 #: model:ir.ui.view,arch_db:pmp_landed_costs.view_create_landed_cost_wizard_form
 #: model:ir.actions.act_window,name:pmp_landed_costs.action_open_landed_cost_creator_wizard_view
 #: model:ir.ui.view,arch_db:pmp_landed_costs.view_stock_container_add_import_sheets_form
+#: model:ir.ui.view,arch_db:pmp_landed_costs.view_import_sheet_form
 msgid "Create landed costs"
 msgstr "Crear costes de destino"
 

--- a/project-addons/pmp_landed_costs/i18n/fr.po
+++ b/project-addons/pmp_landed_costs/i18n/fr.po
@@ -116,6 +116,7 @@ msgstr "Feuille d'importation"
 #: model:ir.ui.view,arch_db:pmp_landed_costs.view_create_landed_cost_wizard_form
 #: model:ir.model.fields,field_description:pmp_landed_costs.field_landed_cost_creator_wizard_import_sheet_id
 #: model:ir.model.fields,field_description:pmp_landed_costs.field_stock_landed_cost_import_sheet_id
+#: model:ir.ui.view,arch_db:pmp_landed_costs.view_import_sheet_form
 msgid "Create landed costs"
 msgstr "Créer des coûts cibles"
 

--- a/project-addons/pmp_landed_costs/i18n/it.po
+++ b/project-addons/pmp_landed_costs/i18n/it.po
@@ -236,6 +236,7 @@ msgstr "Foglio di importazioni"
 #. module: pmp_landed_costs
 #: model:ir.ui.view,arch_db:pmp_landed_costs.view_create_landed_cost_wizard_form
 #: model:ir.actions.act_window,name:pmp_landed_costs.action_open_landed_cost_creator_wizard_view
+#: model:ir.ui.view,arch_db:pmp_landed_costs.view_import_sheet_form
 msgid "Create landed costs"
 msgstr "Creare costi target"
 

--- a/project-addons/pmp_landed_costs/views/import_sheet_view.xml
+++ b/project-addons/pmp_landed_costs/views/import_sheet_view.xml
@@ -27,12 +27,12 @@
                     <field name="inspection"/>
                     <field name="arrival_cost"/>
                 </group>
+                <separator string="Landed costs" colspan="4"/>
                 <group>
                     <field name="landed_cost_count" invisible="1"/>
                     <button name="action_open_landed_cost_creator" string="Create landed costs"
                             type="object" attrs="{'invisible': [('landed_cost_count', '!=', 0)]}"/>
                 </group>
-                <separator string="Landed costs" colspan="4"/>
                 <field name="landed_cost_ids">
                     <tree create="false" editable="true">
                         <field name="name"/>

--- a/project-addons/pmp_landed_costs/views/import_sheet_view.xml
+++ b/project-addons/pmp_landed_costs/views/import_sheet_view.xml
@@ -27,13 +27,18 @@
                     <field name="inspection"/>
                     <field name="arrival_cost"/>
                 </group>
+                <group>
+                    <field name="landed_cost_count" invisible="1"/>
+                    <button name="action_open_landed_cost_creator" string="Create landed costs"
+                            type="object" attrs="{'invisible': [('landed_cost_count', '!=', 0)]}"/>
+                </group>
                 <separator string="Landed costs" colspan="4"/>
                 <field name="landed_cost_ids">
-                    <tree editable="bottom">
+                    <tree create="false" editable="true">
                         <field name="name"/>
                         <field name="date"/>
                         <field name="picking_ids" widget="many2many_tags"/>
-                        <field name="container_ids" widget="many2many_tags"/>
+                        <field name="container_ids" widget="many2many_tags" edit="false"/>
                         <field name="state"/>
                     </tree>
                 </field>


### PR DESCRIPTION
[[IMP] pmp_landed_cost: Botón para crear costes en destino desde la ficha de importación](https://github.com/Comunitea/CMNT_004_15/commit/492163e62e66547a37c82e0d05162a4c7dfa868f)

[[FIX] Posición del botón cambiada](https://github.com/Comunitea/CMNT_004_15/commit/53d7e1d354dc88f8cbbd8a04992df813c872ee9f)
