### PR TITLE
[SAT] Indicar productos no enviados por falta de stock

### DIFF
--- a/project-addons/crm_claim_rma/models/crm_claim_rma.py
+++ b/project-addons/crm_claim_rma/models/crm_claim_rma.py
@@ -288,6 +288,8 @@ class ClaimLine(models.Model):
 
     internal_description = fields.Text(string='Internal Description')
 
+    pending_shipment_stock = fields.Boolean(string='Pending shipment due to lack of stock')
+
     @api.onchange('product_id')
     def _get_default_supplier(self):
         if self.product_id and len(self.product_id.seller_ids):

--- a/project-addons/crm_claim_rma_custom/i18n/de.po
+++ b/project-addons/crm_claim_rma_custom/i18n/de.po
@@ -38,5 +38,6 @@ msgstr "Visiotech - RMA empfangen"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view_invisible_states
 msgid "Shipping pending for lack of stock"
 msgstr "Ausstehende Lieferung aufgrund von fehlendem Lagerbestand"

--- a/project-addons/crm_claim_rma_custom/i18n/de.po
+++ b/project-addons/crm_claim_rma_custom/i18n/de.po
@@ -35,3 +35,8 @@ msgstr "<p>Sehr geehrter Kunde,</p> <p>Wir informieren Sie, dass wir die Produkt
 #: model:mail.template,subject:crm_claim_rma_custom.rma_received_template
 msgid "Visiotech - RMA received"
 msgstr "Visiotech - RMA empfangen"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+msgid "Shipping pending for lack of stock"
+msgstr "Ausstehende Lieferung aufgrund von fehlendem Lagerbestand"

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -757,3 +757,8 @@ msgstr "<ul><li> Responsable: %s</il><li> Fecha Recepción Final: %s <b>&rarr;</
 #, python-format
 msgid "<ul><li> Officer: %s</il><li> Received Date: %s <b>&rarr;</b> %s</il></ul>"
 msgstr "<ul><li> Responsable: %s</il><li> Fecha Recepción: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+msgid "Shipping pending for lack of stock"
+msgstr "Pendiente de envío por falta de stock"

--- a/project-addons/crm_claim_rma_custom/i18n/es.po
+++ b/project-addons/crm_claim_rma_custom/i18n/es.po
@@ -760,5 +760,6 @@ msgstr "<ul><li> Responsable: %s</il><li> Fecha Recepción: %s <b>&rarr;</b> %s<
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view_invisible_states
 msgid "Shipping pending for lack of stock"
 msgstr "Pendiente de envío por falta de stock"

--- a/project-addons/crm_claim_rma_custom/i18n/fr.po
+++ b/project-addons/crm_claim_rma_custom/i18n/fr.po
@@ -35,3 +35,8 @@ msgstr "<p>Cher client,</p> <p>Nous vous informons que nous avons reçu les prod
 #: model:mail.template,subject:crm_claim_rma_custom.rma_received_template
 msgid "Visiotech - RMA received"
 msgstr "Visiotech - RMA reçu"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+msgid "Shipping pending for lack of stock"
+msgstr "Expédition en suspens pour manque de stock"

--- a/project-addons/crm_claim_rma_custom/i18n/fr.po
+++ b/project-addons/crm_claim_rma_custom/i18n/fr.po
@@ -38,5 +38,6 @@ msgstr "Visiotech - RMA reçu"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view_invisible_states
 msgid "Shipping pending for lack of stock"
 msgstr "Expédition en suspens pour manque de stock"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -652,3 +652,8 @@ msgstr "<ul><li> Responsabile: %s</il><li> Data di ricezione finale: %s <b>&rarr
 #, python-format
 msgid "<ul><li> Officer: %s</il><li> Received Date: %s <b>&rarr;</b> %s</il></ul>"
 msgstr "<ul><li> Responsabile: %s</il><li> Data di ricezione: %s <b>&rarr;</b> %s</il></ul>"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+msgid "Shipping pending for lack of stock"
+msgstr "In sospeso per mancanza di disponibilitá"

--- a/project-addons/crm_claim_rma_custom/i18n/it.po
+++ b/project-addons/crm_claim_rma_custom/i18n/it.po
@@ -655,5 +655,6 @@ msgstr "<ul><li> Responsabile: %s</il><li> Data di ricezione: %s <b>&rarr;</b> %
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view_invisible_states
 msgid "Shipping pending for lack of stock"
 msgstr "In sospeso per mancanza di disponibilitá"

