### PR TITLE
Mejoras llegadas nacionales

### DIFF
--- a/project-addons/national_arrivals_es/__init__.py
+++ b/project-addons/national_arrivals_es/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project-addons/national_arrivals_es/i18n/es.po
+++ b/project-addons/national_arrivals_es/i18n/es.po
@@ -26,3 +26,8 @@ msgstr "Llegadas nacionales"
 #: model:ir.ui.view,arch_db:national_arrivals_es.search_last_7_days_picking
 msgid "Last 7 days"
 msgstr "Últimos 7 días"
+
+#. module: national_arrivals_es
+#: model:ir.model.fields,field_description:national_arrivals_es.field_res_partner_is_national_supplier
+msgid "Is national supplier"
+msgstr "Es proveedor nacional"

--- a/project-addons/national_arrivals_es/models/__init__.py
+++ b/project-addons/national_arrivals_es/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/project-addons/national_arrivals_es/models/res_partner.py
+++ b/project-addons/national_arrivals_es/models/res_partner.py
@@ -10,6 +10,7 @@ class ResPartner(models.Model):
         store=True
     )
 
+    @api.depends('supplier', 'property_account_position_id')
     def _compute_is_national_supplier(self):
         """
         Calculates if a supplier has intra or national fiscal position

--- a/project-addons/national_arrivals_es/models/res_partner.py
+++ b/project-addons/national_arrivals_es/models/res_partner.py
@@ -1,0 +1,23 @@
+from odoo import models, api, fields
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    is_national_supplier = fields.Boolean(
+        'Is national supplier',
+        compute='_compute_is_national_supplier',
+        store=True
+    )
+
+    def _compute_is_national_supplier(self):
+        """
+        Calculates if a supplier has intra or national fiscal position
+        """
+        national_fiscal_position_id = self.env.ref('l10n_es.1_fp_nacional').id
+        intra_fiscal_position_id = self.env.ref('l10n_es.1_fp_intra').id
+        for partner in self:
+            partner.is_national_supplier = partner.supplier and partner.property_account_position_id.id in (
+                national_fiscal_position_id,
+                intra_fiscal_position_id
+            )

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -39,10 +39,11 @@
         <field name="view_mode">tree,form</field>
         <field name="view_id" ref="national_arrivals_es.view_national_arrivals_tree"/>
         <field name="domain" eval="['&amp;', ('picking_type_code', '=', 'incoming'),
-                                    ('partner_id.property_account_position_id', 'in', (
+                                    '&amp;', ('partner_id.property_account_position_id', 'in', (
                                         ref('l10n_es.1_fp_nacional'),
                                         ref('l10n_es.1_fp_intra')
-                                    ))]"/>
+                                    )), '|', ('partner_id.supplier', '=', True),
+                                    ('location_id', '=', ref('stock.stock_location_suppliers'))]"/>
         <field name="context">{'search_default_last7days':1}</field>
         <field name="search_view_id" ref="search_last_7_days_picking"/>
     </record>

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -42,8 +42,7 @@
                                     '&amp;', ('partner_id.property_account_position_id', 'in', (
                                         ref('l10n_es.1_fp_nacional'),
                                         ref('l10n_es.1_fp_intra')
-                                    )), '|', ('partner_id.supplier', '=', True),
-                                    ('location_id', '=', ref('stock.stock_location_suppliers'))]"/>
+                                    )), ('location_id', '=', ref('stock.stock_location_suppliers'))]"/>
         <field name="context">{'search_default_last7days':1}</field>
         <field name="search_view_id" ref="search_last_7_days_picking"/>
     </record>

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -39,10 +39,8 @@
         <field name="view_mode">tree,form</field>
         <field name="view_id" ref="national_arrivals_es.view_national_arrivals_tree"/>
         <field name="domain" eval="['&amp;', ('picking_type_code', '=', 'incoming'),
-                                    '&amp;', ('partner_id.property_account_position_id', 'in', (
-                                        ref('l10n_es.1_fp_nacional'),
-                                        ref('l10n_es.1_fp_intra')
-                                    )), ('location_id', '=', ref('stock.stock_location_suppliers'))]"/>
+                                    '&amp;', ('partner_id.is_national_supplier', '=', True),
+                                    ('location_id', '=', ref('stock.stock_location_suppliers'))]"/>
         <field name="context">{'search_default_last7days':1}</field>
         <field name="search_view_id" ref="search_last_7_days_picking"/>
     </record>

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -29,6 +29,6 @@
         <field name="search_view_id" ref="search_last_7_days_picking"/>
     </record>
 
-    <menuitem id="national_incoming_picking_menu" name="National arrivals"
-            parent="purchase.menu_purchase_control" action="action_open_national_arrivals"/>
+    <menuitem id="national_incoming_picking_menu" name="National arrivals" sequence="101"
+            parent="stock.menu_stock_warehouse_mgmt" action="action_open_national_arrivals"/>
 </odoo>

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -7,7 +7,8 @@
             <search string="Last 7 days">
                 <field name="scheduled_date"/>
                 <filter string="Last 7 days" name="last7days" domain="[
-                ('scheduled_date', '&gt;=', ((context_today()-datetime.timedelta(days=7)).strftime('%Y-%m-%d')))
+                ('scheduled_date', '&gt;=', ((context_today()-datetime.timedelta(days=7)).strftime('%Y-%m-%d'))),
+                ('state', 'not in', ('cancel', 'done'))
                 ]"/>
             </search>
         </field>

--- a/project-addons/national_arrivals_es/views/stock_view.xml
+++ b/project-addons/national_arrivals_es/views/stock_view.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="view_national_arrivals_tree" model="ir.ui.view">
+        <field name="name">national.arrivals.tree</field>
+        <field name="model">stock.picking</field>
+        <field name="arch" type="xml">
+            <tree string="National arrivals">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="scheduled_date"/>
+                <field name="date_done"/>
+                <field name="origin"/>
+                <field name="shipping_identifier"/>
+                <field name="backorder_id"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="search_last_7_days_picking">
         <field name="name">Last 7 days</field>
         <field name="model">stock.picking</field>
@@ -20,7 +37,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="view_id" ref="purchase_picking.vpicktree_add_shipping_id"/>
+        <field name="view_id" ref="national_arrivals_es.view_national_arrivals_tree"/>
         <field name="domain" eval="['&amp;', ('picking_type_code', '=', 'incoming'),
                                     ('partner_id.property_account_position_id', 'in', (
                                         ref('l10n_es.1_fp_nacional'),


### PR DESCRIPTION
 [FIX] national_arrivals_es: Añade los campos de los que depende el cálculo del nuevo campo
 [IMP] national_arrivals_es: Añade el campo para ver si es proveedor nacional
 [FIX] national_arrivals_es: Quita filtro redundante
 [IMP] national_arrivals_es: Añade filtros para que solo salgan los albaranes con cliente o ubicación Proveedor
 [IMP] national_arrivals_es: Quita campos de la vista de llegadas nacionales
 [IMP] national_arrivals_es: Modifica filtro Últimos 7 días
 [IMP] national_arrivals_es: Mueve el menú de Llegadas nacionales
