### PR TITLE
Cron facturacion automatica italia

### DIFF
--- a/project-addons/automatize_edi_es/models/sale.py
+++ b/project-addons/automatize_edi_es/models/sale.py
@@ -36,5 +36,9 @@ class SaleOrder(models.Model):
         sale_order_ids: List[Int]
             sale.order ids to be invoiced
         """
-        sales = self.env['sale.order'].browse(sale_order_ids)
-        sales.action_invoice_create()
+        try:
+            sales = self.env['sale.order'].browse(sale_order_ids)
+            sales.action_invoice_create()
+        except Exception as e:
+            self.env.cr.rollback()
+            raise e

--- a/project-addons/automatize_edi_es/models/sale.py
+++ b/project-addons/automatize_edi_es/models/sale.py
@@ -25,3 +25,16 @@ class SaleOrder(models.Model):
             oline.product_uom_qty,
             qty_precision=qty_precision, price_precision=price_precision,
             version=version)
+
+    def action_invoice_create_aux(self, sale_order_ids):
+        """
+        Calls actions_invoice_create with the sale.order passed in sale_order_ids.
+        This function is done because browse odoorpc method raises expected singleton
+
+        Parameter:
+        ---------
+        sale_order_ids: List[Int]
+            sale.order ids to be invoiced
+        """
+        sales = self.env['sale.order'].browse(sale_order_ids)
+        sales.action_invoice_create()

--- a/project-addons/automatize_edi_it/data/automatize_edi_it_data.xml
+++ b/project-addons/automatize_edi_it/data/automatize_edi_it_data.xml
@@ -50,4 +50,16 @@
         <field name="code">model.cron_check_qty_to_invoice_lx()</field>
     </record>
 
+    <record forcecreate="True" id="ir_cron_automate_invoicing_lx" model="ir.cron">
+        <field name="name">Automate invoicing LX</field>
+        <field eval="True" name="active"/>
+        <field name="interval_number">7</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="model_id" ref="model_purchase_order"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_automate_invoicing_lx()</field>
+    </record>
+
 </odoo>

--- a/project-addons/automatize_edi_it/data/automatize_edi_it_data.xml
+++ b/project-addons/automatize_edi_it/data/automatize_edi_it_data.xml
@@ -61,5 +61,8 @@
         <field name="state">code</field>
         <field name="code">model.cron_automate_invoicing_lx()</field>
     </record>
-
+    <record id="es_timeout_request_minutes" model="ir.config_parameter">
+        <field name="key">es_timeout_request_minutes</field>
+        <field name="value">60</field>
+    </record>
 </odoo>

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -207,5 +207,5 @@ class PurchaseOrder(models.Model):
         # Login
         odoo_es.login(server.server_db, server.login, server.password)
         odoo_es.config['auto_commit'] = False
-        odoo_es.config['timeout'] = 600
+        odoo_es.config['timeout'] = 1500
         return odoo_es

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -141,6 +141,7 @@ class PurchaseOrder(models.Model):
         :return:
         """
         search_date = (date.today() - relativedelta(months=months)).strftime("%Y-%m-%d")
+        # FIXME: filters
         purchases = self.search([('invoice_status', '=', 'to invoice'),
                                  ('date_order', '>=', search_date)])
         purchases_filtered = purchases.filtered(lambda p: p.amount_total == p.amount_to_invoice_es)
