### PR TITLE
Corregir aviso compras

### DIFF
--- a/project-addons/dropship_italia_it/models/purchase.py
+++ b/project-addons/dropship_italia_it/models/purchase.py
@@ -92,6 +92,7 @@ class PurchaseOrder(models.Model):
         # Confirm purchase order
         context = self._context.copy()
         context['bypass_override'] = True
+        context['bypass_po_check_lines'] = True
         context.pop('default_state', False)
         self.with_context(context).sudo().button_confirm()
         for pick in self.picking_ids:

--- a/project-addons/purchase_picking/__manifest__.py
+++ b/project-addons/purchase_picking/__manifest__.py
@@ -40,6 +40,8 @@
              'wizard/assign_container_view.xml',
              'wizard/cancel_moves_view.xml',
              'templates/assets.xml',
-             'views/warehouse_view.xml'],
+             'views/warehouse_view.xml',
+             'wizard/purchase_lines_checker_view.xml',
+             'data/parameters.xml'],
     "installable": True
 }

--- a/project-addons/purchase_picking/data/parameters.xml
+++ b/project-addons/purchase_picking/data/parameters.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data noupdate="1">
+        <record id="max_product_purchase_price_diff_perc" model="ir.config_parameter">
+           <field name="key">max_product_purchase_price_diff_perc</field>
+           <field name="value">25</field>
+        </record>
+    </data>
+</odoo>

--- a/project-addons/purchase_picking/i18n/es.po
+++ b/project-addons/purchase_picking/i18n/es.po
@@ -390,6 +390,7 @@ msgstr "¿Estás seguro de que deseas cancelar estos movimientos?"
 
 #. module: purchase_picking
 #: model:ir.ui.view,arch_db:purchase_picking.cancel_moves_wzd_view
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -625,3 +626,31 @@ msgstr "Canal"
 #: model:ir.model.fields,field_description:purchase_picking.field_purchase_order_first_uninvoiced_date
 msgid "First Uninvoiced Date"
 msgstr "Primera fecha sin facturar"
+
+#. module: purchase_picking
+#: model:ir.model.fields,field_description:purchase_picking.field_confirm_purchase_lines_checker_purchase_lines_with_no_price
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Lines with no price"
+msgstr "Líneas sin precio"
+
+#. module: purchase_picking
+#: model:ir.model.fields,field_description:purchase_picking.field_confirm_purchase_lines_checker_purchase_lines_with_price_variance
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Product with high price variance"
+msgstr "Productos con gran variación en el precio"
+
+#. module: purchase_picking
+#: model:ir.actions.act_window,name:purchase_picking.action_open_purchase_lines_checker
+msgid "Purchase lines checker"
+msgstr "Comprobación de líneas de compra"
+
+#. module: purchase_picking
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Continue"
+msgstr "Continuar"
+
+#. module: purchase_picking
+#: code:addons/purchase_picking/product.py:48
+#, python-format
+msgid "The product "%s" has not last purchase"
+msgstr "El producto "%s" no tiene última compra"

--- a/project-addons/purchase_picking/i18n/it.po
+++ b/project-addons/purchase_picking/i18n/it.po
@@ -28,6 +28,7 @@ msgstr "Assegnare spedizione"
 
 #. module: purchase_picking
 #: model:ir.ui.view,arch_db:purchase_picking.create_picking_move_view
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
 msgid "Cancel"
 msgstr "Cancellare"
 
@@ -579,3 +580,31 @@ msgstr "Canale"
 #: model:ir.model.fields,field_description:purchase_picking.field_purchase_order_first_uninvoiced_date
 msgid "First Uninvoiced Date"
 msgstr "Prima data non fatturata"
+
+#. module: purchase_picking
+#: model:ir.model.fields,field_description:purchase_picking.field_confirm_purchase_lines_checker_purchase_lines_with_no_price
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Lines with no price"
+msgstr "Líneas sin precio"
+
+#. module: purchase_picking
+#: model:ir.model.fields,field_description:purchase_picking.field_confirm_purchase_lines_checker_purchase_lines_with_price_variance
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Product with high price variance"
+msgstr "Productos con gran variación en el precio"
+
+#. module: purchase_picking
+#: model:ir.actions.act_window,name:purchase_picking.action_open_purchase_lines_checker
+msgid "Purchase lines checker"
+msgstr "Comprobación de líneas de compra"
+
+#. module: purchase_picking
+#: model:ir.ui.view,arch_db:purchase_picking.purchase_lines_checker_view
+msgid "Continue"
+msgstr "Continuar"
+
+#. module: purchase_picking
+#: code:addons/purchase_picking/product.py:48
+#, python-format
+msgid "The product "%s" has not last purchase"
+msgstr "El producto "%s" no tiene última compra"