--- a/project-addons/crm_claim_rma_custom/i18n/pt.po
+++ b/project-addons/crm_claim_rma_custom/i18n/pt.po
@@ -35,3 +35,8 @@ msgstr "<p>Caro cliente,</p> <p>Informamos que recebemos os produtos corresponde
 #: model:mail.template,subject:crm_claim_rma_custom.rma_received_template
 msgid "Visiotech - RMA received"
 msgstr "Visiotech - RMA recebido"
+
+#. module: crm_claim_rma_custom
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+msgid "Shipping pending for lack of stock"
+msgstr "O envio está a aguardar disponibilidad"

--- a/project-addons/crm_claim_rma_custom/i18n/pt.po
+++ b/project-addons/crm_claim_rma_custom/i18n/pt.po
@@ -38,5 +38,6 @@ msgstr "Visiotech - RMA recebido"
 
 #. module: crm_claim_rma_custom
 #: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view2_add_commercial
+#: model:ir.ui.view,arch_db:crm_claim_rma_custom.crm_claim_line_tree_view_invisible_states
 msgid "Shipping pending for lack of stock"
 msgstr "O envio está a aguardar disponibilidad"

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -206,6 +206,7 @@
                 <attribute name="context">{'search_product_id': product_id}</attribute>
             </field>
             <field name="internal_description" position="after">
+                <field name="pending_shipment_stock"/>
                 <field name="substate_id" options="{'no_open': True,'no_quick_create':True,'no_create_edit':True}"/>
                 <field name="write_date"/>
             </field>

--- a/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
+++ b/project-addons/crm_claim_rma_custom/views/crm_claim_view.xml
@@ -207,7 +207,7 @@
                 <attribute name="context">{'search_product_id': product_id}</attribute>
             </field>
             <field name="internal_description" position="after">
-                <field name="pending_shipment_stock"/>
+                <field name="pending_shipment_stock" string="Shipping pending for lack of stock"/>
                 <field name="substate_id" options="{'no_open': True,'no_quick_create':True,'no_create_edit':True}"/>
                 <field name="write_date"/>
             </field>
@@ -340,7 +340,9 @@
                 <field name="comercial"/>
                 <field name="date_received" string="Received date"/>
             </field>
-
+            <field name="substate_id" position="after">
+                <field name="pending_shipment_stock" string="Shipping pending for lack of stock"/>
+            </field>
         </field>
     </record>
 

--- a/project-addons/custom_report_link/i18n/de.po
+++ b/project-addons/custom_report_link/i18n/de.po
@@ -1125,3 +1125,8 @@ msgid "<b style=\"color:#da1f2e;\">IMPORTANT NOTE:</b>\n"
 "                        <span>Included </span>"
 msgstr "<b style=\"color:#da1f2e;\">Wichtiger Hinweis:</b>\n"
 "                        <span>Inbegriffen </span>"
+
+#. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "SHIPPING PENDING FOR LACK OF STOCK"
+msgstr "Ausstehende Lieferung aufgrund von fehlendem Lagerbestand"

--- a/project-addons/custom_report_link/i18n/es.po
+++ b/project-addons/custom_report_link/i18n/es.po
@@ -1229,3 +1229,8 @@ msgstr "OFERTA VÁLIDA 30 DÍAS"
 #: model:ir.model.fields,field_description:custom_report_link.field_res_partner_explode_kits_in_pdf
 msgid "Explode Kits In Pdf"
 msgstr "Desglosar Kits en PDFs"
+
+#. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "SHIPPING PENDING FOR LACK OF STOCK"
+msgstr "PENDIENTE DE ENVÍO POR FALTA DE STOCK"

--- a/project-addons/custom_report_link/i18n/es.po
+++ b/project-addons/custom_report_link/i18n/es.po
@@ -882,6 +882,11 @@ msgid "Internal Description"
 msgstr "Descripción interna"
 
 #. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "Notes"
+msgstr "Notas"
+
+#. module: custom_report_link
 #: model:ir.model,name:custom_report_link.model_account_invoice
 #: model:ir.ui.view,arch_db:custom_report_link.external_layout_custom_invoice
 msgid "Invoice"

