### PR TITLE
[SAT] Permitir borrar un producto de reemplazo también cuando el albarán de envío esté realizado

### DIFF
--- a/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
+++ b/project-addons/crm_claim_rma/wizard/equivalent_products_wizard.py
@@ -42,7 +42,7 @@ class EquivalentProductsWizard(models.TransientModel):
             and m.location_dest_id.usage in ['supplier', 'customer']
                                                  and m.location_id.id != self.env.ref(
             'crm_rma_advance_location.stock_location_rma').id)
-        if moves and any([x.state != 'cancel' for x in moves]):
+        if moves and any([x.state not in ['cancel', 'done'] for x in moves]):
             raise exceptions.UserError(_("There are open pickings that contain this product"))
         else:
             self.line_id.equivalent_product_id = None


### PR DESCRIPTION
[[FIX] crm_claim_rma: Podemos borrar producto para albarán en estado cancelado y realizado](https://github.com/Comunitea/CMNT_004_15/commit/ef71d009d16fdb8bc1be1ad3d879b8a543560251)