--- a/project-addons/purchase_picking/models/__init__.py
+++ b/project-addons/purchase_picking/models/__init__.py
@@ -1,1 +1,1 @@
-from . import stock, purchase
+from . import stock, purchase, product

--- a/project-addons/purchase_picking/models/product.py
+++ b/project-addons/purchase_picking/models/product.py
@@ -12,12 +12,13 @@ class ProductProduct(models.Model):
         ------
         Float
         """
-        res = self.env['purchase.order.line'].search([('product_id', '=', self.id)])
-        res_filtered = res.filtered(lambda self: self.order_id.state in ['purchase', 'purchase_order'])
-        if not res_filtered:
+        res = self.env['purchase.order.line'].search([
+            ('product_id', '=', self.id),
+            ('order_id.state', 'in', ['purchase', 'purchase_order'])
+        ], order='write_date desc', limit=1)
+        if not res:
             raise NoLastPurchaseException(self.default_code)
-        last_line = res_filtered.sorted(key=lambda self: self.order_id.write_date, reverse=True)[0]
-        return last_line.price_unit
+        return res.price_unit
 
     @staticmethod
     def calculate_product_price_variation(old_price, new_price):

--- a/project-addons/purchase_picking/models/product.py
+++ b/project-addons/purchase_picking/models/product.py
@@ -1,0 +1,48 @@
+from odoo import models, fields, _
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def get_last_purchase_price(self):
+        """
+        Calculates last purchase price of the product.
+        If there is no last purchase raises NoLastPurchaseException
+        Return:
+        ------
+        Float
+        """
+        res = self.env['purchase.order.line'].search([('product_id', '=', self.id)])
+        res_filtered = res.filtered(lambda self: self.order_id.state in ['purchase', 'purchase_order'])
+        if not res_filtered:
+            raise NoLastPurchaseException(self.default_code)
+        last_line = res_filtered.sorted(key=lambda self: self.order_id.write_date, reverse=True)[0]
+        return last_line.price_unit
+
+    @staticmethod
+    def calculate_product_price_variation(old_price, new_price):
+        """
+        Returns the percentage of variation between old price and new_price
+        Parameters:
+        ----------
+        old_price: Float
+            Base price to calculate the percentage variation
+        new_price: Float
+            Price to calculate the difference that gives the percentage
+        Return:
+        ------
+        Float
+            100 * abs(old_price - new_price) / old_price
+        """
+        return abs(old_price - new_price) / old_price * 100
+
+
+class NoLastPurchaseException(Exception):
+    """
+    This error should be raised when a product does not belong to any purchase order line
+    """
+    def __init__(self, product_code, *args):
+        self.message = _('The product "%s" has not last purchase') % product_code
+
+    def __str__(self):
+        return 'NoLastPurchaseException: ' + self.message

--- a/project-addons/purchase_picking/models/purchase.py
+++ b/project-addons/purchase_picking/models/purchase.py
@@ -20,7 +20,7 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import except_orm,UserError
-from odoo.tools.float_utils import float_is_zero, float_compare
+from odoo.addons.purchase_picking.models.product import NoLastPurchaseException
 
 
 class PurchaseOrder(models.Model):
@@ -180,6 +180,56 @@ class PurchaseOrder(models.Model):
             uninvoiced_pickings = order.picking_ids.filtered(lambda p:p.state=='done' and p.date_done and not p.invoice_ids).sorted(key=lambda p: p.date_done)
             if uninvoiced_pickings:
                 order.first_uninvoiced_date = uninvoiced_pickings[0].date_done
+
+    @api.multi
+    def button_confirm(self):
+        """
+        Extends the original method to check if purchase.order lines prices are correct.
+        If there are lines without price or with a high variance in price since last purchase,
+        these lines are shown in a wizard.
+        """
+        if self.env.context.get('bypass_po_check_lines'):
+            return super().button_confirm()
+        for order in self:
+            lines_with_no_price = order.order_line.filtered(lambda l: l.price_subtotal == 0)
+            lines_with_high_price_variation_ids = order.get_lines_with_high_price_variation()
+            if not lines_with_no_price and not lines_with_high_price_variation_ids:
+                # without lines there is nothing to aware
+                return super().button_confirm()
+            wizard = self.env['confirm.purchase.lines.checker'].create({
+                'purchase_lines_with_no_price': [(6, 0, lines_with_no_price.ids)],
+                'purchase_lines_with_price_variance': [(6, 0, lines_with_high_price_variation_ids)],
+                'purchase_id': order.id
+            })
+        action = self.env.ref('purchase_picking.action_open_purchase_lines_checker').read()[0]
+        action['res_id'] = wizard.id
+        return action
+
+    def get_lines_with_high_price_variation(self):
+        """
+        Returns id lines that have a bigger product price variation than umbral
+
+        Return:
+        ------
+        List[Int]
+        """
+        lines_with_high_price_variation = []
+        umbral = float(self.env['ir.config_parameter'].sudo().get_param(
+            'max_product_purchase_price_diff_perc'
+        ))
+        for line in self.order_line:
+            try:
+                product = line.product_id
+                last_purchase_price = product.get_last_purchase_price()  # field in stock_custom
+                if last_purchase_price:
+                    price_variation = product.calculate_product_price_variation(last_purchase_price, line.price_unit)
+                    if price_variation > umbral:
+                        lines_with_high_price_variation.append(line.id)
+            except NoLastPurchaseException:
+                continue
+        return lines_with_high_price_variation
+
+
 class PurchaseOrderLine(models.Model):
 
     _inherit = 'purchase.order.line'

--- a/project-addons/purchase_picking/wizard/__init__.py
+++ b/project-addons/purchase_picking/wizard/__init__.py
@@ -18,6 +18,9 @@
 #
 ##############################################################################
 
-from . import create_picking_move
-from . import assign_container
-from . import cancel_moves
+from . import (
+    create_picking_move,
+    assign_container,
+    cancel_moves,
+    purchase_lines_checker
+)

--- a/project-addons/purchase_picking/wizard/purchase_lines_checker.py
+++ b/project-addons/purchase_picking/wizard/purchase_lines_checker.py
@@ -1,0 +1,23 @@
+from odoo import models, fields
+
+
+class ConfirmPurchaseConfirmLinesChecker(models.TransientModel):
+    _name = 'confirm.purchase.lines.checker'
+
+    purchase_lines_with_no_price = fields.Many2many(
+        'purchase.order.line',
+        'purchase_line_checker_purchase_lines_with_no_price_rel',
+        string='Lines with no price'
+    )
+    purchase_lines_with_price_variance = fields.Many2many(
+        'purchase.order.line',
+        'purchase_line_checker_purchase_lines_with_variance_rel',
+        string='Product with high price variance'
+    )
+    purchase_id = fields.Many2one('purchase.order', 'Purchase Order')
+
+    def button_continue(self):
+        """
+        Calls purchase order's button_confirm bypassing checking lines
+        """
+        self.purchase_id.with_context(bypass_po_check_lines=True).button_confirm()

--- a/project-addons/purchase_picking/wizard/purchase_lines_checker_view.xml
+++ b/project-addons/purchase_picking/wizard/purchase_lines_checker_view.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="purchase_lines_checker_view" model="ir.ui.view">
+        <field name="name">purchase.lines.checker.form</field>
+        <field name="model">confirm.purchase.lines.checker</field>
+        <field name="arch" type="xml">
+            <form string="Otro nombre">
+                <group>
+                    <separator string="Lines with no price" colspan="4" />
+                    <field name="purchase_lines_with_no_price" colspan="4" nolabel="1">
+                        <tree create="false" delete="false" editable="top">
+                            <field name="product_id" readonly="1"/>
+                            <field name="product_id" invisible="1"/>
+                            <field name="product_qty" readonly="1"/>
+                            <field name="price_unit"/>
+                            <field name="discount"/>
+                        </tree>
+                    </field>
+                    <separator string="Product with high price variance" colspan="4" />
+                    <field name="purchase_lines_with_price_variance" colspan="4" nolabel="1">
+                        <tree create="false" delete="false" editable="top">
+                            <field name="product_id" readonly="1"/>
+                            <field name="product_qty" readonly="1"/>
+                            <field name="price_unit"/>
+                            <field name="discount"/>
+                        </tree>
+                    </field>
+                    <footer>
+                        <button string="Continue" name="button_continue" type="object" class="oe_highlight"/>
+                        <button string="Cancel" special="cancel"/>
+                    </footer>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_open_purchase_lines_checker">
+        <field name="name">Purchase lines checker</field>
+        <field name="res_model">confirm.purchase.lines.checker</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="purchase_lines_checker_view"/>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
 [FIX] purchase_picking: Recupera los cambios del aviso de compras
 [FIX] dropship_italia_it: Corrige error al confirmar compra en sincro de dropship
 [FIX] purchase_picking: Corrige el aviso en compras para que solo aparezca si hay lineas que avisar