--- a/project-addons/custom_report_link/i18n/fr.po
+++ b/project-addons/custom_report_link/i18n/fr.po
@@ -1122,3 +1122,8 @@ msgstr "R.M. de Madrid: Tomo 6811, Libro 0, Folio 210, Seccion B, Hoja M-110924,
 #: model:ir.ui.view,arch_db:custom_report_link.external_layout_custom_saleorder
 msgid "OFFER VALID FOR 30 DAYS"
 msgstr "OFFRE VALABLE PENDANT 30 JOURS"
+
+#. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "SHIPPING PENDING FOR LACK OF STOCK"
+msgstr "EXPÉDITION EN SUSPENS POUR MANQUE DE STOCK"

--- a/project-addons/custom_report_link/i18n/it.po
+++ b/project-addons/custom_report_link/i18n/it.po
@@ -1184,3 +1184,8 @@ msgstr "OFFERTA VALIDA 30 GIORNI"
 #: model:ir.model.fields,field_description:custom_report_link.field_res_partner_explode_kits_in_pdf
 msgid "Explode Kits In Pdf"
 msgstr "Scomponi i kit in PDF"
+
+#. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "SHIPPING PENDING FOR LACK OF STOCK"
+msgstr "IN SOSPESO PER MANCANZA DI DISPONIBILITÀ"

--- a/project-addons/custom_report_link/i18n/pt.po
+++ b/project-addons/custom_report_link/i18n/pt.po
@@ -1133,3 +1133,8 @@ msgstr "R.M. de Madrid: Tomo 6811, Libro 0, Folio 210, Seccion B, Hoja M-110924,
 #: model:ir.ui.view,arch_db:custom_report_link.external_layout_custom_saleorder
 msgid "OFFER VALID FOR 30 DAYS"
 msgstr "PROPOSTA VALIDA POR 30 DIAS"
+
+#. module: custom_report_link
+#: model:ir.ui.view,arch_db:custom_report_link.report_claim_custom_document
+msgid "SHIPPING PENDING FOR LACK OF STOCK"
+msgstr "O ENVIO ESTÁ A AGUARDAR DISPONIBILIDAD DE STOCK"

--- a/project-addons/custom_report_link/views/report_claim.xml
+++ b/project-addons/custom_report_link/views/report_claim.xml
@@ -198,22 +198,30 @@
                         </div>
                     </div>
                     <div class="row table-product-info">
-                        <table class="table table-condensed" style="font-size:12px; margin-top: 5%;">
+                        <table class="table table-condensed" style="font-size:12px; margin-top: 5%; width:100%;">
                             <thead>
                                 <tr style="font-weight: bold; background-color:#da1f2e; color:white;">
-                                    <th width="2%" style="vertical-align:middle;"></th>
-                                    <th width="12%" style="vertical-align:middle;">Product</th>
-                                    <th width="10%" style="vertical-align:middle;">Replacement Product</th>
-                                    <th width="7%" class="text-center" style="vertical-align:middle;">Quantity</th>
+                                    <th style="vertical-align:middle;"></th>
+                                    <th style="vertical-align:middle;">Product</th>
+                                    <th style="vertical-align:middle;">Replacement Product</th>
+                                    <th class="text-center" style="vertical-align:middle;">Quantity</th>
                                     <!--<th>Type</th>
                                     <th>Serial/Lot</th>-->
-                                    <th width="24%" style="vertical-align:middle;">Description</th>
-                                    <th width="44%" style="vertical-align:middle;">Internal Description</th>
+                                    <th style="vertical-align:middle;">Description</th>
+                                    <th style="vertical-align:middle;">Internal Description</th>
+
+                                    <t t-set="flag" t-value="true"/>
+                                    <t t-foreach="[x for x in claim.claim_line_ids if x.printable]" t-as="line_id">
+                                        <t t-if="line_id.pending_shipment_stock == true and flag==true">
+                                            <th style="vertical-align:middle;">Notes</th>
+                                            <t t-set="flag" t-value="false"/>
+                                        </t>
+                                    </t>
                                 </tr>
                             </thead>
                             <tbody class="body-product-info" style="font-size:12px; color:#6D6E70;">
                                 <tr t-foreach="[x for x in claim.claim_line_ids if x.printable]" t-as="line_id">