@@ -167,8 +168,7 @@ class PurchaseOrder(models.Model):
 
     def _create_invoice(self):
         """
-        TODO
-        :return:
+        Creates an invoice associated to self
         """
         invoices = self.env["account.invoice"]
         invoice = invoices.create({
@@ -183,8 +183,14 @@ class PurchaseOrder(models.Model):
 
     def _get_odoo_es(self):
         """
-        TODO
-        :return:
+        Connects with Odoo Spain Server and logs in and returns the
+        connection with the server.
+
+        This connection deactivates auto_commit.
+
+        Returns:
+        -------
+            Odoo Spain server connection
         """
         server = self.env['base.synchro.server'].search([('name', '=', 'Visiotech')])
         # Prepare the connection to the server

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -166,6 +166,7 @@ class PurchaseOrder(models.Model):
             orders_es = odoo_es.env['sale.order'].browse([])
             orders_es.action_invoice_create_aux(order_es_ids)
             odoo_es.env.commit()
+            self.env.cr.commit()
         except Exception:
             self.env.cr.rollback()
         finally:

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -160,9 +160,8 @@ class PurchaseOrder(models.Model):
             order_es_ids = odoo_es.env['sale.order'].search([
                 ('client_order_ref', 'in', purchases_filtered.mapped('name')), ('partner_id', '=', 245247)
             ])
-            # FIXME: no funciona al pasarle una lista de ids
-            orders_es = odoo_es.env['sale.order'].browse(order_es_ids)
-            orders_es.action_invoice_create()
+            orders_es = odoo_es.env['sale.order'].browse([])
+            orders_es.action_invoice_create_aux(order_es_ids)
             odoo_es.env.commit()
         except Exception:
             self.env.cr.rollback()

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -165,8 +165,8 @@ class PurchaseOrder(models.Model):
             ])
             orders_es = odoo_es.env['sale.order'].browse([])
             orders_es.action_invoice_create_aux(order_es_ids)
-            odoo_es.env.commit()
             self.env.cr.commit()
+            odoo_es.env.commit()
         except Exception as e:
             self.env.cr.rollback()
             raise e
@@ -207,4 +207,5 @@ class PurchaseOrder(models.Model):
         # Login
         odoo_es.login(server.server_db, server.login, server.password)
         odoo_es.config['auto_commit'] = False
+        odoo_es.config['timeout'] = 600
         return odoo_es

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -5,6 +5,7 @@ from odoo import models, fields, api, exceptions, _
 from datetime import date
 from dateutil.relativedelta import relativedelta
 import odoorpc
+from odoo.tools import float_compare
 
 
 class PurchaseOrderLine(models.Model):
@@ -150,7 +151,9 @@ class PurchaseOrder(models.Model):
                                  ('date_order', '>=', search_date),
                                  ('partner_id', '=', 27),
                                  ('picking_type_id', 'in', picking_type_domain)])
-        purchases_filtered = purchases.filtered(lambda p: p.amount_total == p.amount_to_invoice_es)
+        purchases_filtered = purchases.filtered(
+            lambda p: float_compare(p.amount_total, p.amount_to_invoice_es, precision_digits=2) == 0
+        )
 
         if not purchases_filtered:
             return

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -158,9 +158,10 @@ class PurchaseOrder(models.Model):
         try:
             for purchase in purchases_filtered:
                 purchase._create_invoice()
-                order_es = odoo_es.env['sale.order'].search([
+                order_es_id = odoo_es.env['sale.order'].search([
                     ('client_order_ref', '=', purchase.name), ('partner_id', '=', 245247)
                 ])
+                order_es = odoo_es.env['sale.order'].browse(order_es_id)
                 try:
                     order_es.action_invoice_create()
                     odoo_es.env.commit()

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -154,12 +154,10 @@ class PurchaseOrder(models.Model):
                 order_es = odoo_es.env['sale.order'].search([
                     ('client_order_ref', '=', purchase.name), ('partner_id', '=', 245247)
                 ])
-                # TODO: Revisar que pueda funcionar
                 try:
                     order_es.action_invoice_create()
-                    odoo_es.env.cr.commit()
+                    odoo_es.env.commit()
                 except Exception:
-                    odoo_es.env.cr.rollback()
                     raise OdooEsException(_('Error creating order %s invoice') % order_es.name)
                 self.env.cr.commit()
         except Exception:
@@ -193,6 +191,7 @@ class PurchaseOrder(models.Model):
         odoo_es = odoorpc.ODOO(server.server_url, port=server.server_port)
         # Login
         odoo_es.login(server.server_db, server.login, server.password)
+        odoo_es.config['auto_commit'] = False
         return odoo_es
 
 

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -136,14 +136,20 @@ class PurchaseOrder(models.Model):
 
     def cron_automate_invoicing(self, months=2):
         """
-        TODO
-        :param months:
-        :return:
+        Creates invoices for purchases and for the related sales in Odoo Spain
+
+        Parameters:
+        ----------
+        months: Int
+            Number of months to search purchases
         """
         search_date = (date.today() - relativedelta(months=months)).strftime("%Y-%m-%d")
-        # FIXME: filters
+        picking_type_domain = (self.env.ref('stock.picking_type_in').id,
+                               self.env.ref('stock_dropshipping.picking_type_dropship').id)
         purchases = self.search([('invoice_status', '=', 'to invoice'),
-                                 ('date_order', '>=', search_date)])
+                                 ('date_order', '>=', search_date),
+                                 ('partner_id', '=', 27),
+                                 ('picking_type_id', 'in', picking_type_domain)])
         purchases_filtered = purchases.filtered(lambda p: p.amount_total == p.amount_to_invoice_es)
 
         if not purchases_filtered:

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -207,5 +207,6 @@ class PurchaseOrder(models.Model):
         # Login
         odoo_es.login(server.server_db, server.login, server.password)
         odoo_es.config['auto_commit'] = False
