### PR TITLE
[IMPORTANT] Sincronizar productos equivalentes

### DIFF
--- a/project-addons/flask_middleware_connector/models/product/common.py
+++ b/project-addons/flask_middleware_connector/models/product/common.py
@@ -456,3 +456,15 @@ class ProductBrandGroupListener(Component):
 
     def on_record_unlink(self, record):
         record.with_delay(priority=11, eta=120).unlink_brand_group()
+
+
+class ProductEquivalentListener(Component):
+    _name = 'product.equivalent.event.listener'
+    _inherit = 'base.event.listener'
+    _apply_on = ['product.equivalent']
+
+    def on_record_create(self, record, fields=None):
+        record.product_id.with_delay(priority=11, eta=30).update_product()
+
+    def on_record_unlink(self, record):
+        record.product_id.with_delay(priority=11, eta=30).update_product()

--- a/project-addons/flask_middleware_connector/models/product/exporter.py
+++ b/project-addons/flask_middleware_connector/models/product/exporter.py
@@ -48,7 +48,7 @@ class ProductProductExporter(Component):
             'cost_price': binding.standard_price_2_inc,
             'real_stock': binding.qty_available,
             'special_shipping_costs': binding.special_shipping_costs,
-            'equivalent_products':  str([f'{val}' for val in binding.equivalent_product_ids.mapped("product_name")])
+            'equivalent_products':  str(binding.equivalent_product_ids.mapped("product_name"))
         }
         if binding.show_stock_outside:
             stock_qty = eval(

--- a/project-addons/flask_middleware_connector/models/product/exporter.py
+++ b/project-addons/flask_middleware_connector/models/product/exporter.py
@@ -47,7 +47,8 @@ class ProductProductExporter(Component):
             'volume': binding.volume,
             'cost_price': binding.standard_price_2_inc,
             'real_stock': binding.qty_available,
-            'special_shipping_costs': binding.special_shipping_costs
+            'special_shipping_costs': binding.special_shipping_costs,
+            'equivalent_products':  str([f'{val}' for val in binding.equivalent_product_ids.mapped("product_name")])
         }
         if binding.show_stock_outside:
             stock_qty = eval(

--- a/project-addons/vt_flask_middleware/product.py
+++ b/project-addons/vt_flask_middleware/product.py
@@ -87,10 +87,11 @@ class Product(SyncModel):
     real_stock = FloatField(default=0.0)
     stock_available_es = FloatField(default=0.0)
     special_shipping_costs = BooleanField()
-
+    equivalent_products = CharField(null=True)
 
     def __unicode__(self):
         return self.name
+
 
 class ProductTag(SyncModel):
 


### PR DESCRIPTION
 [FIX] flask_middleware_connector: Mejora el formateo de productos equivalentes
 [IMP] flask_middleware_connector: Añade la exportación de los productos equivalentes
 [IMP] vt_flask_middleware: Crea el campo nuevo en flask

Buenas tardes! Dejo por aquí la query para crear el nuevo campo en flask:

```
alter table product 
add column equivalent_products varchar(150)
```