### PR TITLE
[Cocina] Incluir verificación de cancelado de una solicitud de personalización y botón para volver a recuperarlo

### DIFF
--- a/project-addons/kitchen/i18n/de.po
+++ b/project-addons/kitchen/i18n/de.po
@@ -422,3 +422,13 @@ msgstr "<p>Wenn Sie akzeptieren, werden diese Anpassungen abgebrochen</p>"
 #: model:ir.ui.view,arch_db:kitchen.retrieve_customizations_wizard
 msgid "<p>Do you want to retrieve any cancel customization?</p>"
 msgstr "<p>Möchten Sie eine Anpassung zum Abbrechen abrufen?</p>"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Are you sure you want to cancel?"
+msgstr "Bist du sicher, dass du abbrechen möchtest?"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Recover request"
+msgstr "Wiederherstellungs anfrage"

--- a/project-addons/kitchen/i18n/es.po
+++ b/project-addons/kitchen/i18n/es.po
@@ -1059,3 +1059,15 @@ msgstr "Omitir comprobación de Previews"
 #: code:addons/kitchen/wizard/create_customization_wizard.py:165
 msgid "You can't create a customization with no preview selected : %s"
 msgstr "No puedes crear una personalización sin seleccionar una preview : %s"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Are you sure you want to cancel?"
+msgstr "¿Está seguro de que desea cancelar?"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Recover request"
+msgstr "Recuperar solicitud"
+
+

--- a/project-addons/kitchen/i18n/fr.po
+++ b/project-addons/kitchen/i18n/fr.po
@@ -428,4 +428,12 @@ msgstr "<p>Si vous acceptez, ces personnalisations seront annulées</p>"
 msgid "<p>Do you want to retrieve any cancel customization?</p>"
 msgstr "<p>Voulez-vous récupérer une personnalisation d'annulation?</p>"
 
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Are you sure you want to cancel?"
+msgstr "Es-tu sûre de vouloir annuler?"
 
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Recover request"
+msgstr "Récupérer la sollicitude"

--- a/project-addons/kitchen/i18n/it.po
+++ b/project-addons/kitchen/i18n/it.po
@@ -527,3 +527,13 @@ msgstr "Non ci sono anteprime per questo partner e questi prodotti:%s"
 #: model:ir.model.fields,field_description:kitchen.field_customization_wizard_errors
 msgid "Errors"
 msgstr "Errori"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Are you sure you want to cancel?"
+msgstr "Sei sicuro di voler cancellare?"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Recover request"
+msgstr "Richiesta di recupero"

--- a/project-addons/kitchen/i18n/pt.po
+++ b/project-addons/kitchen/i18n/pt.po
@@ -415,3 +415,13 @@ msgstr "<p>Se você aceitar, essas personalizações serão canceladas</p>"
 #: model:ir.ui.view,arch_db:kitchen.retrieve_customizations_wizard
 msgid "<p>Do you want to retrieve any cancel customization?</p>"
 msgstr "<p>Quer recuperar alguma personalização de cancelamento?</p>"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Are you sure you want to cancel?"
+msgstr "Você tem certeza que deseja cancelar?"
+
+#. module: kitchen
+#: model:ir.ui.view,arch_db:kitchen.kitchen_customization_form
+msgid "Recover request"
+msgstr "Solicitação de recuperação"

--- a/project-addons/kitchen/models/kitchen_customization.py
+++ b/project-addons/kitchen/models/kitchen_customization.py
@@ -342,6 +342,7 @@ class KitchenCustomization(models.Model):
                 for preview in line.preview_ids.filtered(lambda p, l=line: l.preview_selector != p):
                     preview.photo = False
 
+    @api.multi
     def action_recover_request(self):
         for customization in self:
             customization.state = customization.old_state

--- a/project-addons/kitchen/views/kitchen_customization.xml
+++ b/project-addons/kitchen/views/kitchen_customization.xml
@@ -65,13 +65,16 @@
                             attrs="{'invisible': [('state','!=','in_progress')]}"
                             class="oe_highlight" groups="kitchen.group_kitchen"/>
                     <button name="action_cancel" string="Cancel" type="object"
-                            attrs="{'invisible': [('state','not in',('draft','sent','waiting'))]}"/>
+                            attrs="{'invisible': [('state','not in',('draft','sent','waiting'))]}"
+                            confirm="Are you sure you want to cancel?"/>
                     <button name="action_cancel" string="Cancel" type="object" groups="kitchen.group_kitchen"
                             attrs="{'invisible': [('state','!=','in_progress')]}"/>
                     <button name="action_draft" string="Draft" type="object"
                             attrs="{'invisible': ['|',('state','!=','cancel'),'&amp;',('order_state','!=','reserve'),('order_id','!=',False)]}"/>
                     <button name="action_check_old_preview" string="Check Old Preview" type="object"
                             attrs="{'invisible': ['|',('state','not in',['waiting','draft','sent']),('has_old_preview','=',False)]}"/>
+                    <button name="action_recover_request" string="Recover request" type="object" groups="advise_special_shipping_costs.group_operations"
+                            attrs="{'invisible': [('state','!=','cancel')]}"/>
                 </header>
                 <sheet>
                     <div class="oe_title">


### PR DESCRIPTION
[[IMP] kitchen: [Cocina] Incluir verificación de cancelado de una solicitud de personalización y botón para volver a recuperarlo](https://github.com/Comunitea/CMNT_004_15/commit/18f190ad7f0ad9f405c6d7e7a5688684dbb14df9)