-                                    <td class="col-xs-1">
+                                    <td class="col-xs-0.5">
                                         <span t-field="line_id.sequence"/>
                                     </td>
                                     <td class="col-xs-2">
@@ -236,9 +244,12 @@
                                     <td class="col-xs-2" style="font-size:11px">
                                         <span t-field="line_id.name"/>
                                     </td>
-                                    <td class="col-xs-3" style="font-size:11px">
+                                    <td class="col-xs-2.5" style="font-size:11px">
                                         <span t-field="line_id.internal_description"/>
                                     </td>
+                                    <t t-if="line_id.pending_shipment_stock == true">
+                                        <td class="col-xs-2" style="font-size:11px">PENDIENTE DE ENVÍO POR FALTA DE STOCK</td>
+                                    </t>
                                 </tr>
                             </tbody>
                         </table>

--- a/project-addons/custom_report_link/views/report_claim.xml
+++ b/project-addons/custom_report_link/views/report_claim.xml
@@ -248,7 +248,10 @@
                                         <span t-field="line_id.internal_description"/>
                                     </td>
                                     <t t-if="line_id.pending_shipment_stock == true">
-                                        <td class="col-xs-2" style="font-size:11px">PENDIENTE DE ENVÍO POR FALTA DE STOCK</td>
+                                        <td class="col-xs-2" style="font-size:11px">SHIPPING PENDING FOR LACK OF STOCK</td>
+                                    </t>
+                                    <t t-if="line_id.pending_shipment_stock == false">
+                                        <td/>
                                     </t>
                                 </tr>
                             </tbody>

--- a/project-addons/flask_middleware_connector/models/rma/common.py
+++ b/project-addons/flask_middleware_connector/models/rma/common.py
@@ -87,7 +87,8 @@ class ClaimLineListener(Component):
         up_fields = ["product_id", "date_in", "date_out", "substate_id",
                      "name", "move_out_customer_state",
                      "internal_description", "product_returned_quantity",
-                     "equivalent_product_id", "prodlot_id", "invoice_id"]
+                     "equivalent_product_id", "prodlot_id", "invoice_id",
+                     "pending_shipment_stock"]
         if 'web' in fields and record.web:
             record.with_delay(priority=11, eta=120).export_rmaproduct()
         elif not record.web:

--- a/project-addons/flask_middleware_connector/models/rma/exporter.py
+++ b/project-addons/flask_middleware_connector/models/rma/exporter.py
@@ -64,6 +64,7 @@ class ClaimLineExporter(Component):
             "status_id": binding.substate_id.id,
             "prodlot_id": binding.prodlot_id,
             "invoice_id": binding.invoice_id.number,
+            "pending_shipment_stock": binding.pending_shipment_stock
         }
 
         if mode == "insert":

--- a/project-addons/vt_flask_middleware/rma.py
+++ b/project-addons/vt_flask_middleware/rma.py
@@ -1,5 +1,5 @@
 from peewee import CharField, FloatField, IntegerField, ForeignKeyField, \
-    DateTimeField
+    DateTimeField, BooleanField
 from app import app
 from database import SyncModel
 from customer import Customer
@@ -65,6 +65,7 @@ class RmaProduct(SyncModel):
     status_id = ForeignKeyField(RmaStatus, on_delete='CASCADE', null=True)
     prodlot_id = CharField(max_length=45)
     invoice_id = CharField(max_length=45)
+    pending_shipment_stock = BooleanField(default=False)
 
     MOD_NAME = 'rmaproduct'
 


### PR DESCRIPTION
[[IMP] custom_report_link/crm_claim_rma/crm_claim_rma_custom: Indicar productos no enviados por falta de stock](https://github.com/Comunitea/CMNT_004_15/commit/a6b197d79c0c17d83029595597575091ec21abe9)

[[IMP] Traducciones y exportación a flask del campo](https://github.com/Comunitea/CMNT_004_15/commit/f9b172fecb14eb46e31897306dc361d400924089)

[[FIX] Traducciones incluidas y tabla del informe arreglada](https://github.com/Comunitea/CMNT_004_15/commit/bbdf77973501c447b6c7ed9e0bc778f91ec86639)