-        odoo_es.config['timeout'] = 1500
+        timeout_mins = int(self.env['ir.config_parameter'].sudo().get_param('es_timeout_request_minutes'))
+        odoo_es.config['timeout'] = timeout_mins * 60  # needed to be in seconds
         return odoo_es

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -167,8 +167,9 @@ class PurchaseOrder(models.Model):
             orders_es.action_invoice_create_aux(order_es_ids)
             odoo_es.env.commit()
             self.env.cr.commit()
-        except Exception:
+        except Exception as e:
             self.env.cr.rollback()
+            raise e
         finally:
             odoo_es.logout()
 

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -152,7 +152,7 @@ class PurchaseOrder(models.Model):
                                  ('partner_id', '=', 27),
                                  ('picking_type_id', 'in', picking_type_domain)])
         purchases_filtered = purchases.filtered(
-            lambda p: float_compare(p.amount_total, p.amount_to_invoice_es, precision_digits=2) == 0
+            lambda p: float_compare(p.amount_to_invoice_it, p.amount_to_invoice_es, precision_digits=2) == 0
         )
 
         if not purchases_filtered:

--- a/project-addons/automatize_edi_it/models/purchase.py
+++ b/project-addons/automatize_edi_it/models/purchase.py
@@ -134,7 +134,7 @@ class PurchaseOrder(models.Model):
                 mail_id = self.env['mail.mail'].sudo().create(vals)
                 mail_id.sudo().send()
 
-    def cron_automate_invoicing(self, months=2):
+    def cron_automate_invoicing_lx(self, months=2):
         """
         Creates invoices for purchases and for the related sales in Odoo Spain
 


### PR DESCRIPTION
[FIX] automatize_edi_es: Añade manejo de excepciones al facturar
[IMP] automatize_edi_it: Añade parámetro para modificar el timeout de la RPC
[FIX] automatize_edi_it: Aumenta el tiempo del timeout
[IMP] automatize_edi_it: Añade tiempo al timeout
[FIX] automatize_edi_it: Corrige el manejo de la excepción en la facturación automática
[FIX] automatize_edi_it: Corrige la creación de la factura en Italia
[FIX] automatize_edi_it: Corrige el campo con el que compara la cantidad a facturar en España
[FIX] automatize_edi_it: Corrige el filtro de las compras en la facturación automática
[FIX] automatize_edi_it: Corrige la forma de facturar en Odoo España
[IMP] automatize_edi_es: Crea método para poder facturar los pedidos desde Italia
[FIX] automatize_edi_it: Corrige el cron para facturar en una sola factura en españa y otra en italia
[IMP] automatize_edi_it: Crea el cron de la facturación automática
[IMP] automatize_edi_it: Cambia nombre a la función
[FIX] automatize_edi_it: Corrige la busqueda de ventas en Odoo ES
[IMP] automatize_edi_it: Cambia los filtros para buscar sompras
[IMP] automatize_edi_it: Añade docstring
[FIX] automatize_edi_it: Corrige la forma de hacer commit y rollback en odoo_es
[IMP] automatize_edi_it: Añade facturación automática en Italia