### PR TITLE
[HOTFIX] Corregido error permitir exceso de peso

### DIFF
--- a/project-addons/sale_custom/models/sale.py
+++ b/project-addons/sale_custom/models/sale.py
@@ -40,14 +40,13 @@ class SaleOrderLine(models.Model):
                 self.product_uom:
             self.product_packaging = False
             return {}
-        if self.order_id.state == 'sale':
-            if not self.allow_overcome_weight:
-                exception = self.order_id.check_weight(True)
-                if exception:
-                    warning_mess =  {
-                            'title': _('Max weight advise'),
-                            'message': exception}
-                    return {'warning': warning_mess}
+        if self.order_id.state == 'sale' and not self.order_id.allow_overcome_weight:
+            exception = self.order_id.check_weight(True)
+            if exception:
+                warning_mess = {
+                    'title': _('Max weight advise'),
+                    'message': exception}
+                return {'warning': warning_mess}
         if self.product_id.type == 'product':
             precision = self.env['decimal.precision'].\
                 precision_get('Product Unit of Measure')


### PR DESCRIPTION
-[[FIX] sale_custom: Corregido error que salta para permitir exceso de peso cuando cambian cosas del producto](https://github.com/Comunitea/CMNT_004_15/commit/fcf728d1b8fdf4b441d9b13c4dc58d2012b1b756)

Buenas tardes @omar7r , en cuanto puedas, sube el hotfix, porfa.
Gracias!!